### PR TITLE
fix(draft-renderer/readr): modify recommends insert calculation method

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.2.0-alpha.16",
+  "version": "1.2.0-alpha.17",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/readr/utils/index.ts
+++ b/packages/draft-renderer/src/website/readr/utils/index.ts
@@ -111,10 +111,18 @@ const insertRecommendInContent = (
       (item: any) => item?.type === 'unstyled' && item?.text.length
     )
 
-    const divideAmount =
-      Math.round(paragraphs?.length / (relatedPostsBlocks.length + 1)) || 0
+    let divideAmount
 
-    if (data?.length) {
+    //if relatedPosts amounts far more than paragraphs amounts, insert a recommend every other paragraph until paragraphs end.
+    if (relatedPostsBlocks.length) {
+      divideAmount =
+        Math.round(paragraphs?.length / (relatedPostsBlocks.length + 1)) ||
+        (paragraphs?.length ? 1 : 0)
+    } else {
+      divideAmount = 0
+    }
+
+    if (paragraphs?.length) {
       while (i < data.length && divideAmount) {
         if (data[i]?.type === 'unstyled' && data[i]?.text.length) {
           count++


### PR DESCRIPTION
### 調整
- 調整「推薦閱讀」穿插內文計算方式：

   - 透過 **內文總段落數 /  (相關報導數量+1)** 後四捨五入取整數值，決定穿插間距。
   - 當 **相關報導** 數量遠大於 **內文總段落數** 時（四捨五入為 0 時），改為每隔 1 段穿插一篇推薦閱讀，直至內文結束。

- `@mirrormedia/lilith-draft-renderer` 版本升至 `1.2.0-alpha.17`。