### PR TITLE
style(draft-renderer/mm): adjust style of audio and embedded code block

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.2.0-alpha.27",
+  "version": "1.2.0-alpha.28",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/audio-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/audio-block.tsx
@@ -5,9 +5,26 @@ import AmpAudioBlock from './amp/amp-audio-block'
 
 const AudioWrapper = styled.div`
   display: flex;
-  gap: 20px;
+  gap: 8px;
+  align-items: start;
+  flex-direction: column;
+  ${({ theme }) => theme.breakpoint.md} {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 28px;
+  }
 `
-const Audio = styled.audio``
+const AudioName = styled.p`
+  color: #979797;
+  font-size: 14px;
+  line-height: 2;
+  font-weight: 500;
+`
+const Audio = styled.audio`
+  width: 100%;
+  max-width: 300px;
+`
 
 type ImageEntity = {
   id: string
@@ -50,7 +67,7 @@ export function AudioBlock(entity: DraftEntityInstance, contentLayout: string) {
 
   return (
     <AudioWrapper>
-      <p>{audio?.name}</p>
+      <AudioName>{audio?.name}</AudioName>
       {AudioJsx}
     </AudioWrapper>
   )

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/embedded-code-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/embedded-code-block.tsx
@@ -2,9 +2,12 @@ import React, { useEffect, useRef } from 'react'
 import { DraftEntityInstance } from 'draft-js'
 import styled from 'styled-components'
 import AmpEmbeddedCodeBlock from './amp/amp-embedded-code-block'
-
+import { defaultMarginTop, defaultMarginBottom } from '../shared-style'
 export const Block = styled.div`
   position: relative;
+  ${defaultMarginTop}
+  ${defaultMarginBottom}
+  
   /* styles for image link */
   img.img-responsive {
     margin: 0 auto;


### PR DESCRIPTION
## Notable Change
1. 調整atomic block renderer `embedded-code-block`樣式
2. 調整atomic block renderer `audio-block`樣式
3. draft-renderer升版至 `1.2.0-alpha.28`