### PR TITLE
feat(mirrormedia): add `trimmedContent` field and restrict `content` access 

### DIFF
--- a/packages/mirrormedia/lists/Category.ts
+++ b/packages/mirrormedia/lists/Category.ts
@@ -1,27 +1,22 @@
 import { utils } from '@mirrormedia/lilith-core'
-import { list } from '@keystone-6/core';
-import { relationship, checkbox, select, text, integer } from '@keystone-6/core/fields';
+import { list } from '@keystone-6/core'
+import { relationship, select, text, integer } from '@keystone-6/core/fields'
 
-const {
-  allowRoles,
-  admin,
-  moderator,
-  editor,
-  owner,
-} = utils.accessControl
+const { allowRoles, admin, moderator, editor } = utils.accessControl
 
 const listConfigurations = list({
   fields: {
     name: text({
-      label: '名稱', validation: { isRequired: true }
+      label: '名稱',
+      validation: { isRequired: true },
     }),
     slug: text({
       label: 'slug',
       isIndexed: 'unique',
-      validation: { isRequired: true }
+      validation: { isRequired: true },
     }),
-    order: integer({ 
-      label: '排序', 
+    order: integer({
+      label: '排序',
       validation: {
         min: 1,
         max: 9999,
@@ -41,18 +36,17 @@ const listConfigurations = list({
       ref: 'Photo',
     }),
     sections: relationship({
-      ref: "Section.categories",
+      ref: 'Section.categories',
       many: false,
     }),
     posts: relationship({
-      ref: "Post.categories",
+      ref: 'Post.categories',
       many: true,
       ui: {
-        createView: { fieldMode: 'hidden'},
+        createView: { fieldMode: 'hidden' },
         itemView: { fieldMode: 'hidden' },
-      }
+      },
     }),
-
   },
   access: {
     operation: {

--- a/packages/mirrormedia/lists/Category.ts
+++ b/packages/mirrormedia/lists/Category.ts
@@ -1,6 +1,12 @@
 import { utils } from '@mirrormedia/lilith-core'
 import { list } from '@keystone-6/core'
-import { relationship, select, text, integer } from '@keystone-6/core/fields'
+import {
+  relationship,
+  checkbox,
+  select,
+  text,
+  integer,
+} from '@keystone-6/core/fields'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
 
@@ -46,6 +52,10 @@ const listConfigurations = list({
         createView: { fieldMode: 'hidden' },
         itemView: { fieldMode: 'hidden' },
       },
+    }),
+    isMemberOnly: checkbox({
+      label: '會員文章',
+      defaultValue: false,
     }),
   },
   access: {

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -169,7 +169,8 @@ const listConfigurations = list({
       label: '前言',
       disabledButtons: [],
     }),
-    trimmedContet: virtual({
+    trimmedContent: virtual({
+      label: '擷取前5段的內文（不包括換行）',
       ui: {
         createView: { fieldMode: 'hidden' },
         itemView: { fieldMode: 'hidden' },

--- a/packages/mirrormedia/migrations/20230117062209_category_add_is_member_only_field/migration.sql
+++ b/packages/mirrormedia/migrations/20230117062209_category_add_is_member_only_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "isMemberOnly" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -1641,6 +1641,7 @@ type Category {
     skip: Int! = 0
   ): [Post!]
   postsCount(where: PostWhereInput! = {}): Int
+  isMemberOnly: Boolean
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User
@@ -1664,6 +1665,7 @@ input CategoryWhereInput {
   heroImage: PhotoWhereInput
   sections: SectionWhereInput
   posts: PostManyRelationFilter
+  isMemberOnly: BooleanFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
@@ -1676,6 +1678,7 @@ input CategoryOrderByInput {
   slug: OrderDirection
   order: OrderDirection
   state: OrderDirection
+  isMemberOnly: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
@@ -1688,6 +1691,7 @@ input CategoryUpdateInput {
   heroImage: PhotoRelateToOneForUpdateInput
   sections: SectionRelateToOneForUpdateInput
   posts: PostRelateToManyForUpdateInput
+  isMemberOnly: Boolean
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
@@ -1713,6 +1717,7 @@ input CategoryCreateInput {
   heroImage: PhotoRelateToOneForCreateInput
   sections: SectionRelateToOneForCreateInput
   posts: PostRelateToManyForCreateInput
+  isMemberOnly: Boolean
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -71,6 +71,7 @@ type Post {
   heroImageSize: String
   style: String
   brief: JSON
+  trimmedContet: JSON
   content: JSON
   topics: Topic
   titleColor: String

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -71,7 +71,7 @@ type Post {
   heroImageSize: String
   style: String
   brief: JSON
-  trimmedContet: JSON
+  trimmedContent: JSON
   content: JSON
   topics: Topic
   titleColor: String

--- a/packages/mirrormedia/schema.prisma
+++ b/packages/mirrormedia/schema.prisma
@@ -352,22 +352,23 @@ model Section {
 }
 
 model Category {
-  id          Int       @id @default(autoincrement())
-  name        String    @default("")
-  slug        String    @unique @default("")
-  order       Int?
-  state       String    @default("active")
-  heroImage   Photo?    @relation("Category_heroImage", fields: [heroImageId], references: [id])
-  heroImageId Int?      @map("heroImage")
-  sections    Section?  @relation("Category_sections", fields: [sectionsId], references: [id])
-  sectionsId  Int?      @map("sections")
-  posts       Post[]    @relation("Category_posts")
-  createdAt   DateTime?
-  updatedAt   DateTime?
-  createdBy   User?     @relation("Category_createdBy", fields: [createdById], references: [id])
-  createdById Int?      @map("createdBy")
-  updatedBy   User?     @relation("Category_updatedBy", fields: [updatedById], references: [id])
-  updatedById Int?      @map("updatedBy")
+  id           Int       @id @default(autoincrement())
+  name         String    @default("")
+  slug         String    @unique @default("")
+  order        Int?
+  state        String    @default("active")
+  heroImage    Photo?    @relation("Category_heroImage", fields: [heroImageId], references: [id])
+  heroImageId  Int?      @map("heroImage")
+  sections     Section?  @relation("Category_sections", fields: [sectionsId], references: [id])
+  sectionsId   Int?      @map("sections")
+  posts        Post[]    @relation("Category_posts")
+  isMemberOnly Boolean   @default(false)
+  createdAt    DateTime?
+  updatedAt    DateTime?
+  createdBy    User?     @relation("Category_createdBy", fields: [createdById], references: [id])
+  createdById  Int?      @map("createdBy")
+  updatedBy    User?     @relation("Category_updatedBy", fields: [updatedById], references: [id])
+  updatedById  Int?      @map("updatedBy")
 
   @@index([heroImageId])
   @@index([sectionsId])

--- a/packages/mirrormedia/utils/gcp-logging.js
+++ b/packages/mirrormedia/utils/gcp-logging.js
@@ -1,0 +1,27 @@
+import { IncomingMessage } from 'http' // eslint-disable-line
+
+/**
+ *  Follow [Writing structured logs](https://cloud.google.com/run/docs/logging#writing_structured_logs)
+ *  doc to do logging.
+ *
+ *  @param {IncomingMessage} [req]
+ *  @param {string} [projectId]
+ *  @return {Object} globalLogFields
+ */
+function getGlobalLogFields(req, projectId) {
+  const globalLogFields = {}
+
+  // Add log correlation to nest all log messages beneath request log in Log Viewer.
+  const traceHeader = req?.headers?.['x-cloud-trace-context']
+  if (typeof traceHeader === 'string' && traceHeader !== '' && projectId) {
+    const [trace] = traceHeader.split('/')
+    globalLogFields[
+      'logging.googleapis.com/trace'
+    ] = `projects/${projectId}/traces/${trace}`
+  }
+  return globalLogFields
+}
+
+export default {
+  getGlobalLogFields,
+}


### PR DESCRIPTION
### Asana 卡片
https://app.asana.com/0/1181156545719626/1203646042182610/f

### Notable Changes
1. add `trimmedContet` field: 保留 `content` 前 5 個 blocks（不包含空白換行）。
2. update `content` field: 加入「是否為會員文章的判斷」，如果使用者不是 Premium member，且文章是會員文章，則 return `null`

### 提醒
前端在 query 時，可以 `trimmedContent` 和 `content` 一起 query，如果 `content` 不是 `null`，代表使用者可以閱讀該篇文章（文章可能是一般文章或是會員文章）。如果 `content` 是 `null`，則可以使用 `trimmedContent` 來呈現部分文章，並且提示使用者需要註冊成為 Premium 會員才能閱讀。