### PR TITLE
feat(draft-renderer): add utils function to check has content in raw content block

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.1.0-alpha.18",
+  "version": "1.1.0-alpha.19",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/mirrormedia/index.ts
+++ b/packages/draft-renderer/src/website/mirrormedia/index.ts
@@ -1,11 +1,12 @@
 import { blockRenderers } from './block-renderers'
 import { entityDecorators } from './entity-decorators'
 import DraftRenderer from './draft-renderer'
-
+import { hasContentInRawContentBlock } from './utils'
 const MirrorMedia = {
   DraftRenderer,
   blockRenderers,
   entityDecorators,
+  hasContentInRawContentBlock,
 }
 
 export default MirrorMedia

--- a/packages/draft-renderer/src/website/mirrormedia/utils/index.ts
+++ b/packages/draft-renderer/src/website/mirrormedia/utils/index.ts
@@ -1,0 +1,38 @@
+type DraftBlock = {
+  data: object
+  depth: number
+  entityRanges: any[]
+  inlineStyleRanges: any[]
+  key: string
+  text: string
+  type: string
+}
+
+type Draft = {
+  blocks: DraftBlock[]
+  entityMap: object
+}
+
+const hasContentInRawContentBlock = (rawContentBlock: Draft) => {
+  if (
+    !rawContentBlock ||
+    !rawContentBlock.blocks ||
+    !rawContentBlock.blocks.length
+  ) {
+    return false
+  }
+  const hasAtomicBlock = Boolean(
+    rawContentBlock.blocks.some((block) => block.type === 'atomic')
+  )
+  if (hasAtomicBlock) {
+    return hasAtomicBlock
+  }
+  const defaultBlockHasContent = Boolean(
+    rawContentBlock.blocks
+      .filter((block) => block.type !== 'atomic')
+      .some((block) => block.text.trim())
+  )
+  return defaultBlockHasContent
+}
+
+export { hasContentInRawContentBlock }


### PR DESCRIPTION
## Notable Change
由於Adam/mirror-media-next 有需要確認前言或內文是否有內容的需求，原本是寫在 mirror-media-next中 （詳見 https://github.com/mirror-media/Adam/pull/149 ），但後來經文瀚建議，將draft-renderer相關的程式碼都封裝在draft-renderer中，使用draft-renderer的專案則可以直接引用，不需要了解draft-renderer內部的邏輯。