### PR TITLE
feat(draft-renderer/mm): add `wide` layout and change style of certain content and atomic block

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.2.0-alpha.9",
+  "version": "1.2.0-alpha.10",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderer-fn.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderer-fn.tsx
@@ -19,7 +19,7 @@ const {
 
 const AtomicBlock = (props) => {
   const entity = props.contentState.getEntity(props.block.getEntityAt(0))
-
+  const { contentLayout } = props.blockProps
   const entityType = entity.getType()
 
   switch (entityType) {
@@ -29,7 +29,7 @@ const AtomicBlock = (props) => {
       return MediaBlock(entity)
     }
     case 'image': {
-      return ImageBlock(entity)
+      return ImageBlock(entity, contentLayout)
     }
     case 'slideshow': {
       return SlideshowBlock(entity)
@@ -41,7 +41,7 @@ const AtomicBlock = (props) => {
       return EmbeddedCodeBlock(entity)
     }
     case 'INFOBOX': {
-      return InfoBoxBlock(props)
+      return InfoBoxBlock(props, contentLayout)
     }
     case 'DIVIDER': {
       return DividerBlock()
@@ -74,11 +74,12 @@ const AtomicBlock = (props) => {
   return null
 }
 
-export function atomicBlockRenderer(block) {
+export function atomicBlockRenderer(block, contentLayout) {
   if (block.getType() === 'atomic') {
     return {
       component: AtomicBlock,
       editable: false,
+      props: { contentLayout },
     }
   }
 

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { DraftEntityInstance } from 'draft-js'
 import defaultImage from '../assets/default-og-img.png'
 import loadingImage from '../assets/loading.gif'
@@ -10,6 +10,35 @@ import {
   clearAllBodyScrollLocks,
 } from 'body-scroll-lock'
 
+const imageFigureLayoutNormal = css``
+const imageFigureLayoutWide = css`
+  .readr-media-react-image {
+    position: relative;
+    max-width: calc(100% + 20px + 20px);
+    transform: translateX(-20px);
+  }
+`
+
+const figcaptionLayoutNormal = css`
+  margin-top: 12px;
+  ${({ theme }) => theme.breakpoint.md} {
+    margin-top: 20px;
+  }
+`
+const figcaptionLayoutWide = css`
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  padding-top: 12px;
+  margin-top: 16px;
+  position: relative;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  ${({ theme }) => theme.breakpoint.md} {
+    max-width: calc(100% + 20px + 20px);
+    transform: translateX(-20px);
+  }
+`
+
 const Figure = styled.figure`
   margin-block: unset;
   margin-inline: unset;
@@ -19,15 +48,33 @@ const Figure = styled.figure`
     cursor: pointer;
   }
 `
+const ImageFigure = styled(Figure)`
+  ${({ contentLayout }) => {
+    switch (contentLayout) {
+      case 'normal':
+        return imageFigureLayoutNormal
+      case 'wide':
+        return imageFigureLayoutWide
+      default:
+        return imageFigureLayoutNormal
+    }
+  }}
+`
 const Figcaption = styled.figcaption`
   font-size: 14px;
   line-height: 1.8;
   font-weight: 400;
   color: rgba(0, 0, 0, 0.5);
-  margin-top: 12px;
-  ${({ theme }) => theme.breakpoint.md} {
-    margin-top: 20px;
-  }
+  ${({ contentLayout }) => {
+    switch (contentLayout) {
+      case 'normal':
+        return figcaptionLayoutNormal
+      case 'wide':
+        return figcaptionLayoutWide
+      default:
+        return figcaptionLayoutNormal
+    }
+  }}
 `
 const Anchor = styled.a`
   text-decoration: none;
@@ -92,12 +139,14 @@ const LightBoxWrapper = styled.div`
     cursor: auto;
   }
 `
-export function ImageBlock(entity: DraftEntityInstance) {
+export function ImageBlock(
+  entity: DraftEntityInstance,
+  contentLayout = 'normal'
+) {
   const lightBoxRef = useRef(null)
 
   const [shouldOpenLightBox, setShouldOpenLightBox] = useState(false)
   const { name, desc, resized, url } = entity.getData()
-
   const handleOpen = () => {
     if (url) {
       return
@@ -106,19 +155,31 @@ export function ImageBlock(entity: DraftEntityInstance) {
   }
 
   let imgBlock = (
-    <Figure onClick={handleOpen}>
+    <ImageFigure
+      key={resized.original}
+      contentLayout={contentLayout}
+      onClick={handleOpen}
+    >
       <CustomImage
         images={resized}
         defaultImage={defaultImage}
         loadingImage={loadingImage}
+        width={'100vw'}
+        height={'auto'}
+        objectFit={'contain'}
         alt={name}
-        rwd={{ mobile: '100vw', tablet: '640px', default: '100%' }}
+        rwd={{ mobile: '100vw', tablet: '640px', default: '640px' }}
         priority={true}
       ></CustomImage>
       {desc ? (
-        <Figcaption onClick={(e) => e.stopPropagation()}>{desc}</Figcaption>
+        <Figcaption
+          contentLayout={contentLayout}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {desc}
+        </Figcaption>
       ) : null}
-    </Figure>
+    </ImageFigure>
   )
   useEffect(() => {
     if (lightBoxRef && lightBoxRef.current) {

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/info-box-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/info-box-block.tsx
@@ -1,19 +1,88 @@
 import React from 'react'
 import { ContentBlock, ContentState } from 'draft-js'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+
+//for setting background color info box
+const backgroundColorNormal = '#054f77'
+const backgroundColorWide = '#F2F2F2'
+const textColorNormal = '#c4c4c4'
+const textColorWide = 'rgba(0, 0, 0, 0.66)'
+
+const infoBoxWrapperNormal = css`
+  background-color: ${backgroundColorNormal};
+  color: ${textColorNormal};
+  > h2 {
+    color: #ffffff;
+  }
+`
+const infoBoxWrapperWide = css`
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  background-color: ${backgroundColorWide};
+  color: ${textColorWide};
+  border-top: 2px solid #054f77;
+  filter: drop-shadow(0px 4px 12px rgba(0, 0, 0, 0.08))
+    drop-shadow(0px 2px 28px rgba(0, 0, 0, 0.06));
+
+  > h2 {
+    color: black;
+  }
+`
 
 const InfoBoxRenderWrapper = styled.div`
-  background-color: #054f77;
   padding: 32px 30px 22px 30px;
   margin-top: 20px;
   margin-bottom: 20px;
   position: relative;
-  color: #c4c4c4;
   > h2 {
     font-size: 20px;
     line-height: 1.5;
-    color: #ffffff;
     margin-bottom: 18px;
+  }
+
+  ${({ contentLayout }) => {
+    switch (contentLayout) {
+      case 'normal':
+        return infoBoxWrapperNormal
+      case 'wide':
+        return infoBoxWrapperWide
+      default:
+        return infoBoxWrapperNormal
+    }
+  }}
+`
+
+const infoBoxBodyNormal = css`
+  ul {
+    li {
+      &::before {
+        background-color: ${textColorNormal};
+      }
+    }
+  }
+  ol {
+    li {
+      &::before {
+        color: ${textColorNormal};
+      }
+    }
+  }
+`
+const infoBoxBodyWide = css`
+  ul {
+    li {
+      &::before {
+        background-color: ${textColorWide};
+      }
+    }
+  }
+  ol {
+    li {
+      &::before {
+        color: ${textColorWide};
+      }
+    }
   }
 `
 const infoBoxLineHeight = 1.8
@@ -40,7 +109,6 @@ const InfoBoxBody = styled.div`
         height: 6px;
         transform: translate(-50%, -50%);
         border-radius: 50%;
-        background-color: #c4c4c4;
       }
     }
   }
@@ -53,12 +121,21 @@ const InfoBoxBody = styled.div`
       &::before {
         content: counter(list) '.';
         position: absolute;
-        color: #c4c4c4;
         left: -15px;
         width: 15px;
       }
     }
   }
+  ${({ contentLayout }) => {
+    switch (contentLayout) {
+      case 'normal':
+        return infoBoxBodyNormal
+      case 'wide':
+        return infoBoxBodyWide
+      default:
+        return infoBoxBodyNormal
+    }
+  }}
 `
 
 type InfoBoxBlockProps = {
@@ -76,18 +153,22 @@ type InfoBoxBlockProps = {
   contentState: ContentState
 }
 
-export function InfoBoxBlock(props: InfoBoxBlockProps) {
+export function InfoBoxBlock(
+  props: InfoBoxBlockProps,
+  contentLayout = 'normal'
+) {
   const { block, contentState } = props
+
   const entityKey = block.getEntityAt(0)
   const entity = contentState.getEntity(entityKey)
   const { title, body } = entity.getData()
 
   return (
-    <InfoBoxRenderWrapper>
+    <InfoBoxRenderWrapper contentLayout={contentLayout}>
       <h2>{title}</h2>
       <InfoBoxBody
+        contentLayout={contentLayout}
         dangerouslySetInnerHTML={{ __html: body }}
-        className="content"
       />
     </InfoBoxRenderWrapper>
   )

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
@@ -121,6 +121,9 @@ const Desc = styled.figcaption`
   color: rgba(0, 0, 0, 0.5);
   margin-top: 20px;
   min-height: 1.8rem;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 `
 
 // support old version of slideshow without delay propertiy

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
@@ -65,9 +65,9 @@ const SlidesBox = styled.div`
     max-height: 58.75vw;
     min-height: 58.75vw;
     ${({ theme }) => theme.breakpoint.md} {
-      min-width: 640px;
+      min-width: 100%;
       min-height: 428px;
-      max-width: 640px;
+      max-width: 100%;
       max-height: 428px;
     }
   }

--- a/packages/draft-renderer/src/website/mirrormedia/draft-renderer.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/draft-renderer.tsx
@@ -270,7 +270,10 @@ export default function DraftRenderer({
 }) {
   const contentState = convertFromRaw(rawContentBlock)
 
-  const editorState = EditorState.createWithContent(contentState, decorators)
+  const editorState = EditorState.createWithContent(
+    contentState,
+    decorators(contentLayout)
+  )
   const blockRendererFn = (block) => {
     const atomicBlockObj = atomicBlockRenderer(block, contentLayout)
     return atomicBlockObj

--- a/packages/draft-renderer/src/website/mirrormedia/draft-renderer.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/draft-renderer.tsx
@@ -206,18 +206,20 @@ const blockStyleFn = (editorState, block) => {
   return result
 }
 
-const blockRendererFn = (block) => {
-  const atomicBlockObj = atomicBlockRenderer(block)
-  return atomicBlockObj
-}
-
-export default function DraftRenderer({ rawContentBlock }) {
+export default function DraftRenderer({
+  rawContentBlock,
+  contentLayout = 'normal',
+}) {
   const contentState = convertFromRaw(rawContentBlock)
-  const editorState = EditorState.createWithContent(contentState, decorators)
 
+  const editorState = EditorState.createWithContent(contentState, decorators)
+  const blockRendererFn = (block) => {
+    const atomicBlockObj = atomicBlockRenderer(block, contentLayout)
+    return atomicBlockObj
+  }
   return (
     <ThemeProvider theme={theme}>
-      <DraftEditorWrapper>
+      <DraftEditorWrapper contentLayout={contentLayout}>
         <Editor
           editorState={editorState}
           customStyleMap={customStyleMap}

--- a/packages/draft-renderer/src/website/mirrormedia/draft-renderer.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/draft-renderer.tsx
@@ -24,31 +24,13 @@ const defaultSpacingBetweenContent = css`
 const noSpacingBetweenContent = css`
   margin-bottom: unset;
 `
-const DraftEditorWrapper = styled.div`
-  /* Rich-editor default setting (.RichEditor-root)*/
 
-  border: 1px solid #ddd;
-  font-family: 'Georgia', serif;
-  font-size: 14px;
-  padding: 15px;
-
-  /* Custom setting */
+const draftEditorCssNormal = css`
+  color: black;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
     'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  width: 100%;
-  height: 100%;
-  border-radius: 6px;
-  border: 0;
-  padding: 0px;
-  font-size: 18px;
-  line-height: ${draftEditorLineHeight};
-
-  .public-DraftStyleDefault-block {
-    ${defaultSpacingBetweenContent}
-  }
-
-  /* Draft built-in buttons' style */
+  font-weight: normal;
   .public-DraftStyleDefault-header-two {
     font-size: 36px;
     line-height: 1.5;
@@ -59,6 +41,39 @@ const DraftEditorWrapper = styled.div`
   }
   .public-DraftStyleDefault-header-four {
   }
+`
+const draftEditorCssWide = css`
+  color: rgba(64, 64, 64, 0.87);
+  font-family: 'Noto Serif TC', serif;
+  font-weight: 600;
+  .public-DraftStyleDefault-header-two {
+    color: black;
+    font-size: 36px;
+    font-weight: 700;
+  }
+  .public-DraftStyleDefault-header-three {
+    color: black;
+    font-size: 32px;
+    font-weight: 700;
+  }
+  .public-DraftStyleDefault-header-four {
+  }
+`
+
+const DraftEditorWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  border: 0;
+  padding: 0px;
+  font-size: 18px;
+  line-height: ${draftEditorLineHeight};
+
+  .public-DraftStyleDefault-block {
+    ${defaultSpacingBetweenContent}
+  }
+
+  /* Draft built-in buttons' style */
+
   .public-DraftStyleDefault-blockquote {
     position: relative;
     width: 100%;
@@ -138,6 +153,17 @@ const DraftEditorWrapper = styled.div`
   /* code-block */
   .public-DraftStyleDefault-pre {
   }
+
+  ${({ contentLayout }) => {
+    switch (contentLayout) {
+      case 'normal':
+        return draftEditorCssNormal
+      case 'wide':
+        return draftEditorCssWide
+      default:
+        return draftEditorCssNormal
+    }
+  }}
   .alignCenter * {
     text-align: center;
   }

--- a/packages/draft-renderer/src/website/mirrormedia/draft-renderer.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/draft-renderer.tsx
@@ -21,9 +21,14 @@ const defaultSpacingBetweenContent = css`
   margin-bottom: 32px;
 `
 
-const noSpacingBetweenContent = css`
-  margin-bottom: unset;
-`
+const noSpacingBetweenContent = {
+  blockquote: css`
+    margin-bottom: unset;
+  `,
+  list: css`
+    margin-bottom: 4px;
+  `,
+}
 
 const draftEditorCssNormal = css`
   color: black;
@@ -41,11 +46,28 @@ const draftEditorCssNormal = css`
   }
   .public-DraftStyleDefault-header-four {
   }
+
+  .public-DraftStyleDefault-blockquote {
+    color: rgba(97, 184, 198, 1);
+    border-image: linear-gradient(
+        to right,
+        rgba(97, 184, 198, 1) 42.5%,
+        transparent 42.5%,
+        transparent 57.5%,
+        rgba(97, 184, 198, 1) 57.5%
+      )
+      100% 1;
+    &::before {
+      background-color: rgba(97, 184, 198, 1);
+    }
+  }
 `
 const draftEditorCssWide = css`
   color: rgba(64, 64, 64, 0.87);
   font-family: 'Noto Serif TC', serif;
   font-weight: 600;
+  font-size: 18px;
+  line-height: 2;
   .public-DraftStyleDefault-header-two {
     color: black;
     font-size: 36px;
@@ -57,6 +79,26 @@ const draftEditorCssWide = css`
     font-weight: 700;
   }
   .public-DraftStyleDefault-header-four {
+  }
+  .public-DraftStyleDefault-blockquote {
+    color: rgba(0, 0, 0, 1);
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+      Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
+      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+      'Noto Color Emoji';
+    font-weight: 400;
+
+    border-image: linear-gradient(
+        to right,
+        rgba(0, 0, 0, 1) 42.5%,
+        transparent 42.5%,
+        transparent 57.5%,
+        rgba(0, 0, 0, 1) 57.5%
+      )
+      100% 1;
+    &::before {
+      background-color: rgba(0, 0, 0, 1);
+    }
   }
 `
 
@@ -80,18 +122,9 @@ const DraftEditorWrapper = styled.div`
     margin: 0 auto;
     max-width: 480px;
     text-align: left;
-    color: rgba(97, 184, 198, 1);
     margin: 48px auto;
     padding-top: 34px;
     border-top: 2px solid;
-    border-image: linear-gradient(
-        to right,
-        rgba(97, 184, 198, 1) 42.5%,
-        transparent 42.5%,
-        transparent 57.5%,
-        rgba(97, 184, 198, 1) 57.5%
-      )
-      100% 1;
     &::before {
       content: '';
       position: absolute;
@@ -100,11 +133,11 @@ const DraftEditorWrapper = styled.div`
       transform: translate(-50%, -50%);
       width: 100%;
       height: 20px;
-      background-image: url(${blockquoteDecoration});
-      background-repeat: no-repeat;
-      background-position: center center;
+      mask-image: url(${blockquoteDecoration});
+      mask-repeat: no-repeat;
+      mask-position: center center;
     }
-    ${noSpacingBetweenContent}
+    ${noSpacingBetweenContent.blockquote}
     ${({ theme }) => theme.breakpoint.md} {
       padding-top: 26px;
     }
@@ -114,7 +147,7 @@ const DraftEditorWrapper = styled.div`
     list-style: none;
     ${defaultSpacingBetweenContent}
     .public-DraftStyleDefault-block {
-      ${noSpacingBetweenContent}
+      ${noSpacingBetweenContent.list}
     }
   }
   .public-DraftStyleDefault-unorderedListItem {
@@ -135,7 +168,7 @@ const DraftEditorWrapper = styled.div`
     margin-left: 18px;
     ${defaultSpacingBetweenContent}
     .public-DraftStyleDefault-block {
-      ${noSpacingBetweenContent}
+      ${noSpacingBetweenContent.list}
     }
   }
   .public-DraftStyleDefault-orderedListItem {
@@ -252,6 +285,8 @@ export default function DraftRenderer({
           blockRendererFn={blockRendererFn}
           customStyleFn={customStyleFn}
           readOnly
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          onChange={() => {}}
         />
       </DraftEditorWrapper>
     </ThemeProvider>

--- a/packages/draft-renderer/src/website/mirrormedia/draft-renderer.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/draft-renderer.tsx
@@ -14,21 +14,15 @@ import theme from './theme'
 const draftEditorLineHeight = 2
 /**
  * Due to the data structure from draftjs, each default block contain one HTML element which class name is `public-DraftStyleDefault-block`.
- * So we use this behavior to create spacing between blocks by assign margin-top of which.
+ * So we use this behavior to create spacing between blocks by assign margin-bottom of which.
  * However, some block should not set spacing (e.g. block in <li> and <blockquote>), so we need to unset its margin-top.
  */
 const defaultSpacingBetweenContent = css`
-  .public-DraftStyleDefault-block {
-    margin-top: 1.5em;
-  }
+  margin-bottom: 32px;
 `
-const narrowSpacingBetweenContent = css`
-  margin-top: 20px;
-`
+
 const noSpacingBetweenContent = css`
-  .public-DraftStyleDefault-block {
-    margin-top: unset;
-  }
+  margin-bottom: unset;
 `
 const DraftEditorWrapper = styled.div`
   /* Rich-editor default setting (.RichEditor-root)*/
@@ -49,7 +43,8 @@ const DraftEditorWrapper = styled.div`
   padding: 0px;
   font-size: 18px;
   line-height: ${draftEditorLineHeight};
-  *:not(:first-child) {
+
+  .public-DraftStyleDefault-block {
     ${defaultSpacingBetweenContent}
   }
 
@@ -102,8 +97,10 @@ const DraftEditorWrapper = styled.div`
   .public-DraftStyleDefault-ul {
     margin-left: 18px;
     list-style: none;
-    ${narrowSpacingBetweenContent}
-    ${noSpacingBetweenContent}
+    ${defaultSpacingBetweenContent}
+    .public-DraftStyleDefault-block {
+      ${noSpacingBetweenContent}
+    }
   }
   .public-DraftStyleDefault-unorderedListItem {
     position: relative;
@@ -121,8 +118,10 @@ const DraftEditorWrapper = styled.div`
   }
   .public-DraftStyleDefault-ol {
     margin-left: 18px;
-    ${narrowSpacingBetweenContent}
-    ${noSpacingBetweenContent}
+    ${defaultSpacingBetweenContent}
+    .public-DraftStyleDefault-block {
+      ${noSpacingBetweenContent}
+    }
   }
   .public-DraftStyleDefault-orderedListItem {
     position: relative;

--- a/packages/draft-renderer/src/website/mirrormedia/entity-decorator.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/entity-decorator.tsx
@@ -4,6 +4,11 @@ import { entityDecorators } from './entity-decorators'
 
 const { annotationDecorator, linkDecorator } = entityDecorators
 
-const decorators = new CompositeDecorator([annotationDecorator, linkDecorator])
+const decorators = (contentLayout = 'normal') => {
+  return new CompositeDecorator([
+    annotationDecorator(contentLayout),
+    linkDecorator(contentLayout),
+  ])
+}
 
 export default decorators

--- a/packages/draft-renderer/src/website/mirrormedia/entity-decorators/annotation-decorator.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/entity-decorators/annotation-decorator.tsx
@@ -120,7 +120,10 @@ function findAnnotationEntities(contentBlock, callback, contentState) {
   }, callback)
 }
 
-export const annotationDecorator = {
-  strategy: findAnnotationEntities,
-  component: AnnotationBlock,
+export const annotationDecorator = (contentLayout = 'normal') => {
+  return {
+    strategy: findAnnotationEntities,
+    component: AnnotationBlock,
+    props: { contentLayout },
+  }
 }

--- a/packages/draft-renderer/src/website/mirrormedia/entity-decorators/annotation-decorator.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/entity-decorators/annotation-decorator.tsx
@@ -1,9 +1,16 @@
 import React, { useState } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
+const colorNormal = '#054f77'
+const colorWide = 'rgba(64, 64, 64, 0.87);'
+
+const annotatedTextNormal = css`
+  color: ${colorNormal};
+`
+const annotatedTextWide = css`
+  color: ${colorWide};
+`
 const AnnotatedText = styled.span`
-  color: #054f77;
-
   text-decoration: underline;
   svg {
     display: inline;
@@ -12,14 +19,73 @@ const AnnotatedText = styled.span`
     margin-right: 9px;
     transform: translateY(-50%);
   }
+
+  ${({ contentLayout }) => {
+    switch (contentLayout) {
+      case 'normal':
+        return annotatedTextNormal
+      case 'wide':
+        return annotatedTextWide
+      default:
+        return annotatedTextNormal
+    }
+  }}
 `
+//for setting color of text, color of `<li>` marker in `<ul>` and `<ol>`.
+
+const annotationBodyNormal = css`
+  color: ${colorNormal};
+  margin-top: 16px;
+  margin-bottom: 24px;
+  ul {
+    li {
+      background-color: ${colorNormal};
+    }
+  }
+  ol {
+    li {
+      &::before {
+        color: ${colorNormal};
+      }
+    }
+  }
+  ${({ theme }) => theme.breakpoint.md} {
+    margin-top: 24px;
+    margin-bottom: 24px;
+  }
+`
+const annotationBodyWide = css`
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  color: ${colorWide};
+  margin-top: 16px;
+  margin-bottom: 24px;
+  border: 1px solid black;
+  ul {
+    li {
+      &::before {
+        background-color: ${colorWide};
+      }
+    }
+  }
+  ol {
+    li {
+      &::before {
+        color: ${colorWide};
+      }
+    }
+  }
+  ${({ theme }) => theme.breakpoint.md} {
+    margin-top: 8px;
+    margin-bottom: 32px;
+  }
+`
+
 const annotationBodyLineHeight = 1.8
 const AnnotationBody = styled.div`
   background-color: #e3e3e3;
-  margin-top: 20px;
-  margin-bottom: 20px;
   padding: 24px 32px;
-  color: #054f77;
   font-size: 16px;
   line-height: ${annotationBodyLineHeight};
 
@@ -43,7 +109,6 @@ const AnnotationBody = styled.div`
         height: 6px;
         transform: translate(-50%, -50%);
         border-radius: 50%;
-        background-color: #054f77;
       }
     }
   }
@@ -56,15 +121,35 @@ const AnnotationBody = styled.div`
       &::before {
         content: counter(list) '.';
         position: absolute;
-        color: #054f77;
         left: -15px;
         width: 15px;
       }
     }
   }
+  ${({ contentLayout }) => {
+    switch (contentLayout) {
+      case 'normal':
+        return annotationBodyNormal
+      case 'wide':
+        return annotationBodyWide
+      default:
+        return annotationBodyNormal
+    }
+  }}
 `
+const getSvgColor = (contentLayout = 'normal') => {
+  switch (contentLayout) {
+    case 'normal':
+      return '#054f77'
+    case 'wide':
+      return '#333333'
+    default:
+      return '#054f77'
+  }
+}
 
-function indicatorSvg(shouldRotate: boolean) {
+function indicatorSvg(shouldRotate: boolean, contentLayout = 'normal') {
+  const svgColor = getSvgColor(contentLayout)
   const transform = `translateY(-50%)${shouldRotate ? 'rotate(180deg)' : ''}`
   return (
     <svg
@@ -77,19 +162,20 @@ function indicatorSvg(shouldRotate: boolean) {
     >
       <path
         d="M7.68981 0.28664C7.31321 -0.0955464 6.68679 -0.0955466 6.31019 0.286639L0.269402 6.417C-0.315817 7.01089 0.115195 8 0.959209 8L13.0408 8C13.8848 8 14.3158 7.01089 13.7306 6.417L7.68981 0.28664Z"
-        fill="#054F77"
+        fill={svgColor}
       />
     </svg>
   )
 }
 
 function AnnotationBlock(props) {
-  const { children: annotated } = props
+  const { children: annotated, contentLayout = 'normal' } = props
+  console.log('contentLayout in annotation', contentLayout)
   const [toShowAnnotation, setToShowAnnotation] = useState(false)
   const { bodyHTML } = props.contentState.getEntity(props.entityKey).getData()
   return (
     <React.Fragment>
-      <AnnotatedText>
+      <AnnotatedText contentLayout={contentLayout}>
         {annotated}
         <span
           onClick={(e) => {
@@ -97,11 +183,14 @@ function AnnotationBlock(props) {
             setToShowAnnotation(!toShowAnnotation)
           }}
         >
-          {toShowAnnotation ? indicatorSvg(false) : indicatorSvg(true)}
+          {toShowAnnotation
+            ? indicatorSvg(false, contentLayout)
+            : indicatorSvg(true, contentLayout)}
         </span>
       </AnnotatedText>
       {toShowAnnotation ? (
         <AnnotationBody
+          contentLayout={contentLayout}
           contentEditable={false}
           dangerouslySetInnerHTML={{ __html: bodyHTML }}
         ></AnnotationBody>

--- a/packages/draft-renderer/src/website/mirrormedia/entity-decorators/link-decorator.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/entity-decorators/link-decorator.tsx
@@ -19,9 +19,12 @@ function findLinkEntities(contentBlock, callback, contentState) {
   }, callback)
 }
 
-export const linkDecorator = {
-  strategy: findLinkEntities,
-  component: Link,
+export const linkDecorator = (contentLayout = 'normal') => {
+  return {
+    strategy: findLinkEntities,
+    component: Link,
+    props: { contentLayout },
+  }
 }
 
 function Link(props) {


### PR DESCRIPTION
## Notable Change
1. MirrorMedia底下的元件`<DraftRenderer>`，將新增一參數`contentLayout`。該參數將會影響content block、atomic block所顯示的樣式，如字體、字體大小、顏色、間距等等。
2. 未來將有四種`contentLayout`：`normal`、`wide`、`photography`、`premium`。目前僅新增`normal`與`wide`兩種樣式。
3. 目前透過styled-component的`css`，管理content block、atomic block中不同`contentLayout`所應顯示的樣式為何。


## To do list
1. 需補上`contentLayout`的type。