### PR TITLE
feat(editools): add QAList and QAItem

### DIFF
--- a/packages/editools/lists/QAItem.ts
+++ b/packages/editools/lists/QAItem.ts
@@ -11,7 +11,14 @@ const listConfigurations = list({
     }),
     content: customFields.richTextEditor({
       label: '內文',
-      disabledButtons: ['slideshow'],
+      disabledButtons: [
+        'slideshow',
+        'table',
+        'annotation',
+        'divider',
+        'info-box',
+        'link',
+      ],
     }),
   },
   access: {

--- a/packages/editools/lists/QAItem.ts
+++ b/packages/editools/lists/QAItem.ts
@@ -1,0 +1,26 @@
+import { customFields, utils } from '@mirrormedia/lilith-core'
+import { list } from '@keystone-6/core'
+import { text } from '@keystone-6/core/fields'
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+const listConfigurations = list({
+  fields: {
+    title: text({
+      label: '問題內容',
+      validation: { isRequired: true },
+    }),
+    content: customFields.richTextEditor({
+      label: '內文',
+      disabledButtons: ['slideshow'],
+    }),
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator, editor),
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  },
+})
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/editools/lists/QAList.ts
+++ b/packages/editools/lists/QAList.ts
@@ -1,0 +1,75 @@
+import embedCodeGen from '@readr-media/react-embed-code-generator'
+import { utils } from '@mirrormedia/lilith-core'
+import { list, graphql } from '@keystone-6/core'
+import { text, relationship, virtual } from '@keystone-6/core/fields'
+
+const embedCodeWebpackAssets = embedCodeGen.loadWebpackAssets()
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+const listConfigurations = list({
+  fields: {
+    name: text({
+      label: '名稱',
+      validation: {
+        isRequired: true,
+      },
+    }),
+    items: relationship({
+      ref: 'QAItem',
+      many: true,
+    }),
+    embedCode: virtual({
+      label: 'embed code',
+      field: graphql.field({
+        type: graphql.String,
+        resolve: async (
+          item: Record<string, unknown>,
+          args,
+          context
+        ): Promise<string> => {
+          const id = typeof item?.id === 'number' ? item.id.toString() : null
+          // Find the QAList item
+          const list = await context.query.QAList.findOne({
+            where: { id },
+            query: `
+              id
+              name
+              createdAt
+              updatedAt
+              items {
+                id
+                title
+                content
+                createdAt
+                updatedAt
+              }
+            `,
+          })
+          return embedCodeGen.buildEmbeddedCode(
+            'react-qa-list',
+            { questions: list.items },
+            embedCodeWebpackAssets
+          )
+        },
+      }),
+    }),
+  },
+  ui: {
+    listView: {
+      initialSort: { field: 'id', direction: 'DESC' },
+      initialColumns: ['name'],
+      pageSize: 50,
+    },
+    labelField: 'name',
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator, editor),
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  },
+})
+
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/editools/lists/index.ts
+++ b/packages/editools/lists/index.ts
@@ -18,6 +18,8 @@ import EmbedCode from './EmbedCode'
 import Karaoke from './Karaoke'
 import IndexItem from './IndexItem'
 import InlineIndex from './InlineIndex'
