### PR TITLE
feat(draft-js): add video and audio buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ gcskeyfile.json
 .eslintcache
 
 packages/**/lib
+packages/**/public/*

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-core",
-  "version": "1.2.6",
+  "version": "1.2.7-alpha.0",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -33,7 +33,7 @@
     "@keystone-ui/fields": "^6.0.0",
     "@keystone-ui/modals": "^5.0.0",
     "@twreporter/errors": "^1.1.1",
-    "@mirrormedia/lilith-draft-editor": "1.0.1",
+    "@mirrormedia/lilith-draft-editor": "1.1.0-alpha.3",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",
     "draft-js": "^0.11.7",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-editor",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.3",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "draft-js": "^0.11.7",
-    "@mirrormedia/lilith-draft-renderer": "1.0.0"
+    "@mirrormedia/lilith-draft-renderer": "1.1.0-alpha.6"
   },
   "peerDependencies": {
     "react": "18.1.0",

--- a/packages/draft-editor/src/draft-js/buttons/audio.tsx
+++ b/packages/draft-editor/src/draft-js/buttons/audio.tsx
@@ -1,43 +1,45 @@
 import React, { useState } from 'react'
 import { AtomicBlockUtils, EditorState } from 'draft-js'
 
-import { ImageSelector as DefaultImageSelector } from './selector/image-selector'
+import {
+  AudioSelector as DefaultAudioSelector,
+  AudioEntityWithMeta,
+} from './selector/audio-selector'
 
-export function ImageButton(props: {
+export function AudioButton(props: {
   editorState: EditorState
   onChange: (param: EditorState) => void
   className?: string
-  ImageSelector: typeof DefaultImageSelector
+  AudioSelector: typeof DefaultAudioSelector
 }) {
   const {
     editorState,
     onChange,
     className,
-    ImageSelector = DefaultImageSelector,
+    AudioSelector = DefaultAudioSelector,
   } = props
 
-  const [toShowImageSelector, setToShowImageSelector] = useState(false)
+  const [toShowAudioSelector, setToShowAudioSelector] = useState(false)
 
-  const promptForImageSelector = () => {
-    setToShowImageSelector(true)
+  const promptForAudioSelector = () => {
+    setToShowAudioSelector(true)
   }
 
-  const onImageSelectorChange = (selectedImagesWithMeta, align) => {
-    const selected = selectedImagesWithMeta?.[0]
-    if (!selected) {
-      setToShowImageSelector(false)
+  const onAudioSelectorChange = (
+    selectedAudiosWithMeta: AudioEntityWithMeta[]
+  ) => {
+    const audio = selectedAudiosWithMeta?.[0]?.audio
+    if (!audio) {
+      setToShowAudioSelector(false)
       return
     }
 
     const contentState = editorState.getCurrentContent()
     const contentStateWithEntity = contentState.createEntity(
-      'image',
+      'AUDIO',
       'IMMUTABLE',
       {
-        ...selected?.image,
-        desc: selected?.desc,
-        url: selected?.url,
-        alignment: align,
+        audio,
       }
     )
     const entityKey = contentStateWithEntity.getLastCreatedEntityKey()
@@ -48,23 +50,18 @@ export function ImageButton(props: {
     // The third parameter here is a space string, not an empty string
     // If you set an empty string, you will get an error: Unknown DraftEntity key: null
     onChange(AtomicBlockUtils.insertAtomicBlock(newEditorState, entityKey, ' '))
-    setToShowImageSelector(false)
+    setToShowAudioSelector(false)
   }
 
   return (
     <React.Fragment>
-      {toShowImageSelector && (
-        <ImageSelector
-          onChange={onImageSelectorChange}
-          enableCaption={true}
-          enableUrl={true}
-          enableAlignment={true}
-        />
+      {toShowAudioSelector && (
+        <AudioSelector onChange={onAudioSelectorChange} />
       )}
 
-      <div className={className} onClick={promptForImageSelector}>
-        <i className="far fa-image"></i>
-        <span> Image</span>
+      <div className={className} onClick={promptForAudioSelector}>
+        <i className="fa fa-file-audio"></i>
+        <span> Audio</span>
       </div>
     </React.Fragment>
   )

--- a/packages/draft-editor/src/draft-js/buttons/audio.tsx
+++ b/packages/draft-editor/src/draft-js/buttons/audio.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react'
+import { AtomicBlockUtils, EditorState } from 'draft-js'
+
+import { ImageSelector as DefaultImageSelector } from './selector/image-selector'
+
+export function ImageButton(props: {
+  editorState: EditorState
+  onChange: (param: EditorState) => void
+  className?: string
+  ImageSelector: typeof DefaultImageSelector
+}) {
+  const {
+    editorState,
+    onChange,
+    className,
+    ImageSelector = DefaultImageSelector,
+  } = props
+
+  const [toShowImageSelector, setToShowImageSelector] = useState(false)
+
+  const promptForImageSelector = () => {
+    setToShowImageSelector(true)
+  }
+
+  const onImageSelectorChange = (selectedImagesWithMeta, align) => {
+    const selected = selectedImagesWithMeta?.[0]
+    if (!selected) {
+      setToShowImageSelector(false)
+      return
+    }
+
+    const contentState = editorState.getCurrentContent()
+    const contentStateWithEntity = contentState.createEntity(
+      'image',
+      'IMMUTABLE',
+      {
+        ...selected?.image,
+        desc: selected?.desc,
+        url: selected?.url,
+        alignment: align,
+      }
+    )
+    const entityKey = contentStateWithEntity.getLastCreatedEntityKey()
+    const newEditorState = EditorState.set(editorState, {
+      currentContent: contentStateWithEntity,
+    })
+
+    // The third parameter here is a space string, not an empty string
+    // If you set an empty string, you will get an error: Unknown DraftEntity key: null
+    onChange(AtomicBlockUtils.insertAtomicBlock(newEditorState, entityKey, ' '))
+    setToShowImageSelector(false)
+  }
+
+  return (
+    <React.Fragment>
+      {toShowImageSelector && (
+        <ImageSelector
+          onChange={onImageSelectorChange}
+          enableCaption={true}
+          enableUrl={true}
+          enableAlignment={true}
+        />
+      )}
+
+      <div className={className} onClick={promptForImageSelector}>
+        <i className="far fa-image"></i>
+        <span> Image</span>
+      </div>
+    </React.Fragment>
+  )
+}

--- a/packages/draft-editor/src/draft-js/buttons/selector/audio-selector.tsx
+++ b/packages/draft-editor/src/draft-js/buttons/selector/audio-selector.tsx
@@ -1,0 +1,311 @@
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { Drawer, DrawerController } from '@keystone-ui/modals'
+import { gql, useLazyQuery } from '@keystone-6/core/admin-ui/apollo'
+import { ImageEntity } from './image-selector'
+import { SearchBox, SearchBoxOnChangeFn } from './search-box'
+import { Pagination } from './pagination'
+
+const AudioSearchBox = styled(SearchBox)`
+  margin-top: 10px;
+`
+
+const AudioSelectionWrapper = styled.div`
+  overflow: auto;
+  margin-top: 10px;
+`
+
+const AudioGridsWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  overflow: auto;
+`
+
+const AudioGridWrapper = styled.div`
+  flex: 0 0 50%;
+  cursor: pointer;
+  padding: 0 10px 10px;
+`
+
+const AudioMetaGridsWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  overflow: auto;
+`
+
+const AudioMetaGridWrapper = styled.div`
+  flex: 0 0 50%;
+  cursor: pointer;
+  padding: 0 10px 10px;
+`
+
+const Audio = styled.audio`
+  width: 100%;
+`
+
+const AudioName = styled.p`
+  text-align: center;
+`
+
+const SeparationLine = styled.div`
+  border: #e1e5e9 1px solid;
+  margin-top: 10px;
+  margin-bottom: 10px;
+`
+
+const AudioSelected = styled.div`
+  height: 1.4rem;
+`
+
+const ErrorWrapper = styled.div`
+  & * {
+    margin: 0;
+  }
+`
+
+type ID = string
+
+export type AudioEntity = {
+  id: ID
+  name?: string
+  urlOriginal?: string
+  file?: {
+    url: string
+  }
+  heroImage?: ImageEntity
+}
+
+export type AudioEntityWithMeta = {
+  audio: AudioEntity
+}
+
+type AudioEntityOnSelectFn = (param: AudioEntity) => void
+
+function AudiosGrids(props: {
+  audios: AudioEntity[]
+  selected: AudioEntity[]
+  onSelect: AudioEntityOnSelectFn
+}): React.ReactElement {
+  const { audios, selected, onSelect } = props
+
+  return (
+    <AudioGridsWrapper>
+      {audios.map((audio) => {
+        return (
+          <AudioGrid
+            key={audio.id}
+            isSelected={selected?.includes(audio)}
+            onSelect={() => onSelect(audio)}
+            audio={audio}
+          />
+        )
+      })}
+    </AudioGridsWrapper>
+  )
+}
+
+function AudioGrid(props: {
+  audio: AudioEntity
+  isSelected: boolean
+  onSelect: AudioEntityOnSelectFn
+}) {
+  const { audio, onSelect, isSelected } = props
+  console.log('audio', audio)
+  return (
+    <AudioGridWrapper key={audio?.id} onClick={() => onSelect(audio)}>
+      <AudioSelected>
+        {isSelected ? <i className="fas fa-check-circle"></i> : null}
+      </AudioSelected>
+      <Audio controls>
+        <source src={audio?.urlOriginal} />
+        <source src={audio?.file?.url} />
+      </Audio>
+      <AudioName>{audio?.name}</AudioName>
+    </AudioGridWrapper>
+  )
+}
+
+function AudioMetaGrids(props: { audioMetas: AudioEntityWithMeta[] }) {
+  const { audioMetas } = props
+  return (
+    <AudioMetaGridsWrapper>
+      {audioMetas.map((audioMeta) => (
+        <AudioMetaGrid key={audioMeta?.audio?.id} audioMeta={audioMeta} />
+      ))}
+    </AudioMetaGridsWrapper>
+  )
+}
+
+function AudioMetaGrid(props: {
+  audioMeta: AudioEntityWithMeta
+}): React.ReactElement {
+  const { audioMeta } = props
+  const { audio } = audioMeta
+
+  return (
+    <AudioMetaGridWrapper>
+      <Audio controls>
+        <source src={audio?.urlOriginal} />
+        <source src={audio?.file?.url} />
+      </Audio>
+      <AudioName>{audio?.name}</AudioName>
+    </AudioMetaGridWrapper>
+  )
+}
+
+const AudiosQuery = gql`
+  query Audios($searchText: String!, $take: Int, $skip: Int) {
+    audioFilesCount(where: { name: { contains: $searchText } })
+    audioFiles(
+      where: { name: { contains: $searchText } }
+      take: $take
+      skip: $skip
+    ) {
+      id
+      name
+      urlOriginal
+      file {
+        url
+      }
+      heroImage {
+        imageFile {
+          url
+        }
+        resized {
+          w480
+          w800
+          w1200
+          w1600
+          w2400
+        }
+      }
+    }
+  }
+`
+
+type AudioSelectorOnChangeFn = (params: AudioEntityWithMeta[]) => void
+
+export function AudioSelector(props: { onChange: AudioSelectorOnChangeFn }) {
+  const [
+    queryAudios,
+    { loading, error, data: { audioFiles = [], audioFilesCount = 0 } = {} },
+  ] = useLazyQuery(AudiosQuery, { fetchPolicy: 'no-cache' })
+  const [currentPage, setCurrentPage] = useState(0) // page starts with 1, 0 is used to detect initialization
+  const [searchText, setSearchText] = useState('')
+  const [selected, setSelected] = useState<AudioEntityWithMeta[]>([])
+
+  const pageSize = 6
+
+  const { onChange } = props
+
+  const onSave = () => {
+    onChange(selected)
+  }
+
+  const onCancel = () => {
+    onChange([])
+  }
+
+  const onSearchBoxChange: SearchBoxOnChangeFn = async (searchInput) => {
+    setSearchText(searchInput)
+    setCurrentPage(1)
+  }
+
+  const onAudiosGridSelect: AudioEntityOnSelectFn = (audioEntity) => {
+    setSelected((selected) => {
+      const filterdSelected = selected.filter(
+        (ele) => ele.audio?.id !== audioEntity.id
+      )
+
+      // deselect the audio
+      if (filterdSelected.length !== selected.length) {
+        return filterdSelected
+      }
+
+      // single select
+      return [{ audio: audioEntity }]
+    })
+  }
+
+  const selectedAudios = selected.map((ele: AudioEntityWithMeta) => {
+    return ele.audio
+  })
+
+  useEffect(() => {
+    if (currentPage !== 0) {
+      queryAudios({
+        variables: {
+          searchText: searchText,
+          skip: (currentPage - 1) * pageSize,
+          take: pageSize,
+        },
+      })
+    }
+  }, [currentPage, searchText])
+
+  let searchResult = (
+    <React.Fragment>
+      <AudiosGrids
+        audios={audioFiles}
+        selected={selectedAudios}
+        onSelect={onAudiosGridSelect}
+      />
+      <Pagination
+        currentPage={currentPage}
+        total={audioFilesCount}
+        pageSize={pageSize}
+        onChange={(pageIndex) => {
+          setCurrentPage(pageIndex)
+        }}
+      />
+    </React.Fragment>
+  )
+  if (loading) {
+    searchResult = <p>searching...</p>
+  }
+  if (error) {
+    searchResult = (
+      <ErrorWrapper>
+        <h3>Errors occurs in the `audios` query</h3>
+        <div>
+          <br />
+          <b>Message:</b>
+          <div>{error.message}</div>
+          <br />
+          <b>Stack:</b>
+          <div>{error.stack}</div>
+          <br />
+          <b>Query:</b>
+          <pre>{AudiosQuery.loc.source.body}</pre>
+        </div>
+      </ErrorWrapper>
+    )
+  }
+
+  return (
+    <DrawerController isOpen={true}>
+      <Drawer
+        title="Select audio"
+        actions={{
+          cancel: {
+            label: 'Cancel',
+            action: onCancel,
+          },
+          confirm: {
+            label: 'Confirm',
+            action: onSave,
+          },
+        }}
+      >
+        <div>
+          <AudioSearchBox onChange={onSearchBoxChange} />
+          <AudioSelectionWrapper>
+            <div>{searchResult}</div>
+            {!!selected.length && <SeparationLine />}
+            <AudioMetaGrids audioMetas={selected} />
+          </AudioSelectionWrapper>
+        </div>
+      </Drawer>
+    </DrawerController>
+  )
+}

--- a/packages/draft-editor/src/draft-js/buttons/video.tsx
+++ b/packages/draft-editor/src/draft-js/buttons/video.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react'
+import { AtomicBlockUtils, EditorState } from 'draft-js'
+
+import {
+  VideoSelector as DefaultVideoSelector,
+  VideoEntityWithMeta,
+} from './selector/video-selector'
+
+export function VideoButton(props: {
+  editorState: EditorState
+  onChange: (param: EditorState) => void
+  className?: string
+  VideoSelector: typeof DefaultVideoSelector
+}) {
+  const {
+    editorState,
+    onChange,
+    className,
+    VideoSelector = DefaultVideoSelector,
+  } = props
+
+  const [toShowVideoSelector, setToShowVideoSelector] = useState(false)
+
+  const promptForVideoSelector = () => {
+    setToShowVideoSelector(true)
+  }
+
+  const onVideoSelectorChange = (
+    selectedVideosWithMeta: VideoEntityWithMeta[]
+  ) => {
+    const video = selectedVideosWithMeta?.[0]?.video
+    if (!video) {
+      setToShowVideoSelector(false)
+      return
+    }
+
+    const contentState = editorState.getCurrentContent()
+    const contentStateWithEntity = contentState.createEntity(
+      'VIDEO',
+      'IMMUTABLE',
+      {
+        video,
+      }
+    )
+    const entityKey = contentStateWithEntity.getLastCreatedEntityKey()
+    const newEditorState = EditorState.set(editorState, {
+      currentContent: contentStateWithEntity,
+    })
+
+    // The third parameter here is a space string, not an empty string
+    // If you set an empty string, you will get an error: Unknown DraftEntity key: null
+    onChange(AtomicBlockUtils.insertAtomicBlock(newEditorState, entityKey, ' '))
+    setToShowVideoSelector(false)
+  }
+
+  return (
+    <React.Fragment>
+      {toShowVideoSelector && (
+        <VideoSelector onChange={onVideoSelectorChange} />
+      )}
+
+      <div className={className} onClick={promptForVideoSelector}>
+        <i className="fa fa-video-camera"></i>
+        <span> Video</span>
+      </div>
+    </React.Fragment>
+  )
+}

--- a/packages/draft-editor/src/website/mirrormedia/block-renderer-fn.tsx
+++ b/packages/draft-editor/src/website/mirrormedia/block-renderer-fn.tsx
@@ -15,6 +15,7 @@ const {
   DividerBlock,
   RelatedPostBlock,
   VideoBlock,
+  AudioBlock,
 } = MirrorMedia.blockRenderers
 
 const AtomicBlock = (props) => {
@@ -66,6 +67,9 @@ const AtomicBlock = (props) => {
     }
     case 'VIDEO': {
       return VideoBlock(entity)
+    }
+    case 'AUDIO': {
+      return AudioBlock(entity)
     }
   }
   return null

--- a/packages/draft-editor/src/website/mirrormedia/block-renderer-fn.tsx
+++ b/packages/draft-editor/src/website/mirrormedia/block-renderer-fn.tsx
@@ -14,6 +14,7 @@ const {
   ImageBlock,
   DividerBlock,
   RelatedPostBlock,
+  VideoBlock,
 } = MirrorMedia.blockRenderers
 
 const AtomicBlock = (props) => {
@@ -62,6 +63,9 @@ const AtomicBlock = (props) => {
     }
     case 'SIDEINDEX': {
       return SideIndexBlock(props)
+    }
+    case 'VIDEO': {
+      return VideoBlock(entity)
     }
   }
   return null

--- a/packages/draft-editor/src/website/mirrormedia/draft-editor.tsx
+++ b/packages/draft-editor/src/website/mirrormedia/draft-editor.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../draft-js/buttons/text-align'
 import { FontColorButton } from '../../draft-js/buttons/font-color'
 import { BackgroundColorButton } from '../../draft-js/buttons/background-color'
+import { VideoButton } from '../../draft-js/buttons/video'
 
 import {
   CUSTOM_STYLE_PREFIX_FONT_COLOR,
@@ -74,6 +75,7 @@ export const buttonNames = {
   backgroundVideo: 'background-video',
   relatedPost: 'related-post',
   sideIndex: 'side-index',
+  video: 'video',
 }
 
 const disabledButtonsOnBasicEditor = [
@@ -91,6 +93,7 @@ const disabledButtonsOnBasicEditor = [
   buttonNames.backgroundVideo,
   buttonNames.relatedPost,
   buttonNames.sideIndex,
+  buttonNames.video,
 ]
 
 type ButtonStyleProps = {
@@ -259,6 +262,7 @@ const CustomAlignCenterButton = createButtonWithoutProps(
   true
 )
 const CustomAlignLeftButton = createButtonWithoutProps(AlignLeftButton, true)
+const CustomVideoButton = createButtonWithoutProps(VideoButton)
 
 const DraftEditorWrapper = styled.div`
   /* Rich-editor default setting (.RichEditor-root)*/
