### PR TITLE
refactor(draft-renderer/slideshow): add useMemo to prevent unneed re-render

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.1.0-alpha.13",
+  "version": "1.1.0-alpha.14",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useMemo } from 'react'
 import styled from 'styled-components'
 import { DraftEntityInstance } from 'draft-js'
 import CustomImage from '@readr-media/react-image'
@@ -156,8 +156,11 @@ export function SlideshowBlockV2(entity: DraftEntityInstance) {
   /** Position of slide box */
   const slideBoxPosition = `calc(${sliderWidth} * ${slidesOffset +
     indexOfCurrentImage} * -1 + ${dragDistance}px)`
-  const { images } = entity.getData()
-  const displayedImage = images.map((image) => image.resized)
+  const { images } = useMemo(() => entity.getData(), [entity])
+  const displayedImage = useMemo(
+    () => images.map((image) => image.resized),
+    images
+  )
   const slidesLength = images.length
   const descOfCurrentImage = images?.[indexOfCurrentImage]?.desc
 
@@ -179,14 +182,27 @@ export function SlideshowBlockV2(entity: DraftEntityInstance) {
    *
    * The amount of item need to clone is decided by variable `slidesOffset`
    */
-  const slidesWithClone = [].concat(
-    displayedImage?.slice(-slidesOffset),
-    displayedImage,
-    displayedImage?.slice(0, slidesOffset)
+  const slidesWithClone = useMemo(
+    () =>
+      [].concat(
+        displayedImage?.slice(-slidesOffset),
+        displayedImage,
+        displayedImage?.slice(0, slidesOffset)
+      ),
+    [displayedImage]
   )
-  const slidesJsx = slidesWithClone.map((item, index) => (
-    <CustomImage images={item} key={index} objectFit={'contain'} />
-  ))
+  const slidesJsx = useMemo(
+    () =>
+      slidesWithClone.map((item, index) => (
+        <CustomImage
+          images={item}
+          key={index}
+          objectFit={'contain'}
+          priority={true}
+        />
+      )),
+    [slidesWithClone]
+  )
 
   const handleClickPrev = () => {
     if (isShifting) {


### PR DESCRIPTION
## Notable Change
使用`useMemo`，以避免slideshow元件所使用的`CustomImage`，不斷重新re-render


## Commit Detail

由於在拖曳的過程中，state `dragDistance`會不斷改變，並導致該元件re-render。而該元件re-render時，也會導致其中所使用的元件`CustomImage`也被re-render，並會造成該`CustomImage`的useEffect重跑一次，導致會對已經取得圖片url重新發request，產生不必要的request。
該PR則使用了useMemo，避免`CustomImage`會在slideshow re-render時一併re-render