### PR TITLE
chore: update cloudbuild.yaml and Dockerfile to speed up build time

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
   # build docker image for target sub-pacakge
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/cloud-builders/gcloud
     id: Build Image
     entrypoint: 'bash'
     args:
@@ -8,7 +8,7 @@ steps:
       - |
         cp yarn.lock packages/$_TARGET_PACKAGE
         cd packages/$_TARGET_PACKAGE
-        docker build -t gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA} .
+        gcloud builds submit -t gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA} .
 
   # build docker image for target sub-pacakge
   - name: gcr.io/cloud-builders/docker

--- a/packages/editools/Dockerfile
+++ b/packages/editools/Dockerfile
@@ -27,10 +27,12 @@ RUN mkdir -p $APP_DIR
 
 WORKDIR $APP_DIR
 
-COPY . $APP_DIR
+COPY package.json yarn.lock $APP_DIR
 
 ## Install application dependencies
 RUN yarn install
+
+COPY . $APP_DIR
 
 ## Build application bundles
 RUN yarn build

--- a/packages/mirrormedia/Dockerfile
+++ b/packages/mirrormedia/Dockerfile
@@ -27,11 +27,13 @@ RUN mkdir -p $APP_DIR
 
 WORKDIR $APP_DIR
 
-COPY . $APP_DIR
+COPY package.json yarn.lock $APP_DIR
 
 ## Install application dependencies
 RUN yarn install
 RUN yarn postinstall
+
+COPY . $APP_DIR
 
 ## Build application bundles
 RUN yarn build

--- a/packages/seinsights/Dockerfile
+++ b/packages/seinsights/Dockerfile
@@ -27,11 +27,13 @@ RUN mkdir -p $APP_DIR
 
 WORKDIR $APP_DIR
 
-COPY . $APP_DIR
+COPY package.json yarn.lock $APP_DIR
 
 ## Install application dependencies
 RUN yarn install
 RUN yarn postinstall
+
+COPY . $APP_DIR
 
 ## Build application bundles
 RUN yarn build

--- a/packages/vision/Dockerfile
+++ b/packages/vision/Dockerfile
@@ -27,11 +27,13 @@ RUN mkdir -p $APP_DIR
 
 WORKDIR $APP_DIR
 
-COPY . $APP_DIR
+COPY package.json yarn.lock $APP_DIR
 
 ## Install application dependencies
 RUN yarn install
 RUN yarn postinstall
+
+COPY . $APP_DIR
 
 ## Build application bundles
 RUN yarn build


### PR DESCRIPTION
### Notable Changes
- 將 docker build 改為 gcloud builds submit 後，gcloud builds submit 會使用 Kanoki cache 來 cache docker image layer。

[文件說明](https://cloud.google.com/build/docs/optimize-builds/kaniko-cache)：
> if you run builds using the gcloud builds submit --tag [IMAGE] command, you can enable Kaniko cache by setting the property builds/use_kaniko to True as shown below: `gcloud config set builds/use_kaniko True`

- 在 yarn install 前一個 step，只 copy 需要的檔案，當 copy 的檔案沒有變動時，`yarn install` step 就會使用 cache 的版本。