@@ -780,6 +784,15 @@ class RichTextEditor extends React.Component<RichTextEditorProps, State> {
                   onChange={this.onChange}
                   readOnly={this.state.readOnly}
                   ImageSelector={ImageSelector}
+                />
+              </ButtonGroup>
+              <ButtonGroup>
+                <CustomVideoButton
+                  isDisabled={disabledButtons.includes(buttonNames.video)}
+                  editorState={editorState}
+                  onChange={this.onChange}
+                  readOnly={this.state.readOnly}
+                  VideoSelector={VideoSelector}
                 />
               </ButtonGroup>
               <ButtonGroup>

--- a/packages/draft-editor/src/website/mirrormedia/draft-editor.tsx
+++ b/packages/draft-editor/src/website/mirrormedia/draft-editor.tsx
@@ -32,6 +32,7 @@ import {
 import { FontColorButton } from '../../draft-js/buttons/font-color'
 import { BackgroundColorButton } from '../../draft-js/buttons/background-color'
 import { VideoButton } from '../../draft-js/buttons/video'
+import { AudioButton } from '../../draft-js/buttons/audio'
 
 import {
   CUSTOM_STYLE_PREFIX_FONT_COLOR,
@@ -41,6 +42,7 @@ import { getSelectionBlockData } from '../../draft-js/buttons/text-align'
 import { ImageSelector } from './selector/image-selector'
 import { VideoSelector } from './selector/video-selector'
 import { PostSelector } from './selector/post-selector'
+import { AudioSelector } from './selector/audio-selector'
 
 export const buttonNames = {
   // inline styles
@@ -76,6 +78,7 @@ export const buttonNames = {
   relatedPost: 'related-post',
   sideIndex: 'side-index',
   video: 'video',
+  audio: 'audio',
 }
 
 const disabledButtonsOnBasicEditor = [
@@ -94,6 +97,7 @@ const disabledButtonsOnBasicEditor = [
   buttonNames.relatedPost,
   buttonNames.sideIndex,
   buttonNames.video,
+  buttonNames.audio,
 ]
 
 type ButtonStyleProps = {
@@ -263,6 +267,7 @@ const CustomAlignCenterButton = createButtonWithoutProps(
 )
 const CustomAlignLeftButton = createButtonWithoutProps(AlignLeftButton, true)
 const CustomVideoButton = createButtonWithoutProps(VideoButton)
+const CustomAudioButton = createButtonWithoutProps(AudioButton)
 
 const DraftEditorWrapper = styled.div`
   /* Rich-editor default setting (.RichEditor-root)*/
@@ -793,6 +798,15 @@ class RichTextEditor extends React.Component<RichTextEditorProps, State> {
                   onChange={this.onChange}
                   readOnly={this.state.readOnly}
                   VideoSelector={VideoSelector}
+                />
+              </ButtonGroup>
+              <ButtonGroup>
+                <CustomAudioButton
+                  isDisabled={disabledButtons.includes(buttonNames.audio)}
+                  editorState={editorState}
+                  onChange={this.onChange}
+                  readOnly={this.state.readOnly}
+                  AudioSelector={AudioSelector}
                 />
               </ButtonGroup>
               <ButtonGroup>

--- a/packages/draft-editor/src/website/mirrormedia/selector/audio-selector.tsx
+++ b/packages/draft-editor/src/website/mirrormedia/selector/audio-selector.tsx
@@ -1,0 +1,311 @@
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { Drawer, DrawerController } from '@keystone-ui/modals'
+import { gql, useLazyQuery } from '@keystone-6/core/admin-ui/apollo'
+import { ImageEntity } from './image-selector'
+import { SearchBox, SearchBoxOnChangeFn } from './search-box'
+import { Pagination } from './pagination'
+
+const AudioSearchBox = styled(SearchBox)`
+  margin-top: 10px;
+`
+
+const AudioSelectionWrapper = styled.div`
+  overflow: auto;
+  margin-top: 10px;
+`
+
+const AudioGridsWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  overflow: auto;
+`
+
+const AudioGridWrapper = styled.div`
+  flex: 0 0 50%;
+  cursor: pointer;
+  padding: 0 10px 10px;
+`
+
+const AudioMetaGridsWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  overflow: auto;
+`
+
+const AudioMetaGridWrapper = styled.div`
+  flex: 0 0 50%;
+  cursor: pointer;
+  padding: 0 10px 10px;
+`
+
+const Audio = styled.audio`
+  width: 100%;
+`
+
+const AudioName = styled.p`
+  text-align: center;
+`
+
+const SeparationLine = styled.div`
+  border: #e1e5e9 1px solid;
+  margin-top: 10px;
+  margin-bottom: 10px;
+`
+
+const AudioSelected = styled.div`
+  height: 1.4rem;
+`
+
+const ErrorWrapper = styled.div`
+  & * {
+    margin: 0;
+  }
+`
+
+type ID = string
+
+export type AudioEntity = {
+  id: ID
+  name?: string
+  urlOriginal?: string
+  file?: {
+    url: string
+  }
+  heroImage?: ImageEntity
+}
+
+export type AudioEntityWithMeta = {
+  audio: AudioEntity
+}
+
+type AudioEntityOnSelectFn = (param: AudioEntity) => void
+
+function AudiosGrids(props: {
+  audios: AudioEntity[]
+  selected: AudioEntity[]
+  onSelect: AudioEntityOnSelectFn
+}): React.ReactElement {
+  const { audios, selected, onSelect } = props
+
+  return (
+    <AudioGridsWrapper>
+      {audios.map((audio) => {
+        return (
+          <AudioGrid
+            key={audio.id}
+            isSelected={selected?.includes(audio)}
+            onSelect={() => onSelect(audio)}
+            audio={audio}
+          />
+        )
+      })}
+    </AudioGridsWrapper>
+  )
+}
+
+function AudioGrid(props: {
+  audio: AudioEntity
+  isSelected: boolean
+  onSelect: AudioEntityOnSelectFn
+}) {
+  const { audio, onSelect, isSelected } = props
+  console.log('audio', audio)
+  return (
+    <AudioGridWrapper key={audio?.id} onClick={() => onSelect(audio)}>
+      <AudioSelected>
+        {isSelected ? <i className="fas fa-check-circle"></i> : null}
+      </AudioSelected>
+      <Audio controls>
+        <source src={audio?.urlOriginal} />
+        <source src={audio?.file?.url} />
+      </Audio>
+      <AudioName>{audio?.name}</AudioName>
+    </AudioGridWrapper>
+  )
+}
+
+function AudioMetaGrids(props: { audioMetas: AudioEntityWithMeta[] }) {
+  const { audioMetas } = props
+  return (
+    <AudioMetaGridsWrapper>
+      {audioMetas.map((audioMeta) => (
+        <AudioMetaGrid key={audioMeta?.audio?.id} audioMeta={audioMeta} />
+      ))}
+    </AudioMetaGridsWrapper>
+  )
+}
+
+function AudioMetaGrid(props: {
+  audioMeta: AudioEntityWithMeta
+}): React.ReactElement {
+  const { audioMeta } = props
+  const { audio } = audioMeta
+
+  return (
+    <AudioMetaGridWrapper>
+      <Audio controls>
+        <source src={audio?.urlOriginal} />
+        <source src={audio?.file?.url} />
+      </Audio>
+      <AudioName>{audio?.name}</AudioName>
+    </AudioMetaGridWrapper>
+  )
+}
+
+const AudiosQuery = gql`
+  query Audios($searchText: String!, $take: Int, $skip: Int) {
+    audioFilesCount(where: { name: { contains: $searchText } })
+    audioFiles(
+      where: { name: { contains: $searchText } }
+      take: $take
+      skip: $skip
+    ) {
+      id
+      name
+      urlOriginal
+      file {
+        url
+      }
+      heroImage {
+        imageFile {
+          url
+        }
+        resized {
+          w480
+          w800
+          w1200
+          w1600
+          w2400
+        }
+      }
+    }
+  }
+`
+
+type AudioSelectorOnChangeFn = (params: AudioEntityWithMeta[]) => void
+
+export function AudioSelector(props: { onChange: AudioSelectorOnChangeFn }) {
+  const [
+    queryAudios,
+    { loading, error, data: { audioFiles = [], audioFilesCount = 0 } = {} },
+  ] = useLazyQuery(AudiosQuery, { fetchPolicy: 'no-cache' })
+  const [currentPage, setCurrentPage] = useState(0) // page starts with 1, 0 is used to detect initialization
+  const [searchText, setSearchText] = useState('')
+  const [selected, setSelected] = useState<AudioEntityWithMeta[]>([])
+
+  const pageSize = 6
+
+  const { onChange } = props
+
+  const onSave = () => {
+    onChange(selected)
+  }
+
+  const onCancel = () => {
+    onChange([])
+  }
+
+  const onSearchBoxChange: SearchBoxOnChangeFn = async (searchInput) => {
+    setSearchText(searchInput)
+    setCurrentPage(1)
+  }
+
+  const onAudiosGridSelect: AudioEntityOnSelectFn = (audioEntity) => {
+    setSelected((selected) => {
+      const filterdSelected = selected.filter(
+        (ele) => ele.audio?.id !== audioEntity.id
+      )
+
+      // deselect the audio
+      if (filterdSelected.length !== selected.length) {
+        return filterdSelected
+      }
+
+      // single select
+      return [{ audio: audioEntity }]
+    })
+  }
+
+  const selectedAudios = selected.map((ele: AudioEntityWithMeta) => {
+    return ele.audio
+  })
+
+  useEffect(() => {
+    if (currentPage !== 0) {
+      queryAudios({
+        variables: {
+          searchText: searchText,
+          skip: (currentPage - 1) * pageSize,
+          take: pageSize,
+        },
+      })
+    }
+  }, [currentPage, searchText])
+
+  let searchResult = (
+    <React.Fragment>
+      <AudiosGrids
+        audios={audioFiles}
+        selected={selectedAudios}
+        onSelect={onAudiosGridSelect}
+      />
+      <Pagination
+        currentPage={currentPage}
+        total={audioFilesCount}
+        pageSize={pageSize}
+        onChange={(pageIndex) => {
+          setCurrentPage(pageIndex)
+        }}
+      />
+    </React.Fragment>
+  )
+  if (loading) {
+    searchResult = <p>searching...</p>
+  }
+  if (error) {
+    searchResult = (
+      <ErrorWrapper>
+        <h3>Errors occurs in the `audios` query</h3>
+        <div>
+          <br />
+          <b>Message:</b>
+          <div>{error.message}</div>
+          <br />
+          <b>Stack:</b>
+          <div>{error.stack}</div>
+          <br />
+          <b>Query:</b>
+          <pre>{AudiosQuery.loc.source.body}</pre>
+        </div>
+      </ErrorWrapper>
+    )
+  }
+
+  return (
+    <DrawerController isOpen={true}>
+      <Drawer
+        title="Select audio"
+        actions={{
+          cancel: {
+            label: 'Cancel',
+            action: onCancel,
+          },
+          confirm: {
+            label: 'Confirm',
+            action: onSave,
+          },
+        }}
+      >
+        <div>
+          <AudioSearchBox onChange={onSearchBoxChange} />
+          <AudioSelectionWrapper>
+            <div>{searchResult}</div>
+            {!!selected.length && <SeparationLine />}
+            <AudioMetaGrids audioMetas={selected} />
+          </AudioSelectionWrapper>
+        </div>
+      </Drawer>
+    </DrawerController>
+  )
+}

--- a/packages/draft-editor/src/website/mirrormedia/selector/image-selector.tsx
+++ b/packages/draft-editor/src/website/mirrormedia/selector/image-selector.tsx
@@ -101,6 +101,10 @@ const ErrorWrapper = styled.div`
   }
 `
 
+const ImageName = styled.p`
+  text-align: center;
+`
+
 type ID = string
 
 export type ImageEntity = {
@@ -208,6 +212,7 @@ function ImageMetaGrid(props: {
         src={image?.resized?.w800}
         onError={(e) => (e.currentTarget.src = image?.imageFile?.url)}
       />
+      <ImageName>{image?.name}</ImageName>
       {enableCaption && (
         <React.Fragment>
           <Label htmlFor="caption">Image Caption:</Label>

--- a/packages/draft-editor/src/website/mirrormedia/selector/video-selector.tsx
+++ b/packages/draft-editor/src/website/mirrormedia/selector/video-selector.tsx
@@ -92,6 +92,10 @@ const ErrorWrapper = styled.div`
   }
 `
 
+const VideoName = styled.p`
+  text-align: center;
+`
+
 type ID = string
 
 export type VideoEntity = {
@@ -178,6 +182,7 @@ function VideoMetaGrid(props: {
         <source src={video?.urlOriginal} />
         <source src={video?.file?.url} />
       </Video>
+      <VideoName>{video?.name}</VideoName>
     </VideoMetaGridWrapper>
   )
 }

--- a/packages/draft-editor/src/website/readr/block-renderer-fn.tsx
+++ b/packages/draft-editor/src/website/readr/block-renderer-fn.tsx
@@ -15,6 +15,7 @@ const {
   DividerBlock,
   RelatedPostBlock,
   VideoBlock,
+  AudioBlock,
 } = Readr.blockRenderers
 
 const AtomicBlock = (props) => {
@@ -66,6 +67,9 @@ const AtomicBlock = (props) => {
     }
     case 'VIDEO': {
       return VideoBlock(entity)
+    }
+    case 'AudioBlock': {
+      return AudioBlock(entity)
     }
   }
   return null

--- a/packages/draft-editor/src/website/readr/block-renderer-fn.tsx
+++ b/packages/draft-editor/src/website/readr/block-renderer-fn.tsx
@@ -14,6 +14,7 @@ const {
   SlideshowBlockV2,
   DividerBlock,
   RelatedPostBlock,
+  VideoBlock,
 } = Readr.blockRenderers
 
 const AtomicBlock = (props) => {
@@ -62,6 +63,9 @@ const AtomicBlock = (props) => {
     }
     case 'SIDEINDEX': {
       return SideIndexBlock(props)
+    }
+    case 'VIDEO': {
+      return VideoBlock(entity)
     }
   }
   return null

--- a/packages/draft-editor/src/website/readr/draft-editor.tsx
+++ b/packages/draft-editor/src/website/readr/draft-editor.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../draft-js/buttons/text-align'
 import { FontColorButton } from '../../draft-js/buttons/font-color'
 import { BackgroundColorButton } from '../../draft-js/buttons/background-color'
+import { VideoButton } from '../../draft-js/buttons/video'
 
 import {
   CUSTOM_STYLE_PREFIX_FONT_COLOR,
@@ -74,6 +75,7 @@ export const buttonNames = {
   backgroundVideo: 'background-video',
   relatedPost: 'related-post',
   sideIndex: 'side-index',
+  video: 'video',
 }
 
 const disabledButtonsOnBasicEditor = [
@@ -91,6 +93,7 @@ const disabledButtonsOnBasicEditor = [
   buttonNames.backgroundVideo,
   buttonNames.relatedPost,
   buttonNames.sideIndex,
+  buttonNames.video,
 ]
 
 type ButtonStyleProps = {
@@ -259,6 +262,7 @@ const CustomAlignCenterButton = createButtonWithoutProps(
   true
 )
 const CustomAlignLeftButton = createButtonWithoutProps(AlignLeftButton, true)
+const CustomVideoButton = createButtonWithoutProps(VideoButton)
 
 const DraftEditorWrapper = styled.div`
   /* Rich-editor default setting (.RichEditor-root)*/
@@ -780,6 +784,15 @@ class RichTextEditor extends React.Component<RichTextEditorProps, State> {
                   onChange={this.onChange}
                   readOnly={this.state.readOnly}
                   ImageSelector={ImageSelector}
+                />
+              </ButtonGroup>
+              <ButtonGroup>
+                <CustomVideoButton
+                  isDisabled={disabledButtons.includes(buttonNames.video)}
+                  editorState={editorState}
+                  onChange={this.onChange}
+                  readOnly={this.state.readOnly}
+                  VideoSelector={VideoSelector}
                 />
               </ButtonGroup>
               <ButtonGroup>

--- a/packages/draft-editor/src/website/readr/draft-editor.tsx
+++ b/packages/draft-editor/src/website/readr/draft-editor.tsx
@@ -32,6 +32,7 @@ import {
 import { FontColorButton } from '../../draft-js/buttons/font-color'
 import { BackgroundColorButton } from '../../draft-js/buttons/background-color'
 import { VideoButton } from '../../draft-js/buttons/video'
+import { AudioButton } from '../../draft-js/buttons/audio'
 
 import {
   CUSTOM_STYLE_PREFIX_FONT_COLOR,
@@ -41,6 +42,7 @@ import { getSelectionBlockData } from '../../draft-js/buttons/text-align'
 import { ImageSelector } from './selector/image-selector'
 import { VideoSelector } from './selector/video-selector'
 import { PostSelector } from './selector/post-selector'
+import { AudioSelector } from './selector/audio-selector'
 
 export const buttonNames = {
   // inline styles
@@ -76,6 +78,7 @@ export const buttonNames = {
   relatedPost: 'related-post',
   sideIndex: 'side-index',
   video: 'video',
+  audio: 'audio',
 }
 
 const disabledButtonsOnBasicEditor = [
@@ -94,6 +97,7 @@ const disabledButtonsOnBasicEditor = [
   buttonNames.relatedPost,
   buttonNames.sideIndex,
   buttonNames.video,
+  buttonNames.audio,
 ]
 
 type ButtonStyleProps = {
@@ -263,6 +267,7 @@ const CustomAlignCenterButton = createButtonWithoutProps(
 )
 const CustomAlignLeftButton = createButtonWithoutProps(AlignLeftButton, true)
 const CustomVideoButton = createButtonWithoutProps(VideoButton)
+const CustomAudioButton = createButtonWithoutProps(AudioButton)
 
 const DraftEditorWrapper = styled.div`
   /* Rich-editor default setting (.RichEditor-root)*/
@@ -793,6 +798,15 @@ class RichTextEditor extends React.Component<RichTextEditorProps, State> {
                   onChange={this.onChange}
                   readOnly={this.state.readOnly}
                   VideoSelector={VideoSelector}
+                />
+              </ButtonGroup>
+              <ButtonGroup>
+                <CustomAudioButton
+                  isDisabled={disabledButtons.includes(buttonNames.audio)}
+                  editorState={editorState}
+                  onChange={this.onChange}
+                  readOnly={this.state.readOnly}
+                  AudioSelector={AudioSelector}
                 />
               </ButtonGroup>
               <ButtonGroup>

--- a/packages/draft-editor/src/website/readr/selector/audio-selector.tsx
+++ b/packages/draft-editor/src/website/readr/selector/audio-selector.tsx
@@ -1,0 +1,311 @@
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { Drawer, DrawerController } from '@keystone-ui/modals'
+import { gql, useLazyQuery } from '@keystone-6/core/admin-ui/apollo'
+import { ImageEntity } from './image-selector'
+import { SearchBox, SearchBoxOnChangeFn } from './search-box'
+import { Pagination } from './pagination'
+
+const AudioSearchBox = styled(SearchBox)`
+  margin-top: 10px;
+`
+
+const AudioSelectionWrapper = styled.div`
+  overflow: auto;
+  margin-top: 10px;
+`
+
+const AudioGridsWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  overflow: auto;
+`
+
+const AudioGridWrapper = styled.div`
+  flex: 0 0 50%;
+  cursor: pointer;
+  padding: 0 10px 10px;
+`
+
+const AudioMetaGridsWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  overflow: auto;
+`
+
+const AudioMetaGridWrapper = styled.div`
+  flex: 0 0 50%;
+  cursor: pointer;
+  padding: 0 10px 10px;
+`
+
+const Audio = styled.audio`
+  width: 100%;
+`
+
+const AudioName = styled.p`
+  text-align: center;
+`
+
+const SeparationLine = styled.div`
+  border: #e1e5e9 1px solid;
+  margin-top: 10px;
+  margin-bottom: 10px;
+`
+
+const AudioSelected = styled.div`
+  height: 1.4rem;
+`
+
+const ErrorWrapper = styled.div`
+  & * {
+    margin: 0;
+  }
+`
+
+type ID = string
+
+export type AudioEntity = {
+  id: ID
+  name?: string
+  url?: string
+  file?: {
+    url: string
+  }
+  heroImage?: ImageEntity
+}
+
+export type AudioEntityWithMeta = {
+  audio: AudioEntity
+}
+
+type AudioEntityOnSelectFn = (param: AudioEntity) => void
+
+function AudiosGrids(props: {
+  audios: AudioEntity[]
+  selected: AudioEntity[]
+  onSelect: AudioEntityOnSelectFn
+}): React.ReactElement {
+  const { audios, selected, onSelect } = props
+
+  return (
+    <AudioGridsWrapper>
+      {audios.map((audio) => {
+        return (
+          <AudioGrid
+            key={audio.id}
+            isSelected={selected?.includes(audio)}
+            onSelect={() => onSelect(audio)}
+            audio={audio}
+          />
+        )
+      })}
+    </AudioGridsWrapper>
+  )
+}
+
+function AudioGrid(props: {
+  audio: AudioEntity
+  isSelected: boolean
+  onSelect: AudioEntityOnSelectFn
+}) {
+  const { audio, onSelect, isSelected } = props
+  console.log('audio', audio)
+  return (
+    <AudioGridWrapper key={audio?.id} onClick={() => onSelect(audio)}>
+      <AudioSelected>
+        {isSelected ? <i className="fas fa-check-circle"></i> : null}
+      </AudioSelected>
+      <Audio controls>
+        <source src={audio?.url} />
+        <source src={audio?.file?.url} />
+      </Audio>
+      <AudioName>{audio?.name}</AudioName>
+    </AudioGridWrapper>
+  )
+}
+
+function AudioMetaGrids(props: { audioMetas: AudioEntityWithMeta[] }) {
+  const { audioMetas } = props
+  return (
+    <AudioMetaGridsWrapper>
+      {audioMetas.map((audioMeta) => (
+        <AudioMetaGrid key={audioMeta?.audio?.id} audioMeta={audioMeta} />
+      ))}
+    </AudioMetaGridsWrapper>
+  )
+}
+
+function AudioMetaGrid(props: {
+  audioMeta: AudioEntityWithMeta
+}): React.ReactElement {
+  const { audioMeta } = props
+  const { audio } = audioMeta
+
+  return (
+    <AudioMetaGridWrapper>
+      <Audio controls>
+        <source src={audio?.url} />
+        <source src={audio?.file?.url} />
+      </Audio>
+      <AudioName>{audio?.name}</AudioName>
+    </AudioMetaGridWrapper>
+  )
+}
+
+const AudiosQuery = gql`
+  query Audios($searchText: String!, $take: Int, $skip: Int) {
+    audioFilesCount(where: { name: { contains: $searchText } })
+    audioFiles(
+      where: { name: { contains: $searchText } }
+      take: $take
+      skip: $skip
+    ) {
+      id
+      name
+      url
+      file {
+        url
+      }
+      heroImage {
+        imageFile {
+          url
+        }
+        resized {
+          w480
+          w800
+          w1200
+          w1600
+          w2400
+        }
+      }
+    }
+  }
+`
+
+type AudioSelectorOnChangeFn = (params: AudioEntityWithMeta[]) => void
+
+export function AudioSelector(props: { onChange: AudioSelectorOnChangeFn }) {
+  const [
+    queryAudios,
+    { loading, error, data: { audioFiles = [], audioFilesCount = 0 } = {} },
+  ] = useLazyQuery(AudiosQuery, { fetchPolicy: 'no-cache' })
+  const [currentPage, setCurrentPage] = useState(0) // page starts with 1, 0 is used to detect initialization
+  const [searchText, setSearchText] = useState('')
+  const [selected, setSelected] = useState<AudioEntityWithMeta[]>([])
+
+  const pageSize = 6
+
+  const { onChange } = props
+
+  const onSave = () => {
+    onChange(selected)
+  }
+
+  const onCancel = () => {
+    onChange([])
+  }
+
+  const onSearchBoxChange: SearchBoxOnChangeFn = async (searchInput) => {
+    setSearchText(searchInput)
+    setCurrentPage(1)
+  }
+
+  const onAudiosGridSelect: AudioEntityOnSelectFn = (audioEntity) => {
+    setSelected((selected) => {
+      const filterdSelected = selected.filter(
+        (ele) => ele.audio?.id !== audioEntity.id
+      )
+
+      // deselect the audio
+      if (filterdSelected.length !== selected.length) {
+        return filterdSelected
+      }
+
+      // single select
+      return [{ audio: audioEntity }]
+    })
+  }
+
+  const selectedAudios = selected.map((ele: AudioEntityWithMeta) => {
+    return ele.audio
+  })
+
+  useEffect(() => {
+    if (currentPage !== 0) {
+      queryAudios({
+        variables: {
+          searchText: searchText,
+          skip: (currentPage - 1) * pageSize,
+          take: pageSize,
+        },
+      })
+    }
+  }, [currentPage, searchText])
+
+  let searchResult = (
+    <React.Fragment>
+      <AudiosGrids
+        audios={audioFiles}
+        selected={selectedAudios}
+        onSelect={onAudiosGridSelect}
+      />
+      <Pagination
+        currentPage={currentPage}
+        total={audioFilesCount}
+        pageSize={pageSize}
+        onChange={(pageIndex) => {
+          setCurrentPage(pageIndex)
+        }}
+      />
+    </React.Fragment>
+  )
+  if (loading) {
+    searchResult = <p>searching...</p>
+  }
+  if (error) {
+    searchResult = (
+      <ErrorWrapper>
+        <h3>Errors occurs in the `audios` query</h3>
+        <div>
+          <br />
+          <b>Message:</b>
+          <div>{error.message}</div>
+          <br />
+          <b>Stack:</b>
+          <div>{error.stack}</div>
+          <br />
+          <b>Query:</b>
+          <pre>{AudiosQuery.loc.source.body}</pre>
+        </div>
+      </ErrorWrapper>
+    )
+  }
+
+  return (
+    <DrawerController isOpen={true}>
+      <Drawer
+        title="Select audio"
+        actions={{
+          cancel: {
+            label: 'Cancel',
+            action: onCancel,
+          },
+          confirm: {
+            label: 'Confirm',
+            action: onSave,
+          },
+        }}
+      >
+        <div>
+          <AudioSearchBox onChange={onSearchBoxChange} />
+          <AudioSelectionWrapper>
+            <div>{searchResult}</div>
+            {!!selected.length && <SeparationLine />}
+            <AudioMetaGrids audioMetas={selected} />
+          </AudioSelectionWrapper>
+        </div>
+      </Drawer>
+    </DrawerController>
+  )
+}

--- a/packages/draft-editor/src/website/readr/selector/image-selector.tsx
+++ b/packages/draft-editor/src/website/readr/selector/image-selector.tsx
@@ -101,6 +101,10 @@ const ErrorWrapper = styled.div`
   }
 `
 
+const ImageName = styled.p`
+  text-align: center;
+`
+
 type ID = string
 
 export type ImageEntity = {
@@ -208,6 +212,7 @@ function ImageMetaGrid(props: {
         src={image?.resized?.w800}
         onError={(e) => (e.currentTarget.src = image?.imageFile?.url)}
       />
+      <ImageName>{image?.name}</ImageName>
       {enableCaption && (
         <React.Fragment>
           <Label htmlFor="caption">Image Caption:</Label>

--- a/packages/draft-editor/src/website/readr/selector/video-selector.tsx
+++ b/packages/draft-editor/src/website/readr/selector/video-selector.tsx
@@ -92,6 +92,10 @@ const ErrorWrapper = styled.div`
   }
 `
 
+const VideoName = styled.p`
+  text-align: center;
+`
+
 type ID = string
 
 export type VideoEntity = {
@@ -178,6 +182,7 @@ function VideoMetaGrid(props: {
         <source src={video?.url} />
         <source src={video?.file?.url} />
       </Video>
+      <VideoName>{video?.name}</VideoName>
     </VideoMetaGridWrapper>
   )
 }

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.1.0-alpha.4",
+  "version": "1.1.0-alpha.6",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderer-fn.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderer-fn.tsx
@@ -13,6 +13,7 @@ const {
   BGVideoBlock,
   RelatedPostBlock,
   SideIndexBlock,
+  VideoBlock,
 } = blockRenderers
 
 const AtomicBlock = (props) => {
@@ -61,6 +62,9 @@ const AtomicBlock = (props) => {
     }
     case 'SIDEINDEX': {
       return SideIndexBlock(props)
+    }
+    case 'VIDEO': {
+      return VideoBlock(entity)
     }
   }
   return null

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderer-fn.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderer-fn.tsx
@@ -14,6 +14,7 @@ const {
   RelatedPostBlock,
   SideIndexBlock,
   VideoBlock,
+  AudioBlock,
 } = blockRenderers
 
 const AtomicBlock = (props) => {
@@ -65,6 +66,9 @@ const AtomicBlock = (props) => {
     }
     case 'VIDEO': {
       return VideoBlock(entity)
+    }
+    case 'AUDIO': {
+      return AudioBlock(entity)
     }
   }
   return null

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/audio-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/audio-block.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import styled from 'styled-components'
+import { DraftEntityInstance } from 'draft-js'
+
+const AudioWrapper = styled.div`
+  display: flex;
+  gap: 20px;
+`
+const Audio = styled.audio``
+
+type ImageEntity = {
+  id: string
+  name?: string
+  imageFile: {
+    url: string
+  }
+  resized: {
+    original: string
+    w480: string
+    w800: string
+    w1200: string
+    w1600: string
+    w2400: string
+  }
+}
+
+type AudioEntity = {
+  id: string
+  name?: string
+  urlOriginal?: string
+  file?: {
+    url: string
+  }
+  heroImage?: ImageEntity
+}
+
+export function AudioBlock(entity: DraftEntityInstance) {
+  const { audio }: { audio: AudioEntity } = entity.getData()
+
+  return (
+    <AudioWrapper>
+      <p>{audio?.name}</p>
+      <Audio controls>
+        <source src={audio?.urlOriginal} />
+        <source src={audio?.file?.url} />
+      </Audio>
+    </AudioWrapper>
+  )
+}

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/index.ts
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/index.ts
@@ -11,6 +11,7 @@ import { SideIndexBlock } from './side-index-block'
 import { SlideshowBlock, SlideshowBlockV2 } from './slideshow-block'
 import { TableBlock } from './table-block'
 import { VideoBlock } from './video-block'
+import { AudioBlock } from './audio-block'
 
 export const blockRenderers = {
   BGImageBlock,
@@ -27,4 +28,5 @@ export const blockRenderers = {
   SlideshowBlockV2,
   TableBlock,
   VideoBlock,
+  AudioBlock,
 }

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/index.ts
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/index.ts
@@ -10,6 +10,7 @@ import { RelatedPostBlock } from './related-post-block'
 import { SideIndexBlock } from './side-index-block'
 import { SlideshowBlock, SlideshowBlockV2 } from './slideshow-block'
 import { TableBlock } from './table-block'
+import { VideoBlock } from './video-block'
 
 export const blockRenderers = {
   BGImageBlock,
@@ -25,4 +26,5 @@ export const blockRenderers = {
   SlideshowBlock,
   SlideshowBlockV2,
   TableBlock,
+  VideoBlock,
 }

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/video-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/video-block.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import styled from 'styled-components'
+import { DraftEntityInstance } from 'draft-js'
+
+const Video = styled.video`
+  width: 100%;
+`
+
+type ImageEntity = {
+  id: string
+  name?: string
+  imageFile: {
+    url: string
+  }
+  resized: {
+    original: string
+    w480: string
+    w800: string
+    w1200: string
+    w1600: string
+    w2400: string
+  }
+}
+
+type VideoEntity = {
+  id: string
+  name?: string
+  urlOriginal: string
+  youtubeUrl?: string
+  file: {
+    filename?: string
+    filesize: number
+    url: string
+  }
+  heroImage: ImageEntity
+}
+
+export function VideoBlock(entity: DraftEntityInstance) {
+  const { video }: { video: VideoEntity } = entity.getData()
+
+  return (
+    <Video muted autoPlay loop controls>
+      <source src={video?.urlOriginal} />
+      <source src={video?.file?.url} />
+    </Video>
+  )
+}

--- a/packages/draft-renderer/src/website/readr/block-renderer-fn.tsx
+++ b/packages/draft-renderer/src/website/readr/block-renderer-fn.tsx
@@ -13,6 +13,7 @@ const {
   BGVideoBlock,
   RelatedPostBlock,
   SideIndexBlock,
+  VideoBlock,
 } = blockRenderers
 
 const AtomicBlock = (props: any) => {
@@ -61,6 +62,9 @@ const AtomicBlock = (props: any) => {
     }
     case 'SIDEINDEX': {
       return SideIndexBlock(props)
+    }
+    case 'VIDEO': {
+      return VideoBlock(entity)
     }
   }
   return null

--- a/packages/draft-renderer/src/website/readr/block-renderer-fn.tsx
+++ b/packages/draft-renderer/src/website/readr/block-renderer-fn.tsx
@@ -14,6 +14,7 @@ const {
   RelatedPostBlock,
   SideIndexBlock,
   VideoBlock,
+  AudioBlock,
 } = blockRenderers
 
 const AtomicBlock = (props: any) => {
@@ -65,6 +66,9 @@ const AtomicBlock = (props: any) => {
     }
     case 'VIDEO': {
       return VideoBlock(entity)
+    }
+    case 'AUDIO': {
+      return AudioBlock(entity)
     }
   }
   return null

--- a/packages/draft-renderer/src/website/readr/block-renderers/audio-block.tsx
+++ b/packages/draft-renderer/src/website/readr/block-renderers/audio-block.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import styled from 'styled-components'
+import { DraftEntityInstance } from 'draft-js'
+
+const AudioWrapper = styled.div`
+  display: flex;
+  gap: 20px;
+`
+const Audio = styled.audio``
+
+type ImageEntity = {
+  id: string
+  name?: string
+  imageFile: {
+    url: string
+  }
+  resized: {
+    original: string
+    w480: string
+    w800: string
+    w1200: string
+    w1600: string
+    w2400: string
+  }
+}
+
+type AudioEntity = {
+  id: string
+  name?: string
+  url?: string
+  file?: {
+    url: string
+  }
+  heroImage?: ImageEntity
+}
+
+export function AudioBlock(entity: DraftEntityInstance) {
+  const { audio }: { audio: AudioEntity } = entity.getData()
+
+  return (
+    <AudioWrapper>
+      <p>{audio?.name}</p>
+      <Audio controls>
+        <source src={audio?.url} />
+        <source src={audio?.file?.url} />
+      </Audio>
+    </AudioWrapper>
+  )
+}

--- a/packages/draft-renderer/src/website/readr/block-renderers/index.ts
+++ b/packages/draft-renderer/src/website/readr/block-renderers/index.ts
@@ -11,6 +11,7 @@ import { SideIndexBlock } from './side-index-block'
 import { SlideshowBlock, SlideshowBlockV2 } from './slideshow-block'
 import { TableBlock } from './table-block'
 import { VideoBlock } from './video-block'
+import { AudioBlock } from './audio-block'
 
 export const blockRenderers = {
   BGImageBlock,
@@ -27,4 +28,5 @@ export const blockRenderers = {
   SlideshowBlockV2,
   TableBlock,
   VideoBlock,
+  AudioBlock,
 }

--- a/packages/draft-renderer/src/website/readr/block-renderers/index.ts
+++ b/packages/draft-renderer/src/website/readr/block-renderers/index.ts
@@ -10,6 +10,7 @@ import { RelatedPostBlock } from './related-post-block'
 import { SideIndexBlock } from './side-index-block'
 import { SlideshowBlock, SlideshowBlockV2 } from './slideshow-block'
 import { TableBlock } from './table-block'
+import { VideoBlock } from './video-block'
 
 export const blockRenderers = {
   BGImageBlock,
@@ -25,4 +26,5 @@ export const blockRenderers = {
   SlideshowBlock,
   SlideshowBlockV2,
   TableBlock,
+  VideoBlock,
 }

--- a/packages/draft-renderer/src/website/readr/block-renderers/video-block.tsx
+++ b/packages/draft-renderer/src/website/readr/block-renderers/video-block.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import styled from 'styled-components'
+import { DraftEntityInstance } from 'draft-js'
+
+const Video = styled.video`
+  width: 100%;
+`
+
+type ImageEntity = {
+  id: string
+  name?: string
+  imageFile: {
+    url: string
+  }
+  resized: {
+    original: string
+    w480: string
+    w800: string
+    w1200: string
+    w1600: string
+    w2400: string
+  }
+}
+
+type VideoEntity = {
+  id: string
+  name?: string
+  url: string
+  youtubeUrl?: string
+  file: {
+    filename?: string
+    filesize: number
+    url: string
+  }
+  coverPhoto: ImageEntity
+}
+
+export function VideoBlock(entity: DraftEntityInstance) {
+  const { video }: { video: VideoEntity } = entity.getData()
+
+  return (
+    <Video muted autoPlay loop controls>
+      <source src={video?.url} />
+      <source src={video?.file?.url} />
+    </Video>
+  )
+}

--- a/packages/editools/package.json
+++ b/packages/editools/package.json
@@ -20,7 +20,7 @@
     "@keystone-6/auth": "1.0.0",
     "@keystone-6/core": "1.1.1",
     "@keystone-6/fields-document": "1.0.1",
-    "@mirrormedia/lilith-core": "1.2.6",
+    "@mirrormedia/lilith-core": "1.2.7-alpha.0",
     "@readr-media/react-embed-code-generator": "2.2.0",
     "cheerio": "^1.0.0-rc.12",
     "default-import": "^1.1.5",

--- a/packages/mirrormedia/package.json
+++ b/packages/mirrormedia/package.json
@@ -19,7 +19,7 @@
     "@keystone-6/auth": "1.0.0",
     "@keystone-6/core": "1.1.1",
     "@keystone-6/fields-document": "1.0.1",
-    "@mirrormedia/lilith-core": "1.2.6",
+    "@mirrormedia/lilith-core": "1.2.7-alpha.0",
     "@twreporter/errors": "^1.1.2",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/packages/readr/package.json
+++ b/packages/readr/package.json
@@ -19,7 +19,7 @@
     "@keystone-6/auth": "1.0.0",
     "@keystone-6/core": "1.1.1",
     "@keystone-6/fields-document": "1.0.1",
-    "@mirrormedia/lilith-core": "1.2.6",
+    "@mirrormedia/lilith-core": "1.2.7-alpha.0",
     "express": "^4.17.1",
     "http-proxy-middleware": "^2.0.3",
     "patch-package": "^6.4.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,6 +2137,14 @@
     styled-components "5.3.5"
     zlib "^1.0.5"
 
+"@mirrormedia/lilith-draft-editor@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-editor/-/lilith-draft-editor-1.0.1.tgz#995ece11c47a98be721656ee9bdc6e481d94b975"
+  integrity sha512-yB/qx8dLYAWSFmyp4Dj3toe2+WSrlfPRnrn8VoSBY8O3hjqxQPQlgvT3zZp2MIjhVMk2D/OrLy6yS7gwuDk/Vg==
+  dependencies:
+    "@mirrormedia/lilith-draft-renderer" "1.0.0"
+    draft-js "^0.11.7"
+
 "@mirrormedia/lilith-draft-renderer@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.0.0.tgz#eb29a1c2cc3603e3f670e30c697101678475143a"


### PR DESCRIPTION
# Notable change
- add video and audio buttons for both mirrormedia and readr websites in draft-editor
- add video and audio block renderers for both mirrormedia and readr websites in draft-renderer