### PR TITLE
fix(editools): update liveblogQuery.ts. Remove `ref` field due to gql schema change

### DIFF
--- a/packages/editools/lists/queries/liveblogQuery.ts
+++ b/packages/editools/lists/queries/liveblogQuery.ts
@@ -10,7 +10,6 @@ export function buildLiveBlogQuery(take?: number) {
     heroImage {
       name
       imageFile {
-        ref
         url
       }
     }
@@ -35,7 +34,6 @@ export function buildLiveBlogQuery(take?: number) {
       heroImage {
         name
         imageFile {
-          ref
           url
           width
           height


### PR DESCRIPTION
Due to this change https://github.com/mirror-media/Lilith/pull/379, GQL schema has changed.
There is no `ref` field anymore. 
Therefore, this patch fixes wrong GQL query.