### PR TITLE
feat(core): auto add virtual field to return relationship items in input order

### DIFF
--- a/packages/readr/lists/Post.ts
+++ b/packages/readr/lists/Post.ts
@@ -58,48 +58,30 @@ const listConfigurations = list({
       many: true,
       label: '作者',
     }),
-    manualOrderOfWriters: json({
-      label: '作者手動排序結果',
-    }),
     photographers: relationship({
       many: true,
       label: '攝影',
       ref: 'Author',
-    }),
-    manualOrderOfPhotographers: json({
-      label: '攝影手動排序結果',
     }),
     cameraOperators: relationship({
       label: '影音',
       many: true,
       ref: 'Author',
     }),
-    manualOrderOfCameraOperators: json({
-      label: '影音手動排序結果',
-    }),
     designers: relationship({
       label: '設計',
       many: true,
       ref: 'Author',
-    }),
-    manualOrderOfDesigners: json({
-      label: '設計手動排序結果',
     }),
     engineers: relationship({
       many: true,
       label: '工程',
       ref: 'Author',
     }),
-    manualOrderOfEngineers: json({
-      label: '工程手動排序結果',
-    }),
     dataAnalysts: relationship({
       many: true,
       label: '資料分析',
       ref: 'Author',
-    }),
-    manualOrderOfDataAnalysts: json({
-      label: '資料分析手動排序結果',
     }),
     otherByline: text({
       validation: { isRequired: false },
@@ -110,7 +92,7 @@ const listConfigurations = list({
     }),
     leadingEmbeddedCode: text({
       label: 'Leading embedded code',
-      ui: { displayMode: 'textarea' }
+      ui: { displayMode: 'textarea' },
     }),
     heroVideo: relationship({
       label: 'Leading Video',
@@ -207,9 +189,6 @@ const listConfigurations = list({
       ref: 'Post',
       many: true,
       label: '相關文章',
-    }),
-    manualOrderOfRelatedPosts: json({
-      label: '相關文章手動排序結果',
     }),
     data: relationship({
       ref: 'DataSet.relatedPosts',
@@ -383,42 +362,49 @@ export default utils.addManualOrderRelationshipFields(
   [
     {
       fieldName: 'manualOrderOfWriters',
+      fieldLabel: '作者手動排序結果',
       targetFieldName: 'writers',
       targetListName: 'Author',
       targetListLabelField: 'name',
     },
     {
       fieldName: 'manualOrderOfPhotographers',
+      fieldLabel: '攝影手動排序結果',
       targetFieldName: 'photographers',
       targetListName: 'Author',
       targetListLabelField: 'name',
     },
     {
       fieldName: 'manualOrderOfCameraOperators',
+      fieldLabel: '影音手動排序結果',
       targetFieldName: 'cameraOperators',
       targetListName: 'Author',
       targetListLabelField: 'name',
     },
     {
       fieldName: 'manualOrderOfDesigners',
+      fieldLabel: '設計手動排序結果',
       targetFieldName: 'designers',
       targetListName: 'Author',
       targetListLabelField: 'name',
     },
     {
       fieldName: 'manualOrderOfEngineers',
+      fieldLabel: '工程手動排序結果',
       targetFieldName: 'engineers',
       targetListName: 'Author',
       targetListLabelField: 'name',
     },
     {
       fieldName: 'manualOrderOfDataAnalysts',
+      fieldLabel: '資料分析手動排序結果',
       targetFieldName: 'dataAnalysts',
       targetListName: 'Author',
       targetListLabelField: 'name',
     },
     {
       fieldName: 'manualOrderOfRelatedPosts',
+      fieldLabel: '相關文章手動排序結果',
       targetFieldName: 'relatedPosts',
       targetListName: 'Post',
       targetListLabelField: 'name',

--- a/packages/readr/schema.graphql
+++ b/packages/readr/schema.graphql
@@ -1357,7 +1357,6 @@ type Post {
     skip: Int! = 0
   ): [Author!]
   writersCount(where: AuthorWhereInput! = {}): Int
-  manualOrderOfWriters: JSON
   photographers(
     where: AuthorWhereInput! = {}
     orderBy: [AuthorOrderByInput!]! = []
@@ -1365,7 +1364,6 @@ type Post {
     skip: Int! = 0
   ): [Author!]
   photographersCount(where: AuthorWhereInput! = {}): Int
-  manualOrderOfPhotographers: JSON
   cameraOperators(
     where: AuthorWhereInput! = {}
     orderBy: [AuthorOrderByInput!]! = []
@@ -1373,7 +1371,6 @@ type Post {
     skip: Int! = 0
   ): [Author!]
   cameraOperatorsCount(where: AuthorWhereInput! = {}): Int
-  manualOrderOfCameraOperators: JSON
   designers(
     where: AuthorWhereInput! = {}
     orderBy: [AuthorOrderByInput!]! = []
@@ -1381,7 +1378,6 @@ type Post {
     skip: Int! = 0
   ): [Author!]
   designersCount(where: AuthorWhereInput! = {}): Int
-  manualOrderOfDesigners: JSON
   engineers(
     where: AuthorWhereInput! = {}
     orderBy: [AuthorOrderByInput!]! = []
@@ -1389,7 +1385,6 @@ type Post {
     skip: Int! = 0
   ): [Author!]
   engineersCount(where: AuthorWhereInput! = {}): Int
-  manualOrderOfEngineers: JSON
   dataAnalysts(
     where: AuthorWhereInput! = {}
     orderBy: [AuthorOrderByInput!]! = []
@@ -1397,7 +1392,6 @@ type Post {
     skip: Int! = 0
   ): [Author!]
   dataAnalystsCount(where: AuthorWhereInput! = {}): Int
-  manualOrderOfDataAnalysts: JSON
   otherByline: String
   leadingEmbeddedCode: String
   heroVideo: Video
@@ -1434,7 +1428,6 @@ type Post {
     skip: Int! = 0
   ): [Post!]
   relatedPostsCount(where: PostWhereInput! = {}): Int
-  manualOrderOfRelatedPosts: JSON
   data(
     where: DataSetWhereInput! = {}
     orderBy: [DataSetOrderByInput!]! = []
@@ -1463,6 +1456,20 @@ type Post {
   updatedAt: DateTime
   createdBy: User
   updatedBy: User
+  manualOrderOfWriters: JSON
+  writersInInputOrder: [Author]
+  manualOrderOfPhotographers: JSON
+  photographersInInputOrder: [Author]
+  manualOrderOfCameraOperators: JSON
+  cameraOperatorsInInputOrder: [Author]
+  manualOrderOfDesigners: JSON
+  designersInInputOrder: [Author]
+  manualOrderOfEngineers: JSON
+  engineersInInputOrder: [Author]
+  manualOrderOfDataAnalysts: JSON
+  dataAnalystsInInputOrder: [Author]
+  manualOrderOfRelatedPosts: JSON
+  relatedPostsInInputOrder: [Post]
 }
 
 input PostWhereUniqueInput {
@@ -1572,17 +1579,11 @@ input PostUpdateInput {
   publishTime: DateTime
   categories: CategoryRelateToManyForUpdateInput
   writers: AuthorRelateToManyForUpdateInput
-  manualOrderOfWriters: JSON
   photographers: AuthorRelateToManyForUpdateInput
-  manualOrderOfPhotographers: JSON
   cameraOperators: AuthorRelateToManyForUpdateInput
-  manualOrderOfCameraOperators: JSON
   designers: AuthorRelateToManyForUpdateInput
-  manualOrderOfDesigners: JSON
   engineers: AuthorRelateToManyForUpdateInput
-  manualOrderOfEngineers: JSON
   dataAnalysts: AuthorRelateToManyForUpdateInput
-  manualOrderOfDataAnalysts: JSON
   otherByline: String
   leadingEmbeddedCode: String
   heroVideo: VideoRelateToOneForUpdateInput
@@ -1601,7 +1602,6 @@ input PostUpdateInput {
   readingTime: Int
   collabration: CollaborationRelateToManyForUpdateInput
   relatedPosts: PostRelateToManyForUpdateInput
-  manualOrderOfRelatedPosts: JSON
   data: DataSetRelateToManyForUpdateInput
   ogTitle: String
   ogDescription: String
@@ -1618,6 +1618,13 @@ input PostUpdateInput {
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
   updatedBy: UserRelateToOneForUpdateInput
+  manualOrderOfWriters: JSON
+  manualOrderOfPhotographers: JSON
+  manualOrderOfCameraOperators: JSON
+  manualOrderOfDesigners: JSON
+  manualOrderOfEngineers: JSON
+  manualOrderOfDataAnalysts: JSON
+  manualOrderOfRelatedPosts: JSON
 }
 
 input CategoryRelateToManyForUpdateInput {
@@ -1674,17 +1681,11 @@ input PostCreateInput {
   publishTime: DateTime
   categories: CategoryRelateToManyForCreateInput
   writers: AuthorRelateToManyForCreateInput
-  manualOrderOfWriters: JSON
   photographers: AuthorRelateToManyForCreateInput
-  manualOrderOfPhotographers: JSON
   cameraOperators: AuthorRelateToManyForCreateInput
-  manualOrderOfCameraOperators: JSON
   designers: AuthorRelateToManyForCreateInput
-  manualOrderOfDesigners: JSON
   engineers: AuthorRelateToManyForCreateInput
-  manualOrderOfEngineers: JSON
   dataAnalysts: AuthorRelateToManyForCreateInput
-  manualOrderOfDataAnalysts: JSON
   otherByline: String
   leadingEmbeddedCode: String
   heroVideo: VideoRelateToOneForCreateInput
@@ -1703,7 +1704,6 @@ input PostCreateInput {
   readingTime: Int
   collabration: CollaborationRelateToManyForCreateInput
   relatedPosts: PostRelateToManyForCreateInput
-  manualOrderOfRelatedPosts: JSON
   data: DataSetRelateToManyForCreateInput
   ogTitle: String
   ogDescription: String
@@ -1720,6 +1720,13 @@ input PostCreateInput {
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput
   updatedBy: UserRelateToOneForCreateInput
+  manualOrderOfWriters: JSON
+  manualOrderOfPhotographers: JSON
+  manualOrderOfCameraOperators: JSON
+  manualOrderOfDesigners: JSON
+  manualOrderOfEngineers: JSON
+  manualOrderOfDataAnalysts: JSON
+  manualOrderOfRelatedPosts: JSON
 }
 
 input CategoryRelateToManyForCreateInput {

--- a/packages/readr/schema.prisma
+++ b/packages/readr/schema.prisma
@@ -327,17 +327,11 @@ model Post {
   publishTime                  DateTime?
   categories                   Category[]        @relation("Category_relatedPost")
   writers                      Author[]          @relation("Author_posts")
-  manualOrderOfWriters         Json?
   photographers                Author[]          @relation("Post_photographers")
-  manualOrderOfPhotographers   Json?
   cameraOperators              Author[]          @relation("Post_cameraOperators")
-  manualOrderOfCameraOperators Json?
   designers                    Author[]          @relation("Post_designers")
-  manualOrderOfDesigners       Json?
   engineers                    Author[]          @relation("Post_engineers")
-  manualOrderOfEngineers       Json?
   dataAnalysts                 Author[]          @relation("Post_dataAnalysts")
-  manualOrderOfDataAnalysts    Json?
   otherByline                  String?
   leadingEmbeddedCode          String            @default("")
   heroVideo                    Video?            @relation("Post_heroVideo", fields: [heroVideoId], references: [id])
@@ -359,7 +353,6 @@ model Post {
   readingTime                  Int?
   collabration                 Collaboration[]   @relation("Collaboration_posts")
   relatedPosts                 Post[]            @relation("Post_relatedPosts")
-  manualOrderOfRelatedPosts    Json?
   data                         DataSet[]         @relation("DataSet_relatedPosts")
   ogTitle                      String?
   ogDescription                String?
@@ -380,6 +373,13 @@ model Post {
   createdById                  Int?              @map("createdBy")
   updatedBy                    User?             @relation("Post_updatedBy", fields: [updatedById], references: [id])
   updatedById                  Int?              @map("updatedBy")
+  manualOrderOfWriters         Json?
+  manualOrderOfPhotographers   Json?
+  manualOrderOfCameraOperators Json?
+  manualOrderOfDesigners       Json?
+  manualOrderOfEngineers       Json?
+  manualOrderOfDataAnalysts    Json?
+  manualOrderOfRelatedPosts    Json?
   from_EditorChoice_choices    EditorChoice[]    @relation("EditorChoice_choices")
   from_Post_relatedPosts       Post[]            @relation("Post_relatedPosts")
   from_Feature_featurePost     Feature[]         @relation("Feature_featurePost")


### PR DESCRIPTION
### 問題描述
KeystoneJS 6 的 relationship 並不會紀錄使用者輸入的順序，K6 的順序是由存入資料庫時所產生的 id 來決定。
但因為編輯台有「紀錄輸入順序」的需求，例如：一篇「文章」（`post`）在輸入「多位作者」（`writers`）時，會希望透過輸入的順序來區分有第一作者、第二作者。
然而，因為 K6 的 relationship field 沒有紀錄「編輯輸入作者時的順序」，所以 query 出來的作者資料，並不會照編輯的設想去排列。

### 解決辦法
透過 `@readr-media/lilith/core` 提供的 `addManualOrderRelationshipFields` function，在 list object 上加入 `manualOrderOfWriters` 和 `writersInInputOrder` （延續上述範例）兩個 fields；並且針對 `resolveInput` hook 添加邏輯，將 input order 存入 `manualOrderOfWriters`。

而 `authorsInInputOrder` virtual field 則可以提供 GQL schema 和 resolver，將 `manualOrderOfWriters` 和 `writers` 兩個欄位的值排序，依照編輯所輸入的排序回傳。