### PR TITLE
refactor(draft-renderer/embed-code): optimize embed code UX

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.1.0-alpha.14",
+  "version": "1.1.0-alpha.15",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -23,7 +23,8 @@
   "license": "MIT",
   "dependencies": {
     "@readr-media/react-image": "^1.5.1",
-    "draft-js": "^0.11.7"
+    "draft-js": "^0.11.7",
+    "node-html-parser": "^6.1.5"
   },
   "peerDependencies": {
     "react": "18.1.0",

--- a/packages/draft-renderer/src/website/readr/block-renderers/embedded-code-block.tsx
+++ b/packages/draft-renderer/src/website/readr/block-renderers/embedded-code-block.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useMemo, useRef } from 'react'
 import { DraftEntityInstance } from 'draft-js'
 import styled from 'styled-components'
+import { parse } from 'node-html-parser'
 
 export const Block = styled.div`
   position: relative;
@@ -25,45 +26,62 @@ export const EmbeddedCodeBlock = (entity: DraftEntityInstance) => {
   const { caption, embeddedCode } = entity.getData()
   const embedded = useRef(null)
 
-  useEffect(() => {
-    if (!embedded.current) return
-    const node: HTMLElement = embedded.current
+  // const ele = parse(`<div id="draft-embed">${embeddedCode}</div>`)
 
-    const fragment = document.createDocumentFragment()
-
-    // `embeddedCode` is a string, which may includes
-    // multiple '<script>' tags and other html tags.
-    // For executing '<script>' tags on the browser,
-    // we need to extract '<script>' tags from `embeddedCode` string first.
-    //
-    // The approach we have here is to parse html string into elements,
-    // and we could use DOM element built-in functions,
-    // such as `querySelectorAll` method, to query '<script>' elements,
-    // and other non '<script>' elements.
-    const parser = new DOMParser()
-    const ele = parser.parseFromString(
-      `<div id="draft-embed">${embeddedCode}</div>`,
-      'text/html'
-    )
-    const scripts = ele.querySelectorAll('script')
-    const nonScripts = ele.querySelectorAll('div#draft-embed > :not(script)')
-
-    nonScripts.forEach((ele) => {
-      fragment.appendChild(ele)
-    })
-
-    scripts.forEach((s) => {
-      const scriptEle = document.createElement('script')
-      const attrs = s.attributes
-      for (let i = 0; i < attrs.length; i++) {
-        scriptEle.setAttribute(attrs[i].name, attrs[i].value)
-      }
-      scriptEle.text = s.text || ''
-      fragment.appendChild(scriptEle)
-    })
-
-    node.appendChild(fragment)
+  const ele = useMemo(() => {
+    return parse(`<div id="draft-embed">${embeddedCode}</div>`)
   }, [embeddedCode])
+  const nonScripts = useMemo(
+    () => ele.querySelectorAll('div#draft-embed > :not(script)'),
+    [ele]
+  )
+  const scripts = useMemo(() => ele.querySelectorAll('script'), [ele])
+  const nonScriptHtml = useMemo(
+    () => nonScripts.reduce((prev, next) => prev + next.toString(), ''),
+    [embeddedCode]
+  )
+
+  useEffect(() => {
+    if (embedded.current) {
+      const node: HTMLElement = embedded.current
+
+      const fragment = document.createDocumentFragment()
+
+      // `embeddedCode` is a string, which may includes
+      // multiple '<script>' tags and other html tags.
+      // For executing '<script>' tags on the browser,
+      // we need to extract '<script>' tags from `embeddedCode` string first.
+      //
+      // The approach we have here is to parse html string into elements,
+      // and we could use DOM element built-in functions,
+      // such as `querySelectorAll` method, to query '<script>' elements,
+      // and other non '<script>' elements.
+      // const parser = new DOMParser()
+      // const ele = parser.parseFromString(
+      //   `<div id="draft-embed">${embeddedCode}</div>`,
+      //   'text/html'
+      // )
+      // const scripts = ele.querySelectorAll('script')
+
+      scripts.forEach((s) => {
+        const scriptEle = document.createElement('script')
+        const attrs = s.attributes
+        for (const key in attrs) {
+          scriptEle.setAttribute(key, attrs[key])
+        }
+        scriptEle.text = s.text || ''
+        fragment.appendChild(scriptEle)
+      })
+
+      node.appendChild(fragment)
+
+      return () => {
+        node.querySelectorAll('script').forEach(function(script) {
+          node.removeChild(script)
+        })
+      }
+    }
+  }, [scripts])
 
   return (
     <div>
@@ -77,7 +95,12 @@ export const EmbeddedCodeBlock = (entity: DraftEntityInstance) => {
         // hijacking the users' cursors.
       }
       <input hidden disabled />
-      <Block ref={embedded} />
+      <Block
+        ref={embedded}
+        dangerouslySetInnerHTML={{
+          __html: nonScriptHtml,
+        }}
+      />
       {caption ? <Caption>{caption}</Caption> : null}
     </div>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,12 +2137,41 @@
     styled-components "5.3.5"
     zlib "^1.0.5"
 
+"@mirrormedia/lilith-core@1.2.7-alpha.2":
+  version "1.2.7-alpha.2"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-core/-/lilith-core-1.2.7-alpha.2.tgz#85e2526cdc4b0a14967fd670dfc2843689ed31fa"
+  integrity sha512-SDiaBMpvwSq5MZaYab5kg0p599fMilR6kXoTqCwzctLXqI8CFoPMFWPMVjjXyEx9snTLay9ydCPQagsZXyYugg==
+  dependencies:
+    "@google-cloud/storage" "^5.18.0"
+    "@keystone-ui/button" "^6.0.0"
+    "@keystone-ui/fields" "^6.0.0"
+    "@keystone-ui/modals" "^5.0.0"
+    "@mirrormedia/lilith-draft-editor" "1.1.0-alpha.5"
+    "@twreporter/errors" "^1.1.1"
+    axios "^0.26.0"
+    draft-convert "^2.1.12"
+    draft-js "^0.11.7"
+    htmlparser2 "^7.2.0"
+    immutable "^4.0.0"
+    lodash "^4.17.21"
+    shortid "^2.2.16"
+    styled-components "5.3.5"
+    zlib "^1.0.5"
+
 "@mirrormedia/lilith-draft-editor@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-editor/-/lilith-draft-editor-1.0.1.tgz#995ece11c47a98be721656ee9bdc6e481d94b975"
   integrity sha512-yB/qx8dLYAWSFmyp4Dj3toe2+WSrlfPRnrn8VoSBY8O3hjqxQPQlgvT3zZp2MIjhVMk2D/OrLy6yS7gwuDk/Vg==
   dependencies:
     "@mirrormedia/lilith-draft-renderer" "1.0.0"
+    draft-js "^0.11.7"
+
+"@mirrormedia/lilith-draft-editor@1.1.0-alpha.5":
+  version "1.1.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-editor/-/lilith-draft-editor-1.1.0-alpha.5.tgz#a4a702a5b723a33449e1b7fdf6349ad3ce87e350"
+  integrity sha512-ihQAPHMTEPG4InvfjGyy5eqqA9JdwfgAfRLRwnoAuCST4LcSGumSDXahr5jAO92QBdIS0QeaQC+VuJS6n3wzUg==
+  dependencies:
+    "@mirrormedia/lilith-draft-renderer" "1.1.0-alpha.7"
     draft-js "^0.11.7"
 
 "@mirrormedia/lilith-draft-renderer@1.0.0":
@@ -5723,6 +5752,11 @@ hasha@5.2.2:
     is-stream "^2.0.0"
     type-fest "^0.8.0"
 
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 hexoid@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
@@ -7160,6 +7194,14 @@ node-forge@^1.3.1:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
 
+node-html-parser@^6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.5.tgz#c819dceb13a10a7642ff92f94f870b4f77968097"
+  integrity sha512-fAaM511feX++/Chnhe475a0NHD8M7AxDInsqQpz6x63GRF7xYNdS8Vo5dKsIVPgsOvG7eioRRTZQnWBrhDHBSg==
+  dependencies:
+    css-select "^5.1.0"
+    he "1.2.0"
+
 node-releases@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
@@ -7901,7 +7943,16 @@ react-day-picker@^8.0.4:
   resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-8.2.0.tgz#f6cac34d53e1ce963e561940e33fadec874e48cb"
   integrity sha512-6sI9+qk1xXSvV94WOz0H4FVGFaGquwMLQGw9WXoOZajMY/CVrLsautRFwkdjZ9jWj7WZR2Se1mTMrEpmcB6BEQ==
 
-react-dom@18.1.0, react-dom@^17.0.2, react-dom@^18.1.0:
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
+
+react-dom@^18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.1.0.tgz#7f6dd84b706408adde05e1df575b3a024d7e8a2f"
   integrity sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==
@@ -7995,12 +8046,20 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.2, react-transition-g
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@18.1.0, react@^17.0.2:
+react@18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.1.0.tgz#6f8620382decb17fdc5cc223a115e2adbf104890"
   integrity sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==
   dependencies:
     loose-envify "^1.1.0"
+
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 read-pkg-up@7.0.1, read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -8277,6 +8336,14 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 scheduler@^0.22.0:
   version "0.22.0"


### PR DESCRIPTION
# Notable Change
原本在 useEffect 才把全部 embed code append 到 DOM 上面的做法會導致 non-script 的 tags (包含 html tag 和 style tag) 會在 useEffect 才被 append 到 dom 上面造成 embed code 的內容憑空出現把內容往下擠的跳動。

透過將 non-script tags 從 embed code 中分離出來塞進 dangerouslySetInnerHtml 之中不僅可以提早 non-script tags render 的時間，更可以讓 SSR 產生的 HTML 就直接包含這些 non-script tags，達到優化使用者體驗的效果。

## Dev Note (踩坑紀錄)
`dangerouslySetInnerHtml` 雖然不會讓 script tag 在被 set 完之後被執行(因為底層就是使用`setInnerHtml`)，但仍然會存在在產生出來的 HTML 之中，在 CSR 的情況下不會有問題，但在 SSR 之下就會造成 server side 產生的 HTML 上含有 embed code 的 script tags，當 browser 解析 HTML 的時候反而會被執行的異常狀況(漏洞)。

這樣的行為看似可以符合我們的需求(無腦把 ebmed code 塞進 `dangerouslySetInnerHtml` 他就會動)，但只要 react component re-render 的情況下就會恢復成 CSR 的結果 ( script tags 再次無效化)，結果是還是要特別處理在 useEffect 之中把 script tags 手動 append 上去，然而一但在 useEffect 中加上這段邏輯意味著第一次 browser 從 server 拿到 HTML 的時候又會執行兩次 script tags... 

要解決上述的困境又另外需要在 browser 針對 SSR 產生出來的 embed code script 觸發的時候特別紀錄 state，然後在 useEffect 中判斷該 state 來決定要不要 append script tags，需要透過額外塞入客製化的 self-invoke function 不管是存值到 window，或是更改某個同樣被額外塞入的 div 的 attribute 來達成，但前者需要特別區別不同的 embed code component 以避免狀態互相污染、後者則是會導致 react client side first initialize 的時候執行完 `dangerouslySetInnerHtml` 之後發現該額外塞入的 div 的 attribute 被更改導致 hydration error 的問題。

除此之外，即便確保 component 不會 re-render 的狀況，`dangerouslySetInnerHtml` 中塞入 script 也可能造成 browser 執行 embed code 的 script 時發生 hydration error (原因同上)。

花了許多時間打轉之後，最終直接處理 embed code string 把 script tags 和 non-script tags 分開成了最乾淨的解法，而分開的方式有兩種：
1. 用 regEx 把 script tags 找出來
    - 優點：容易撰寫 isomorphic 的 code
    - 缺點：embed code 中的 script 不良寫法可能導致 regEx 尋找出錯，可能會需要一直補漏洞，補到 regEx 難以維護
2. 用第三方套件 html parser 把 script tags 找出來
    - 優點：用類似 web API DomParser 類比 browser parse HTML 的方法，可以避免 script tags 沒寫好但還是可以被 browser 執行的狀況
    - 缺點：該套件需要是 isomorphic 才不會產生 hydration error，且 html parse 會需要在 server side 執行，可能影響到 server 的執行效能 (可以靠 cache 緩解)

最後在不想重複面對 regEx 修繕以及 Nick 找到了好用的 node-html-parser 套件的情況下，就產生了 embed-code-block 中現在的寫法。

