### PR TITLE
feat(draft-renderer): add shared-style for mirrormedia, not preload image

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.2.0-alpha.17",
+  "version": "1.2.0-alpha.18",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/divider-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/divider-block.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
-
+import { defaultMarginTop, defaultMarginBottom } from '../shared-style'
 const Divider = styled.hr`
   border-top: 1px solid #9d9d9d;
-  margin-top: 32px;
-  margin-bottom: 32px;
+  ${defaultMarginTop}
+  ${defaultMarginBottom}
 `
 
 export const DividerBlock = () => {

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
@@ -170,7 +170,7 @@ export function ImageBlock(
         objectFit={'contain'}
         alt={name}
         rwd={{ mobile: '100vw', tablet: '640px', default: '640px' }}
-        priority={true}
+        priority={false}
       ></CustomImage>
       {desc ? (
         <Figcaption

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
@@ -4,6 +4,7 @@ import { DraftEntityInstance } from 'draft-js'
 import defaultImage from '../assets/default-og-img.png'
 import loadingImage from '../assets/loading.gif'
 import CustomImage from '@readr-media/react-image'
+import { defaultMarginTop, defaultMarginBottom } from '../shared-style'
 import {
   disableBodyScroll,
   enableBodyScroll,
@@ -42,8 +43,8 @@ const figcaptionLayoutWide = css`
 const Figure = styled.figure`
   margin-block: unset;
   margin-inline: unset;
-  margin-top: 20px;
-  margin-bottom: 20px;
+  ${defaultMarginTop}
+  ${defaultMarginBottom}
   .readr-media-react-image {
     cursor: pointer;
   }

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/info-box-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/info-box-block.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ContentBlock, ContentState } from 'draft-js'
 import styled, { css } from 'styled-components'
+import { defaultMarginTop, defaultMarginBottom } from '../shared-style'
 
 //for setting background color info box
 const backgroundColorNormal = '#054f77'
@@ -32,8 +33,8 @@ const infoBoxWrapperWide = css`
 
 const InfoBoxRenderWrapper = styled.div`
   padding: 32px 30px 22px 30px;
-  margin-top: 20px;
-  margin-bottom: 20px;
+  ${defaultMarginTop}
+  ${defaultMarginBottom}
   position: relative;
   > h2 {
     font-size: 20px;

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react'
 import styled from 'styled-components'
-import { DraftEntityInstance } from 'draft-js'
+import { EntityInstance } from 'draft-js'
+import { defaultMarginTop, defaultMarginBottom } from '../shared-style'
 import CustomImage from '@readr-media/react-image'
 const Image = styled.img`
   width: 100%;
@@ -35,8 +36,8 @@ const sliderWidth = '100%'
 const slidesOffset = 2
 
 const Wrapper = styled.figure`
-  margin-top: 20px;
-  margin-bottom: 20px;
+  ${defaultMarginTop}
+  ${defaultMarginBottom}
 `
 
 const SlideshowV2 = styled.figure`
@@ -127,7 +128,7 @@ const Desc = styled.figcaption`
 `
 
 // support old version of slideshow without delay propertiy
-export function SlideshowBlock(entity: DraftEntityInstance) {
+export function SlideshowBlock(entity: EntityInstance) {
   const images = entity.getData()
   return (
     <Figure>
@@ -148,7 +149,7 @@ export function SlideshowBlock(entity: DraftEntityInstance) {
  * Inspired by [Works of Claudia Conceicao](https://codepen.io/cconceicao/pen/PBQawy),
  * [twreporter slideshow component](https://github.com/twreporter/twreporter-npm-packages/blob/master/packages/react-article-components/src/components/body/slideshow/index.js)
  */
-export function SlideshowBlockV2(entity: DraftEntityInstance) {
+export function SlideshowBlockV2(entity: EntityInstance) {
   const slidesBoxRef = useRef<HTMLDivElement>(null)
   /** Current index of the displayed slide */
   const [indexOfCurrentImage, setIndexOfCurrentImage] = useState(0)

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
@@ -202,7 +202,7 @@ export function SlideshowBlockV2(entity: EntityInstance) {
           images={item}
           key={index}
           objectFit={'contain'}
-          priority={true}
+          priority={false}
         />
       )),
     [slidesWithClone]

--- a/packages/draft-renderer/src/website/mirrormedia/draft-renderer.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/draft-renderer.tsx
@@ -9,6 +9,7 @@ import {
   CUSTOM_STYLE_PREFIX_FONT_COLOR,
   CUSTOM_STYLE_PREFIX_BACKGROUND_COLOR,
 } from '../../draft-js/const'
+import { defaultMarginBottom } from './shared-style'
 import theme from './theme'
 
 const draftEditorLineHeight = 2
@@ -17,9 +18,6 @@ const draftEditorLineHeight = 2
  * So we use this behavior to create spacing between blocks by assign margin-bottom of which.
  * However, some block should not set spacing (e.g. block in <li> and <blockquote>), so we need to unset its margin-top.
  */
-const defaultSpacingBetweenContent = css`
-  margin-bottom: 32px;
-`
 
 const noSpacingBetweenContent = {
   blockquote: css`
@@ -111,7 +109,7 @@ const DraftEditorWrapper = styled.div`
   line-height: ${draftEditorLineHeight};
 
   .public-DraftStyleDefault-block {
-    ${defaultSpacingBetweenContent}
+    ${defaultMarginBottom}
   }
 
   /* Draft built-in buttons' style */
@@ -145,7 +143,7 @@ const DraftEditorWrapper = styled.div`
   .public-DraftStyleDefault-ul {
     margin-left: 18px;
     list-style: none;
-    ${defaultSpacingBetweenContent}
+    ${defaultMarginBottom}
     .public-DraftStyleDefault-block {
       ${noSpacingBetweenContent.list}
     }
@@ -166,7 +164,7 @@ const DraftEditorWrapper = styled.div`
   }
   .public-DraftStyleDefault-ol {
     margin-left: 18px;
-    ${defaultSpacingBetweenContent}
+    ${defaultMarginBottom}
     .public-DraftStyleDefault-block {
       ${noSpacingBetweenContent.list}
     }

--- a/packages/draft-renderer/src/website/mirrormedia/shared-style/index.ts
+++ b/packages/draft-renderer/src/website/mirrormedia/shared-style/index.ts
@@ -1,0 +1,10 @@
+import { css } from 'styled-components'
+
+const defaultMarginTop = css`
+  margin-top: 32px;
+`
+const defaultMarginBottom = css`
+  margin-bottom: 32px;
+`
+
+export { defaultMarginBottom, defaultMarginTop }


### PR DESCRIPTION
## Notable Changes
1. 參考`/website/readr`的做法，於mirrormedia中新增一資料夾`/shared-style`，並新增兩個css `defaultMarginBottom`與`defaultMarginTop`，用於設定不同content block、atomic block的css間距。
2. 不預先載入slideshow與imageblock的圖片，以提升載入速度。