### PR TITLE
feat: update SpecialfeatureList.ts. Record the user input order of relationship `specialfeatures` field

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mirrormedia/lilith-core Changelog
 
+## 2022-12-23, Version 1.2.0
+### Notable Changes
+- export `utils.addManualOrderRelationshipFields`
+
+### Commits
+* \[[`93e5646796`](https://github.com/mirror-media/lilith/commit/93e5646796)] - chore(core): update pkg version to 1.2.0 (nickhsine)
+* \[[`f819d3f50b`](https://github.com/mirror-media/lilith/commit/f819d3f50b)] - feat(core): export `utils.addManualOrderRelationshipFields` (nickhsine)
+
 ## 2022-12-12, Version 1.1.1
 ### Commits
 * \[[`0464b22d5d`](https://github.com/mirror-media/lilith/commit/0464b22d5d)] - chore(core): update version to 1.1.1 (nickhsine)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-core",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 import * as accessControl from './utils/accessControl'
+import addManualOrderRelationshipFields from './utils/manual-order-relationship'
 import draftConverter from './custom-fields/rich-text-editor/draft-to-api-data/draft-converter'
 import { CustomFile } from './custom-fields/file'
 import { CustomRelationship } from './custom-fields/relationship'
@@ -16,6 +17,7 @@ export const customFields = {
 
 export const utils = {
   accessControl,
+  addManualOrderRelationshipFields,
   addTrackingFields,
 }
 
@@ -23,4 +25,3 @@ export default {
   customFields,
   utils,
 }
-

--- a/packages/core/src/utils/manual-order-relationship.ts
+++ b/packages/core/src/utils/manual-order-relationship.ts
@@ -1,0 +1,150 @@
+import { ListConfig } from '@keystone-6/core'
+import { json } from '@keystone-6/core/fields'
+
+type ManualOrderFieldConfig = {
+  fieldName: string
+  fieldLabel?: string
+  targetFieldName: string
+  targetListName: string
+  targetListLabelField: string
+}
+
+/**
+ * For `relationship` field, KeystoneJS won't take user input order into account.
+ * Therefore, after the create/update operation is done,
+ * the order of relationship items maybe not be the same order as the user input order.
+ *
+ * This function
+ * - adds monitoring fields in the list
+ * - decorate `list.hooks.resolveInput` to record the user input order in the monitoring fields
+ *
+ * For example, if we have two lists like
+ *  ```
+ *  const User = {
+ *    fields: {
+ *      name: text(),
+ *    }
+ *  }
+ *
+ *  const Post = {
+ *    fields: {
+ *      title: text(),
+ *      content: text(),
+ *      authors: relationship({ref: 'User', many: true})
+ *    }
+ *  }
+ *  ```
+ *
+ *  if we want to snapshot the authors input order, we can use this function like
+ *  ```
+ *  const postList = addManualOrderRelationshipFields([
+ *    {
+ *      fieldName: 'manualOrderOfAuthors',
+ *      fieldLabel: 'authors 手動排序結果',
+ *      targetFieldName: 'authors',
+ *      targetListName: 'User',
+ *      targetListLabelField: 'name', // refer to `User.fields.name`
+ *    }
+ *  ])(post)
+ *  ```
+ *
+ *  `addManualOrderRelationshipFields` will create another field `manualOrderOfAuthors`
+ *  in the list, and decorate `list.hooks.resolveInput` to record the update/create operation
+ *  if the operation modifies the order of the relationship field.
+ *
+ */
+function addManualOrderRelationshipFields(
+  manualOrderFields: ManualOrderFieldConfig[] = [],
+  list: ListConfig<any, any>
+) {
+  manualOrderFields.forEach((mo) => {
+    if (!list.fields?.[mo.fieldName]) {
+      list.fields[mo.fieldName] = json({
+        label: mo.fieldLabel,
+        ui: {
+          itemView: {
+            fieldMode: 'read',
+          },
+        },
+      })
+    }
+  })
+  list.hooks = list.hooks || {}
+  const originResolveInput = list.hooks?.resolveInput
+  list.hooks.resolveInput = async (props) => {
+    let resolvedData = props.resolvedData
+
+    if (typeof originResolveInput === 'function') {
+      resolvedData = await originResolveInput(props)
+    }
+
+    const { item, context } = props
+
+    for (let i = 0; i < manualOrderFields.length; i++) {
+      const {
+        targetFieldName,
+        fieldName,
+        targetListName,
+        targetListLabelField,
+      } = manualOrderFields[i]
+
+      // if create/update operation modifies the `specialfeatures` field
+      if (resolvedData?.[targetFieldName]) {
+        let currentOrder: { id: string }[] = []
+
+        // update operation due to `item` not being `undefiend`
+        if (item) {
+          const previousOrder: { id: string }[] = Array.isArray(item[fieldName])
+            ? item[fieldName]
+            : []
+
+          // user disconnects/removes some relationship items.
+          const disconnectIds =
+            resolvedData[
+              targetFieldName
+            ]?.disconnect?.map((obj: { id: number }) => obj.id.toString()) || []
+
+          // filtered out to-be-disconnected relationship items
+          currentOrder = previousOrder.filter(({ id }: { id: string }) => {
+            return disconnectIds.indexOf(id) === -1
+          })
+        }
+
+        // user connects/adds some relationship item.
+        const connectedIds =
+          resolvedData[targetFieldName]?.connect?.map((obj: { id: number }) =>
+            obj.id.toString()
+          ) || []
+
+        if (connectedIds.length > 0) {
+          // Query relationship items from the database.
+          // Therefore, we can have other fields to record in the monitoring field
+          const sfToConnect = await context.db[targetListName].findMany({
+            where: { id: { in: connectedIds } },
+          })
+
+          // Database query results are not sorted.
+          // We need to sort them by ourselves.
+          for (let i = 0; i < connectedIds.length; i++) {
+            const sf = sfToConnect.find((obj) => {
+              return `${obj.id}` === connectedIds[i]
+            })
+            if (sf) {
+              currentOrder.push({
+                id: sf.id.toString(),
+                [targetListLabelField]: sf[targetListLabelField],
+              })
+            }
+          }
+        }
+
+        // records the order in the monitoring field
+        resolvedData[fieldName] = currentOrder
+      }
+    }
+    return resolvedData
+  }
+  return list
+}
+
+export default addManualOrderRelationshipFields

--- a/packages/core/src/utils/manual-order-relationship.ts
+++ b/packages/core/src/utils/manual-order-relationship.ts
@@ -41,11 +41,11 @@ type ManualOrderFieldConfig = {
  *    {
  *      fieldName: 'manualOrderOfAuthors',
  *      fieldLabel: 'authors 手動排序結果',
- *      targetFieldName: 'authors',
- *      targetListName: 'User',
+ *      targetFieldName: 'authors', // the target field to record the user input order
+ *      targetListName: 'User', // relationship list name
  *      targetListLabelField: 'name', // refer to `User.fields.name`
  *    }
- *  ])(post)
+ *  ])(Post)
  *  ```
  *
  *  `addManualOrderRelationshipFields` will create another field `manualOrderOfAuthors`

--- a/packages/seinsights/lists/SpecialfeatureList.ts
+++ b/packages/seinsights/lists/SpecialfeatureList.ts
@@ -124,75 +124,13 @@ const listConfigurations = list({
     },
   },
   hooks: {
-    resolveInput: async ({ resolvedData, item, context }) => {
+    resolveInput: async ({ resolvedData }) => {
       const { content } = resolvedData
       if (content) {
         resolvedData.apiData = customFields.draftConverter
           .convertToApiData(content)
           .toJS()
       }
-
-      // For `relationship` field, KeystoneJS won't take user input order into account.
-      // Therefore, after the operation is done, the order of `specialfeatures` items maybe not be the same
-      // order as the user input order.
-      // The following logics records the user input order in `manualOrderOfSpecialFeatures` field.
-      //
-      // if create/update operation modifies the `specialfeatures` field
-      if (resolvedData?.specialfeatures) {
-        let currentOrder: { id: string; title: string }[] = []
-
-        // update operation due to `item` not being `undefiend`
-        if (item) {
-          const previousOrder: { id: string; title: string }[] = Array.isArray(
-            item.manualOrderOfSpecialFeatures
-          )
-            ? item.manualOrderOfSpecialFeatures
-            : []
-
-          // user disconnects/removes some `Specialfeature` items.
-          const disconnectIds =
-            resolvedData.specialfeatures?.disconnect?.map(
-              (obj: { id: number }) => obj.id.toString()
-            ) || []
-
-          // filtered out to-be-disconnected `Specialfeature` items
-          currentOrder = previousOrder.filter(({ id }: { id: string }) => {
-            return disconnectIds.indexOf(id) === -1
-          })
-        }
-
-        // user connects/adds some `Specialfeature` item.
-        const connectedIds =
-          resolvedData.specialfeatures?.connect?.map((obj: { id: number }) =>
-            obj.id.toString()
-          ) || []
-
-        if (connectedIds.length > 0) {
-          // Query `Specialfetaure` items from the database.
-          // Therefore, we can have other fields such as `title`, etc.
-          const sfToConnect = await context.db.Specialfeature.findMany({
-            where: { id: { in: connectedIds } },
-          })
-
-          // Database query results are not sorted.
-          // We need to sort them by ourselves.
-          for (let i = 0; i < connectedIds.length; i++) {
-            const sf = sfToConnect.find((obj) => {
-              return `${obj.id}` === connectedIds[i]
-            })
-            if (sf) {
-              currentOrder.push({
-                id: sf.id.toString(),
-                title: typeof sf.title === 'string' ? sf.title : '',
-              })
-            }
-          }
-        }
-
-        // records the order of `specialfeatures`
-        resolvedData.manualOrderOfSpecialFeatures = currentOrder
-      }
-
       return resolvedData
     },
     validateInput: async ({
@@ -228,4 +166,14 @@ const listConfigurations = list({
   },
 })
 
-export default utils.addTrackingFields(listConfigurations)
+export default utils.addManualOrderRelationshipFields(
+  [
+    {
+      fieldName: 'manualOrderOfSpecialFeatures',
+      targetFieldName: 'specialfeatures',
+      targetListName: 'Specialfeature',
+      targetListLabelField: 'title',
+    },
+  ],
+  utils.addTrackingFields(listConfigurations)
+)

--- a/packages/seinsights/migrations/20221226071620_add_manual_order_of_specialfeatures/migration.sql
+++ b/packages/seinsights/migrations/20221226071620_add_manual_order_of_specialfeatures/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "SpecialfeatureList" ADD COLUMN     "manualOrderOfSpecialFeatures" JSONB;

--- a/packages/seinsights/package.json
+++ b/packages/seinsights/package.json
@@ -19,7 +19,7 @@
     "@keystone-6/auth": "1.0.0",
     "@keystone-6/core": "1.1.1",
     "@keystone-6/fields-document": "1.0.1",
-    "@mirrormedia/lilith-core": "1.2.0-beta.0",
+    "@mirrormedia/lilith-core": "1.2.0",
     "express": "^4.17.1",
     "http-proxy-middleware": "^2.0.3",
     "patch-package": "^6.4.7"

--- a/packages/seinsights/package.json
+++ b/packages/seinsights/package.json
@@ -19,7 +19,7 @@
     "@keystone-6/auth": "1.0.0",
     "@keystone-6/core": "1.1.1",
     "@keystone-6/fields-document": "1.0.1",
-    "@mirrormedia/lilith-core": "^1.0.3",
+    "@mirrormedia/lilith-core": "1.2.0-beta.0",
     "express": "^4.17.1",
     "http-proxy-middleware": "^2.0.3",
     "patch-package": "^6.4.7"

--- a/packages/seinsights/package.json
+++ b/packages/seinsights/package.json
@@ -26,5 +26,9 @@
   },
   "devDependencies": {
     "typescript": "^4.7.4"
+  },
+  "resolutions": {
+    "react": "18.1.0",
+    "react-dom": "18.1.0"
   }
 }

--- a/packages/seinsights/schema.graphql
+++ b/packages/seinsights/schema.graphql
@@ -2072,6 +2072,7 @@ type SpecialfeatureList {
     skip: Int! = 0
   ): [Specialfeature!]
   specialfeaturesCount(where: SpecialfeatureWhereInput! = {}): Int
+  manualOrderOfSpecialFeatures: JSON
   url: String
   section(
     where: SectionWhereInput! = {}
@@ -2144,6 +2145,7 @@ input SpecialfeatureListUpdateInput {
   content: JSON
   topSpecialfeature: SpecialfeatureRelateToOneForUpdateInput
   specialfeatures: SpecialfeatureRelateToManyForUpdateInput
+  manualOrderOfSpecialFeatures: JSON
   url: String
   section: SectionRelateToManyForUpdateInput
   apiData: JSON
@@ -2167,6 +2169,7 @@ input SpecialfeatureListCreateInput {
   content: JSON
   topSpecialfeature: SpecialfeatureRelateToOneForCreateInput
   specialfeatures: SpecialfeatureRelateToManyForCreateInput
+  manualOrderOfSpecialFeatures: JSON
   url: String
   section: SectionRelateToManyForCreateInput
   apiData: JSON

--- a/packages/seinsights/schema.prisma
+++ b/packages/seinsights/schema.prisma
@@ -339,26 +339,27 @@ model Specialfeature {
 }
 
 model SpecialfeatureList {
-  id                  Int                           @id @default(autoincrement())
-  title               String                        @default("")
-  weight              Int?                          @default(85)
-  status              SpecialfeatureListStatusType? @default(draft)
-  publishDate         DateTime?                     @default(now())
-  heroImage           Photo?                        @relation("SpecialfeatureList_heroImage", fields: [heroImageId], references: [id])
-  heroImageId         Int?                          @map("heroImage")
-  content             Json?
-  topSpecialfeature   Specialfeature?               @relation("SpecialfeatureList_topSpecialfeature", fields: [topSpecialfeatureId], references: [id])
-  topSpecialfeatureId Int?                          @map("topSpecialfeature")
-  specialfeatures     Specialfeature[]              @relation("Specialfeature_specialfeatureLists")
-  url                 String                        @default("")
-  section             Section[]                     @relation("Section_specialfeatureLists")
-  apiData             Json?
-  createdAt           DateTime?
-  updatedAt           DateTime?
-  createdBy           User?                         @relation("SpecialfeatureList_createdBy", fields: [createdById], references: [id])
-  createdById         Int?                          @map("createdBy")
-  updatedBy           User?                         @relation("SpecialfeatureList_updatedBy", fields: [updatedById], references: [id])
-  updatedById         Int?                          @map("updatedBy")
+  id                           Int                           @id @default(autoincrement())
+  title                        String                        @default("")
+  weight                       Int?                          @default(85)
+  status                       SpecialfeatureListStatusType? @default(draft)
+  publishDate                  DateTime?                     @default(now())
+  heroImage                    Photo?                        @relation("SpecialfeatureList_heroImage", fields: [heroImageId], references: [id])
+  heroImageId                  Int?                          @map("heroImage")
+  content                      Json?
+  topSpecialfeature            Specialfeature?               @relation("SpecialfeatureList_topSpecialfeature", fields: [topSpecialfeatureId], references: [id])
+  topSpecialfeatureId          Int?                          @map("topSpecialfeature")
+  specialfeatures              Specialfeature[]              @relation("Specialfeature_specialfeatureLists")
+  manualOrderOfSpecialFeatures Json?
+  url                          String                        @default("")
+  section                      Section[]                     @relation("Section_specialfeatureLists")
+  apiData                      Json?
+  createdAt                    DateTime?
+  updatedAt                    DateTime?
+  createdBy                    User?                         @relation("SpecialfeatureList_createdBy", fields: [createdById], references: [id])
+  createdById                  Int?                          @map("createdBy")
+  updatedBy                    User?                         @relation("SpecialfeatureList_updatedBy", fields: [updatedById], references: [id])
+  updatedById                  Int?                          @map("updatedBy")
 
   @@index([heroImageId])
   @@index([topSpecialfeatureId])

--- a/yarn.lock
+++ b/yarn.lock
@@ -1953,6 +1953,26 @@
     "@keystone-ui/popover" "^5.0.0"
     apply-ref "^1.0.0"
 
+"@mirrormedia/lilith-core@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-core/-/lilith-core-1.1.1.tgz#7e63fd6a1bf6b3e93000faa1106aa542dc20d2df"
+  integrity sha512-e6AZl6VOOGXunhVUEmFzUnticMOuRucuPRwfGPV3Fqb9PQyDlrdoTmOmUuA56MenB1mIdRMY7NNmodIkuYfLyw==
+  dependencies:
+    "@google-cloud/storage" "^5.18.0"
+    "@keystone-ui/button" "^6.0.0"
+    "@keystone-ui/fields" "^6.0.0"
+    "@keystone-ui/modals" "^5.0.0"
+    "@twreporter/errors" "^1.1.1"
+    axios "^0.26.0"
+    draft-convert "^2.1.12"
+    draft-js "^0.11.7"
+    htmlparser2 "^7.2.0"
+    immutable "^4.0.0"
+    lodash "^4.17.21"
+    shortid "^2.2.16"
+    styled-components "5.3.5"
+    zlib "^1.0.5"
+
 "@next/env@12.2.5":
   version "12.2.5"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-12.2.5.tgz#d908c57b35262b94db3e431e869b72ac3e1ad3e3"


### PR DESCRIPTION
# Change Reason
For relationship fields, KeystoneJS won't take input order into account. Therefore, if we want to remember the input order, we need to do it by ourselves.

This commit adds `manualOrderOfSpecialFeatures` field, which is used to record the input order of `specialfeatures` field.

We monitor the input order in `resolveInput` hook. If the order changes, we adjust `manualOrderOfSpecialFeatures` field correspondingly.

# Demo

<img width="1436" alt="Screen Shot 2022-12-22 at 10 01 23 PM" src="https://user-images.githubusercontent.com/3000343/209150537-ad424ec0-2360-41c0-ad1b-ec7ad78c7c52.png">

You can see the different orders in `SpecialFeatures` and `SpecialFeatures 手動排序結果` fields.
