### PR TITLE
style(draft-renderer): adjust image-block width

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.2.0-alpha.20",
+  "version": "1.2.0-alpha.21",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
@@ -18,17 +18,26 @@ const imageFigureLayoutNormal = css`
 `
 const imageFigureLayoutWide = css`
   .readr-media-react-image {
+    position: relative;
+    max-width: calc(100% + 20px + 20px);
     width: 100vw;
-    max-width: 640px;
-    transform: translateX(min(50vw - 50% - 20px, 0px));
+    transform: translateX(-20px);
+    @media (min-width: 680px) {
+      max-width: 100%;
+      transform: translateX(0px);
+    }
   }
 `
 const imageFigureLayoutPremium = css`
   .readr-media-react-image {
+    position: relative;
+    max-width: calc(100% + 20px + 20px);
     width: 100vw;
-    max-width: 640px;
-
-    transform: translateX(min(50vw - 50% - 20px, 0px));
+    transform: translateX(-20px);
+    @media (min-width: 680px) {
+      max-width: 100%;
+      transform: translateX(0px);
+    }
   }
 `
 


### PR DESCRIPTION
## Notable Change
在draft-renderer中，圖片需要在特定的條件下滿版，原本的寫法雖能夠使得圖片滿版，但同時也會造成圖片寬度推擠容器寬度，導致頁面實際寬度變寬。這樣的影響是，在螢幕寬度<640px的情況下，桌機版瀏覽器的的X軸scrollbar會出現並且可被拖曳，但這應該是要避免的。
為了避免這樣的情形發生，改採用了最一開始的寫法，並微調css media-query，使得圖片在滿版的同時，不會推擠容器寬度。