### PR TITLE
chore: disable kaniko cache. Use docker --cache-from mechanism instead

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,15 +1,49 @@
 steps:
+  # Temporarily disable kaniko cache approach due to unexpected build errors.
+  #
   # build docker image for target sub-pacakge
   # use debug tag so that we can use `sh` entrypoint
-  - name: 'gcr.io/kaniko-project/executor:debug'
-    id: Build Image
-    entrypoint: 'sh'
+  #- name: 'gcr.io/kaniko-project/executor:debug'
+  #  id: Build Image
+  #  entrypoint: 'sh'
+  #  args:
+  #    - '-c'
+  #    - |
+  #      cp yarn.lock packages/$_TARGET_PACKAGE
+  #      cd packages/$_TARGET_PACKAGE
+  #      /kaniko/executor --context="$(pwd)" --cache=true --cache-ttl=48h --destination=gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA}
+
+  # Pull previous image
+  - name: gcr.io/cloud-builders/docker
     args:
       - '-c'
-      - |
+      - 'docker pull gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest || exit 0'
+    entrypoint: bash
+
+  # Build image
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - '-c'
+      - >
         cp yarn.lock packages/$_TARGET_PACKAGE
+
         cd packages/$_TARGET_PACKAGE
-        /kaniko/executor --context="$(pwd)" --cache=true --cache-ttl=48h --destination=gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA}
+
+        docker build -t \
+
+        gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA} \
+
+        -t gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest \
+
+        --cache-from gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest .
+    entrypoint: bash
+
+  # Push container image to registry
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - 'gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA}'
+
 
   # Deploy container image to Cloud Runs
   - name: gcr.io/cloud-builders/gcloud
@@ -29,6 +63,12 @@ steps:
         gcloud run deploy "$cr" --image gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA} --region asia-east1
 
         done
+
+  # Push container image to registry to update the latest one
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - 'gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest'
 
 timeout: 1200s
 


### PR DESCRIPTION
The build fails unexpectedly due to Kaniko cache using too much memory. Out of memory will make build containers be killed by system. This seems a known issue.
Before this issue is fixed, we change the cache mechanism by using `docker --cache-from` instead.