### PR TITLE
chore: update packages/*/run.sh

### DIFF
--- a/packages/mesh/run.sh
+++ b/packages/mesh/run.sh
@@ -1,18 +1,16 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Run the web service on container startup on the background.
-yarn run db-migrate
-yarn start &
-
-sleep 15s
-
 # Create mount directory for service
 mkdir -p $MNT_DIR
 
 echo "Mounting GCS Fuse."
 gcsfuse --debug_gcs --debug_fuse $GCS_BUCKET $MNT_DIR
 echo "Mounting completed."
+
+# Run the web service on container startup on the background.
+yarn run db-migrate
+yarn start &
 
 # Exit immediately when one of the background processes terminate.
 wait -n

--- a/packages/vision/run.sh
+++ b/packages/vision/run.sh
@@ -1,18 +1,16 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Run the web service on container startup on the background.
-yarn run db-migrate
-yarn start &
-
-sleep 15s
-
 # Create mount directory for service
 mkdir -p $MNT_DIR
 
 echo "Mounting GCS Fuse."
 gcsfuse --debug_gcs --debug_fuse $GCS_BUCKET $MNT_DIR
 echo "Mounting completed."
+
+# Run the web service on container startup on the background.
+yarn run db-migrate
+yarn start &
 
 # Exit immediately when one of the background processes terminate.
 wait -n


### PR DESCRIPTION
Revert workaround commits
- https://github.com/mirror-media/Lilith/commit/6f7ab5539eeee562821c71133515d0eca47e1d47
- https://github.com/mirror-media/Lilith/commit/6f7ab5539eeee562821c71133515d0eca47e1d47

The workaround is to avoid failing to start Keystone server.
In the Keystone initConfig step, Keystone will create folders, `/app/public/images` and
`/app/public/files`, to store images and files. However, those two
folders will also be mounted by GCS bucket via GCSFuse.

The root cause is when Keystone server has no permission to create
folder under `/app/public` since `/app/public/images` has already
mounted by GCSFuse.

The workaround is to let Keystone server to create folders first, and
then replace the folders.

However, this workaround can solve the server starting issue, but can
not solve the folder permission. Keystone server still can not access
the folder.

Therefore, the best solution is to solve the folder permission. Let
Keystone to have permission to access the folders mounted by GCSFuse.