### PR TITLE
feat(seinsights): enable article preview page

### DIFF
--- a/packages/seinsights/keystone.ts
+++ b/packages/seinsights/keystone.ts
@@ -74,6 +74,10 @@ export default withAuth(
         const previewProxyMiddleware = createProxyMiddleware({
           target: envVar.previewServerOrigin,
           changeOrigin: true,
+          pathRewrite: {
+            '/preview/article': '/article',
+            '/preview/specialfeature': '/specialfeature',
+          },
           onProxyRes: (proxyRes) => {
             // The response from preview nuxt server might be with Cache-Control header.
             // However, we don't want to get cached responses for `draft` posts.
@@ -82,8 +86,19 @@ export default withAuth(
           },
         })
 
-        // Proxy requests with `/story/id` url path to preview nuxt server
-        app.get('/article/:id', authenticationMw, previewProxyMiddleware)
+        // Proxy requests with `/preview/article/id` url path to preview nuxt server
+        app.get(
+          '/preview/article/:id',
+          authenticationMw,
+          previewProxyMiddleware
+        )
+
+        // Proxy requests with `/preview/specialfeature/id` url path to preview nuxt server
+        app.get(
+          '/preview/specialfeature/:id',
+          authenticationMw,
+          previewProxyMiddleware
+        )
 
         // Proxy requests with `/_next/*` url path to preview nuxt server
         // if the request's Referer header matches `/article/:id` route.
@@ -94,7 +109,7 @@ export default withAuth(
           (req, res, next) => {
             const referer = req.header('referer') || ''
             // The requests are from preview article page
-            if (referer.match(/\/article\/[^\/]*$/)) { // eslint-disable-line
+            if (referer.match(/\/preview\/\/(article|specialfeature)\/[^\/]*$/)) { // eslint-disable-line
               // go to next middleware to proxy requests to preview server
               return next()
             }

--- a/packages/seinsights/lists/Post.ts
+++ b/packages/seinsights/lists/Post.ts
@@ -1,7 +1,7 @@
 // import envVar from '../environment-variables'
 // @ts-ignore: no definition
 import { customFields, utils } from '@mirrormedia/lilith-core'
-import { list } from '@keystone-6/core'
+import { list, graphql } from '@keystone-6/core'
 import {
   text,
   integer,
@@ -10,6 +10,7 @@ import {
   json,
   timestamp,
   checkbox,
+  virtual,
 } from '@keystone-6/core/fields'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
@@ -183,18 +184,17 @@ const listConfigurations = list({
       label: '會員文章',
       defaultValue: false,
     }),
-    //
-    // previewButton: virtual({
-    //   field: graphql.field({
-    //     type: graphql.String,
-    //     resolve(item: Record<string, unknown>): string {
-    //       return `/story/${item?.id}`
-    //     },
-    //   }),
-    //   ui: {
-    //     views: require.resolve('./preview-button'),
-    //   },
-    // }),
+    previewButton: virtual({
+      field: graphql.field({
+        type: graphql.String,
+        resolve(item: Record<string, unknown>): string {
+          return `/article/${item?.id}`
+        },
+      }),
+      ui: {
+        views: require.resolve('./preview-button'),
+      },
+    }),
     oldCategory: select({
       label: '舊內容分類（工程用）',
       options: [

--- a/packages/seinsights/lists/Post.ts
+++ b/packages/seinsights/lists/Post.ts
@@ -188,7 +188,7 @@ const listConfigurations = list({
       field: graphql.field({
         type: graphql.String,
         resolve(item: Record<string, unknown>): string {
-          return `/article/${item?.id}`
+          return `/preview/article/${item?.id}`
         },
       }),
       ui: {

--- a/packages/seinsights/lists/Specialfeature.ts
+++ b/packages/seinsights/lists/Specialfeature.ts
@@ -1,9 +1,6 @@
 // @ts-ignore: no definition
 import { customFields, utils } from '@mirrormedia/lilith-core'
-import {
-  list,
-  // graphql
-} from '@keystone-6/core'
+import { list, graphql } from '@keystone-6/core'
 import {
   text,
   integer,
@@ -11,7 +8,7 @@ import {
   select,
   json,
   timestamp,
-  // virtual
+  virtual,
 } from '@keystone-6/core/fields'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
@@ -141,17 +138,17 @@ const listConfigurations = list({
       },
       many: true,
     }),
-    // previewButton: virtual({
-    //   field: graphql.field({
-    //     type: graphql.String,
-    //     resolve(item: Record<string, unknown>): string {
-    //       return `/story/${item?.id}`
-    //     },
-    //   }),
-    //   ui: {
-    //     views: require.resolve('./preview-button'),
-    //   },
-    // }),
+    previewButton: virtual({
+      field: graphql.field({
+        type: graphql.String,
+        resolve(item: Record<string, unknown>): string {
+          return `/preview/specialfeature/${item?.id}`
+        },
+      }),
+      ui: {
+        views: require.resolve('./preview-button'),
+      },
+    }),
     apiData: json({
       label: '資料庫使用',
       ui: {

--- a/packages/seinsights/schema.graphql
+++ b/packages/seinsights/schema.graphql
@@ -1353,6 +1353,7 @@ type Post {
   ): [Tag!]
   tagsCount(where: TagWhereInput! = {}): Int
   isPremium: Boolean
+  previewButton: String
   oldCategory: String
   apiDataBrief: JSON
   apiData: JSON

--- a/packages/seinsights/schema.graphql
+++ b/packages/seinsights/schema.graphql
@@ -1930,6 +1930,7 @@ type Specialfeature {
     skip: Int! = 0
   ): [Tag!]
   tagsCount(where: TagWhereInput! = {}): Int
+  previewButton: String
   apiData: JSON
   createdAt: DateTime
   updatedAt: DateTime


### PR DESCRIPTION
### Notable Changes
- add preview server and proxy article page to preview server


### 實作細節
將要到 `/article/:id` 的 requests proxy 到 preview server，讓 preview server 產生 article page ，回傳 article page html 給 CMS server，CMS server 再將 preview server 產生的 article page html 回傳給瀏覽器。瀏覽器進而得以呈現文章頁。

但因為產生 `/article/:id` article page 的 preview server 是由「使用 nextjs 的 seinsights-next」 部署產生，article page 在瀏覽器 render 時，會需要 requests `/_next/*` 底下的 bundle js 和 server js 。然而，「lilith-seinsights 也是透過 nextjs 產生的服務」，所以 lilith-seinsights 本身也會提供 `/_next/*` routes，導致出現重複的 routes，article page 因而無法正常 render。

此 PR 透過 request Referer header `req.header('referer')` 來幫忙判斷現在進來 `/_next/*` 的 requests 是 article page 發起的 還是 CMS web pages 所發起的 requests。如果是 Referer 的網址是 `/article/:id` 結尾，代表是 article page，就將 requests proxy 到 preview server，反之，則進到 CMS server 提供的 routes。