### PR TITLE
style(editools): update InlineIndex css

### DIFF
--- a/packages/editools/lists/InlineIndex.ts
+++ b/packages/editools/lists/InlineIndex.ts
@@ -71,6 +71,7 @@ const listConfigurations = list({
             height: 72px; 
           } 
           .item__color { 
+            flex: 0;
             width: 129px; 
             height: 72px;
             display: flex;


### PR DESCRIPTION
修復 InlineIndex 的長方形沒有對齊的問題，請見下圖。

<img width="914" alt="Screen Shot 2023-01-19 at 10 55 41 AM" src="https://user-images.githubusercontent.com/3000343/213344916-8c7d9967-fc4e-48e6-9ec3-079cf06159ce.png">