+import QAList from './QAList'
+import QAItem from './QAItem'
 
 export const listDefinition = {
   User,
@@ -40,4 +42,6 @@ export const listDefinition = {
   InlineIndex,
   IndexItem,
   Karaoke,
+  QAList,
+  QAItem,
 }

--- a/packages/editools/migrations/20220921092054_add_qa_list_and_qa_item/migration.sql
+++ b/packages/editools/migrations/20220921092054_add_qa_list_and_qa_item/migration.sql
@@ -1,0 +1,66 @@
+-- CreateTable
+CREATE TABLE "QAList" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL DEFAULT E'',
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "QAList_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "QAItem" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL DEFAULT E'',
+    "content" JSONB,
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "QAItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_QAList_items" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE INDEX "QAList_createdBy_idx" ON "QAList"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "QAList_updatedBy_idx" ON "QAList"("updatedBy");
+
+-- CreateIndex
+CREATE INDEX "QAItem_createdBy_idx" ON "QAItem"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "QAItem_updatedBy_idx" ON "QAItem"("updatedBy");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_QAList_items_AB_unique" ON "_QAList_items"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_QAList_items_B_index" ON "_QAList_items"("B");
+
+-- AddForeignKey
+ALTER TABLE "QAList" ADD CONSTRAINT "QAList_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "QAList" ADD CONSTRAINT "QAList_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "QAItem" ADD CONSTRAINT "QAItem_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "QAItem" ADD CONSTRAINT "QAItem_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_QAList_items" ADD FOREIGN KEY ("A") REFERENCES "QAItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_QAList_items" ADD FOREIGN KEY ("B") REFERENCES "QAList"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/editools/schema.graphql
+++ b/packages/editools/schema.graphql
@@ -2434,6 +2434,144 @@ input KaraokeCreateInput {
   updatedBy: UserRelateToOneForCreateInput
 }
 
+type QAList {
+  id: ID!
+  name: String
+  items(
+    where: QAItemWhereInput! = {}
+    orderBy: [QAItemOrderByInput!]! = []
+    take: Int
+    skip: Int! = 0
+  ): [QAItem!]
+  itemsCount(where: QAItemWhereInput! = {}): Int
+  embedCode: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+input QAListWhereUniqueInput {
+  id: ID
+}
+
+input QAListWhereInput {
+  AND: [QAListWhereInput!]
+  OR: [QAListWhereInput!]
+  NOT: [QAListWhereInput!]
+  id: IDFilter
+  name: StringFilter
+  items: QAItemManyRelationFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input QAItemManyRelationFilter {
+  every: QAItemWhereInput
+  some: QAItemWhereInput
+  none: QAItemWhereInput
+}
+
+input QAListOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input QAListUpdateInput {
+  name: String
+  items: QAItemRelateToManyForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input QAItemRelateToManyForUpdateInput {
+  disconnect: [QAItemWhereUniqueInput!]
+  set: [QAItemWhereUniqueInput!]
+  create: [QAItemCreateInput!]
+  connect: [QAItemWhereUniqueInput!]
+}
+
+input QAListUpdateArgs {
+  where: QAListWhereUniqueInput!
+  data: QAListUpdateInput!
+}
+
+input QAListCreateInput {
+  name: String
+  items: QAItemRelateToManyForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
+input QAItemRelateToManyForCreateInput {
+  create: [QAItemCreateInput!]
+  connect: [QAItemWhereUniqueInput!]
+}
+
+type QAItem {
+  id: ID!
+  title: String
+  content: JSON
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+input QAItemWhereUniqueInput {
+  id: ID
+}
+
+input QAItemWhereInput {
+  AND: [QAItemWhereInput!]
+  OR: [QAItemWhereInput!]
+  NOT: [QAItemWhereInput!]
+  id: IDFilter
+  title: StringFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input QAItemOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input QAItemUpdateInput {
+  title: String
+  content: JSON
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input QAItemUpdateArgs {
+  where: QAItemWhereUniqueInput!
+  data: QAItemUpdateInput!
+}
+
+input QAItemCreateInput {
+  title: String
+  content: JSON
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -2615,6 +2753,18 @@ type Mutation {
   updateKaraokes(data: [KaraokeUpdateArgs!]!): [Karaoke]
   deleteKaraoke(where: KaraokeWhereUniqueInput!): Karaoke
   deleteKaraokes(where: [KaraokeWhereUniqueInput!]!): [Karaoke]
+  createQAList(data: QAListCreateInput!): QAList
+  createQALists(data: [QAListCreateInput!]!): [QAList]
+  updateQAList(where: QAListWhereUniqueInput!, data: QAListUpdateInput!): QAList
+  updateQALists(data: [QAListUpdateArgs!]!): [QAList]
+  deleteQAList(where: QAListWhereUniqueInput!): QAList
+  deleteQALists(where: [QAListWhereUniqueInput!]!): [QAList]
+  createQAItem(data: QAItemCreateInput!): QAItem
+  createQAItems(data: [QAItemCreateInput!]!): [QAItem]
+  updateQAItem(where: QAItemWhereUniqueInput!, data: QAItemUpdateInput!): QAItem
+  updateQAItems(data: [QAItemUpdateArgs!]!): [QAItem]
+  deleteQAItem(where: QAItemWhereUniqueInput!): QAItem
+  deleteQAItems(where: [QAItemWhereUniqueInput!]!): [QAItem]
   endSession: Boolean!
   authenticateUserWithPassword(
     email: String!
@@ -2808,6 +2958,22 @@ type Query {
   ): [Karaoke!]
   karaoke(where: KaraokeWhereUniqueInput!): Karaoke
   karaokesCount(where: KaraokeWhereInput! = {}): Int
+  qALists(
+    where: QAListWhereInput! = {}
+    orderBy: [QAListOrderByInput!]! = []
+    take: Int
+    skip: Int! = 0
+  ): [QAList!]
+  qAList(where: QAListWhereUniqueInput!): QAList
+  qAListsCount(where: QAListWhereInput! = {}): Int
+  qAItems(
+    where: QAItemWhereInput! = {}
+    orderBy: [QAItemOrderByInput!]! = []
+    take: Int
+    skip: Int! = 0
+  ): [QAItem!]
+  qAItem(where: QAItemWhereUniqueInput!): QAItem
+  qAItemsCount(where: QAItemWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
 }

--- a/packages/editools/schema.prisma
+++ b/packages/editools/schema.prisma
@@ -56,6 +56,10 @@ model User {
   from_IndexItem_updatedBy           IndexItem[]           @relation("IndexItem_updatedBy")
   from_Karaoke_createdBy             Karaoke[]             @relation("Karaoke_createdBy")
   from_Karaoke_updatedBy             Karaoke[]             @relation("Karaoke_updatedBy")
+  from_QAList_createdBy              QAList[]              @relation("QAList_createdBy")
+  from_QAList_updatedBy              QAList[]              @relation("QAList_updatedBy")
+  from_QAItem_createdBy              QAItem[]              @relation("QAItem_createdBy")
+  from_QAItem_updatedBy              QAItem[]              @relation("QAItem_updatedBy")
 }
 
 model LiveblogItem {
@@ -557,6 +561,37 @@ model Karaoke {
   createdById         Int?      @map("createdBy")
   updatedBy           User?     @relation("Karaoke_updatedBy", fields: [updatedById], references: [id])
   updatedById         Int?      @map("updatedBy")
+
+  @@index([createdById])
+  @@index([updatedById])
+}
+
+model QAList {
+  id          Int       @id @default(autoincrement())
+  name        String    @default("")
+  items       QAItem[]  @relation("QAList_items")
+  createdAt   DateTime?
+  updatedAt   DateTime?
+  createdBy   User?     @relation("QAList_createdBy", fields: [createdById], references: [id])
+  createdById Int?      @map("createdBy")
+  updatedBy   User?     @relation("QAList_updatedBy", fields: [updatedById], references: [id])
+  updatedById Int?      @map("updatedBy")
+
+  @@index([createdById])
+  @@index([updatedById])
+}
+
+model QAItem {
+  id                Int       @id @default(autoincrement())
+  title             String    @default("")
+  content           Json?
+  createdAt         DateTime?
+  updatedAt         DateTime?
+  createdBy         User?     @relation("QAItem_createdBy", fields: [createdById], references: [id])
+  createdById       Int?      @map("createdBy")
+  updatedBy         User?     @relation("QAItem_updatedBy", fields: [updatedById], references: [id])
+  updatedById       Int?      @map("updatedBy")
+  from_QAList_items QAList[]  @relation("QAList_items")
 
   @@index([createdById])
   @@index([updatedById])


### PR DESCRIPTION
# Notable Changes
- add `lists/QAList.ts`
- add `lists/QAItem.ts`
- 從 `lists/Form.ts` 中抽出與 Q&A 有關的欄位（只留必要的欄位）
- 在 QAList 中，透過 virtual field 產生 embed code

# TODOs (Future work)
- 刪除 Form.ts 中與 Q&A 有關的欄位與邏輯。
- 目前的 `@readr-media/react-embed-code-generator` 產生的 `@readr-media/react-qa-list` 不支援 `font-color` 按鈕，需要找時間更新 `@readr-media/react-qa-list` 套件。
