### PR TITLE
refactor(edittools): add index item order

### DIFF
--- a/packages/editools/keystone.ts
+++ b/packages/editools/keystone.ts
@@ -96,6 +96,7 @@ export default withAuth(
               query: `
                 embedCode
                 index {
+                  order
                   embedCode
                 }
               `,
@@ -109,7 +110,9 @@ export default withAuth(
             res.send(
               `<html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head><body><div style="margin: 0 auto; max-width: 600px;">${
                 item?.embedCode
-              }</div>${item.index?.map((index) => index.embedCode)}</html>`
+              }</div>${item.index
+                ?.sort((a, b) => a.order - b.order)
+                .map((index) => index.embedCode)}</html>`
             )
           }
         )

--- a/packages/editools/lists/IndexItem.ts
+++ b/packages/editools/lists/IndexItem.ts
@@ -2,7 +2,13 @@
 // @ts-ignore
 import { utils } from '@mirrormedia/lilith-core'
 import { list, graphql } from '@keystone-6/core'
-import { text, image, relationship, virtual } from '@keystone-6/core/fields'
+import {
+  text,
+  image,
+  relationship,
+  virtual,
+  integer,
+} from '@keystone-6/core/fields'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
 
@@ -14,6 +20,10 @@ const listConfigurations = list({
     }),
     slug: text({
       label: 'slug',
+      validation: { isRequired: true },
+    }),
+    order: integer({
+      label: '排序',
       validation: { isRequired: true },
     }),
     imageFile: image({
@@ -47,7 +57,7 @@ const listConfigurations = list({
   ui: {
     listView: {
       initialSort: { field: 'id', direction: 'DESC' },
-      initialColumns: ['name', 'slug'],
+      initialColumns: ['name', 'slug', 'order'],
       pageSize: 50,
     },
     labelField: 'name',

--- a/packages/editools/lists/InlineIndex.ts
+++ b/packages/editools/lists/InlineIndex.ts
@@ -19,9 +19,9 @@ const listConfigurations = list({
       many: true,
       ui: {
         displayMode: 'cards',
-        cardFields: ['name', 'slug', 'imageFile', 'color'],
+        cardFields: ['name', 'slug', 'order', 'imageFile', 'color'],
         inlineCreate: {
-          fields: ['name', 'slug', 'imageFile', 'color'],
+          fields: ['name', 'slug', 'order', 'imageFile', 'color'],
         },
       },
     }),
@@ -43,6 +43,7 @@ const listConfigurations = list({
                 slug
                 name
                 color
+                order
                 imageFile {
                   url
                 }
@@ -50,14 +51,17 @@ const listConfigurations = list({
             `,
           })
           let indexItemsCode = ''
-          indexData?.index?.forEach((item) => {
-            const urlPrefix = `${config.googleCloudStorage.origin}/${config.googleCloudStorage.bucket}`
-            const leftArea = item.imageFile?.url
-              ? `<img src='${urlPrefix}${item.imageFile?.url}' class='item__img' alt='${item.name}'/>`
-              : `<div class='item__color'>
+          const { index } = indexData
+          index
+            .sort((a, b) => a.order - b.order)
+            .forEach((item) => {
+              const urlPrefix = `${config.googleCloudStorage.origin}/${config.googleCloudStorage.bucket}`
+              const leftArea = item.imageFile?.url
+                ? `<img src='${urlPrefix}${item.imageFile?.url}' class='item__img' alt='${item.name}'/>`
+                : `<div class='item__color'>
                   <div class='item__color--item' style='background: ${item.color};'></div>
                 </div>`
-            indexItemsCode += `
+              indexItemsCode += `
             <li class='item'>
               <a class='item__link' href='#${item.slug}'>
                   ${leftArea}
@@ -65,7 +69,7 @@ const listConfigurations = list({
               </a>
             </li>
           `
-          })
+            })
           return `<ul class='toc'>${indexItemsCode}</ul><style>${item.style}</style>`
         },
       }),

--- a/packages/editools/migrations/20220803085659_add_inline_item_order/migration.sql
+++ b/packages/editools/migrations/20220803085659_add_inline_item_order/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Added the required column `order` to the `IndexItem` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "IndexItem" ADD COLUMN     "order" INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "_IndexItem_index" ADD FOREIGN KEY ("A") REFERENCES "IndexItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_IndexItem_index" ADD FOREIGN KEY ("B") REFERENCES "InlineIndex"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/editools/schema.graphql
+++ b/packages/editools/schema.graphql
@@ -2163,6 +2163,7 @@ type IndexItem {
   id: ID!
   name: String
   slug: String
+  order: Int
   imageFile: ImageFieldOutput
   color: String
   index(
@@ -2191,6 +2192,7 @@ input IndexItemWhereInput {
   id: IDFilter
   name: StringFilter
   slug: StringFilter
+  order: IntFilter
   color: StringFilter
   index: InlineIndexManyRelationFilter
   originCode: StringFilter
@@ -2210,6 +2212,7 @@ input IndexItemOrderByInput {
   id: OrderDirection
   name: OrderDirection
   slug: OrderDirection
+  order: OrderDirection
   color: OrderDirection
   originCode: OrderDirection
   createdAt: OrderDirection
@@ -2219,6 +2222,7 @@ input IndexItemOrderByInput {
 input IndexItemUpdateInput {
   name: String
   slug: String
+  order: Int
   imageFile: ImageFieldInput
   color: String
   index: InlineIndexRelateToManyForUpdateInput
@@ -2244,6 +2248,7 @@ input IndexItemUpdateArgs {
 input IndexItemCreateInput {
   name: String
   slug: String
+  order: Int
   imageFile: ImageFieldInput
   color: String
   index: InlineIndexRelateToManyForCreateInput

--- a/packages/editools/schema.prisma
+++ b/packages/editools/schema.prisma
@@ -503,6 +503,7 @@ model IndexItem {
   id                  Int           @id @default(autoincrement())
   name                String        @default("")
   slug                String        @default("")
+  order               Int
   imageFile_filesize  Int?
   imageFile_extension String?
   imageFile_width     Int?


### PR DESCRIPTION
### 描述
- 在 `IndexItem` 中新增 order。
- 在 `InlineIndeces` 的 embed code 中按照 order 從小到大排序，並於 preview 中顯示。