### PR TITLE
feat(draft-renderer): add `insertRecommend` props & bump version to `1.2.0-alpha.16`

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.2.0-alpha.15",
+  "version": "1.2.0-alpha.16",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/readr/block-renderers/related-post-block.tsx
+++ b/packages/draft-renderer/src/website/readr/block-renderers/related-post-block.tsx
@@ -9,6 +9,8 @@ const RelatedPostWrapper = styled.div`
   border: 2px solid #04295e;
   border-width: 2px 2px 2px 12px;
   padding: 16px;
+  ${({ theme }) => theme.margin.default};
+
   ${({ theme }) => theme.breakpoint.md} {
     padding: 24px;
   }
@@ -29,16 +31,21 @@ const RelatedPostItem = styled.div`
   display: flex;
 `
 const RelatedPostAnchorWrapper = styled.a`
-  display: flex;
   text-decoration: none;
+  display: inline-block;
+  margin: 12px 0 0;
+
+  &:hover span {
+    border-bottom: 2px solid #04295e;
+  }
 `
 
 const RelatedPost = styled.span`
   color: rgba(0, 9, 40, 0.87);
   font-size: 18px;
   line-height: 1.6;
-  margin: 12px 0 0;
   border-bottom: 2px solid #ebf02c;
+  padding-bottom: 2px;
 `
 
 export function RelatedPostBlock(entity: DraftEntityInstance) {

--- a/packages/draft-renderer/src/website/readr/types/index.ts
+++ b/packages/draft-renderer/src/website/readr/types/index.ts
@@ -1,0 +1,36 @@
+type ResizedImages = {
+  original?: string
+  w480?: string
+  w800?: string
+  w1200?: string
+  w1600?: string
+  w2400?: string
+}
+
+type PhotoWithResizedOnly = { resized: ResizedImages | null }
+
+enum ValidPostStyle {
+  NEWS = 'news',
+  FRAME = 'frame',
+  BLANK = 'blank',
+  REPORT = 'report',
+  PROJECT3 = 'project3',
+  EMBEDDED = 'embedded',
+  REVIEW = 'review',
+  MEMO = 'memo',
+  DUMMY = 'dummy',
+  CARD = 'card',
+  QA = 'qa',
+  SCROLLABLE_VIDEO = 'scrollablevideo',
+}
+
+export type Post = {
+  id: string
+  slug: string
+  style: ValidPostStyle
+  title: string // alias to `name`
+  publishTime: string
+  readingTime: number
+  heroImage: PhotoWithResizedOnly | null
+  ogImage: PhotoWithResizedOnly | null
+}

--- a/packages/draft-renderer/src/website/readr/utils/index.ts
+++ b/packages/draft-renderer/src/website/readr/utils/index.ts
@@ -1,6 +1,10 @@
 import { RawDraftContentState } from 'draft-js'
+// eslint-disable-next-line prettier/prettier
+import type { Post } from '../types'
 
-const hasContentInRawContentBlock = (rawContentBlock: RawDraftContentState) => {
+const hasContentInRawContentBlock = (
+  rawContentBlock?: RawDraftContentState
+) => {
   if (
     !rawContentBlock ||
     !rawContentBlock.blocks ||
@@ -22,14 +26,16 @@ const hasContentInRawContentBlock = (rawContentBlock: RawDraftContentState) => {
   return defaultBlockHasContent
 }
 
-const removeEmptyContentBlock = (rawContentBlock: RawDraftContentState) => {
+const removeEmptyContentBlock = (
+  rawContentBlock?: RawDraftContentState
+): any => {
   const hasContent = hasContentInRawContentBlock(rawContentBlock)
   if (!hasContent) {
     throw new Error(
       'There is no content in rawContentBlock, please check again.'
     )
   }
-  const blocksWithHideEmptyBlock = rawContentBlock.blocks
+  const blocksWithHideEmptyBlock = rawContentBlock?.blocks
     .map((block) => {
       if (block.type === 'atomic' || block.text) {
         return block
@@ -42,4 +48,115 @@ const removeEmptyContentBlock = (rawContentBlock: RawDraftContentState) => {
   return { ...rawContentBlock, blocks: blocksWithHideEmptyBlock }
 }
 
-export { hasContentInRawContentBlock, removeEmptyContentBlock }
+const insertRecommendInContent = (
+  content: RawDraftContentState,
+  insertRecommend: Post[]
+) => {
+  const relatedPostsEntityMaps = insertRecommend?.map((post: Post) => ({
+    data: {
+      posts: [
+        {
+          heroImage: post?.heroImage || {},
+          id: post?.id || '',
+          name: post?.title || '',
+          ogImage: post?.ogImage || null,
+          slug: post?.slug || '',
+          subtitle: null,
+        },
+      ],
+    },
+    type: 'RELATEDPOST',
+    mutability: 'IMMUTABLE',
+  }))
+
+  const insertRelatedEntities = relatedPostsEntityMaps.reduce(
+    (accumulator, current) => {
+      // +1000 to increase diversity to avoid `key` duplication
+      const entityKey = Number(current?.data?.posts[0].id) + 1000
+      return {
+        ...accumulator,
+        [entityKey]: current,
+      }
+    },
+    {}
+  )
+
+  const entityMapWithInsertRecommend = {
+    ...content.entityMap,
+    ...insertRelatedEntities,
+  }
+
+  const relatedPostsBlocks = insertRecommend.map(
+    (post: Post, index: number) => {
+      // +1000 to increase diversity to avoid `key` duplication
+      const entityKey = Number(post.id) + 1000
+      return {
+        key: `insertRecommend-${index}`,
+        data: {},
+        text: ' ', //notice: if text: '' will show error
+        type: 'atomic',
+        depth: 0,
+        entityRanges: [{ key: entityKey, length: 1, offset: 0 }],
+        inlineStyleRanges: [],
+      }
+    }
+  )
+
+  function insertRecommendBlocks(data: any) {
+    let i = 0
+    let count = 0
+
+    // B: insert recommends based on related-posts amount
+    const paragraphs = data?.filter(
+      (item: any) => item?.type === 'unstyled' && item?.text.length
+    )
+
+    const divideAmount =
+      Math.round(paragraphs?.length / (relatedPostsBlocks.length + 1)) || 0
+
+    if (data?.length) {
+      while (i < data.length && divideAmount) {
+        if (data[i]?.type === 'unstyled' && data[i]?.text.length) {
+          count++
+
+          const item = relatedPostsBlocks[count / divideAmount - 1]
+          if (count % divideAmount === 0 && item) {
+            data.splice(i + 1, 0, item)
+          }
+        }
+        i++
+      }
+    }
+
+    // A: insert recommends each 5 paragraphs (same as READr 2.0)
+    // if (data?.length) {
+    //   while (i < data.length) {
+    //     if (data[i]?.type === 'unstyled' && data[i]?.text.length) {
+    //       count++
+
+    //       const item = relatedPostsBlocks[count / 5 - 1]
+    //       if (count % 5 === 0 && item) {
+    //         data.splice(i + 1, 0, item)
+    //       }
+    //     }
+    //     i++
+    //   }
+    // }
+    return data
+  }
+
+  const rawContent = removeEmptyContentBlock(content)
+
+  const contentWithInsertRecommend: any = {
+    blocks: insertRecommendBlocks(rawContent?.blocks),
+    entityMap: entityMapWithInsertRecommend,
+  }
+
+  return contentWithInsertRecommend
+}
+
+export {
+  hasContentInRawContentBlock,
+  insertRecommendInContent,
+  removeEmptyContentBlock,
+}


### PR DESCRIPTION
### 新增
- 新增 props `insertRecommend`，可傳入「推薦閱讀」文章資料。
- utils 新增 `insertRecommendInContent` 方法，依據「推薦閱讀」文章數量，穿插至原有內文的 blocks/entityMap 中。
- 新增 `types/index.ts`，存放常用 type 設定。 
- `@mirrormedia/lilith-draft-renderer` 版本升至 `1.2.0-alpha.16`。

### 調整
- 原先是 export `removeEmptyContentBlock` 方法於 READr 的文章頁使用，考量到目前文章頁資料皆會使用到 `removeEmptyContentBlock`，因此修改成讓資料統一於  `draft-renderer/readr` 中處理，文章頁僅需傳原始資料（ ex: postData.content ) 即可，提高易讀性。
- `draft-renderer/readr` 會統一對傳入的 `rawContentBlock` 進行驗證與執行 `removeEmptyContentBlock` ，並依照是否有 `insertRecommend` 參數，決定是否需要執行 `insertRecommendInContent`。