### PR TITLE
refactor(draft-renderer/slideshow): improve user experience when dragging

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -22,7 +22,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@readr-media/react-image": "^1.5.1",
+    "@readr-media/react-image": "1.6.0",
     "body-scroll-lock": "3.1.5",
     "draft-js": "^0.11.7",
     "node-html-parser": "^6.1.5"

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.2.0-alpha.31",
+  "version": "1.2.0-alpha.32",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,6 +3753,11 @@
     styled-components "5.3.5"
     uuid "^8.3.2"
 
+"@readr-media/react-image@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-1.6.0.tgz#1bff81cdaa8b14f255c22b2504df1d09fc783223"
+  integrity sha512-k4FOxVlAdvsFY5zP7nczs11LrJ3mA2T6Y7rwoTjpA9GMhlf3wtLWD84/XwcsGXNvHg0gbxQtmOcNvKE1LsZxwg==
+
 "@readr-media/react-image@^1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-1.5.1.tgz#d04b809416be6a1432a0a3154f2641292d7b6b8d"


### PR DESCRIPTION
## Notable Change
1. 調整draft-renderer中slideshow的程式碼，優化lazy-load觸發條件。
2. 由於lazy-load會導致在特定條件下，圖片會有一閃的狀況發生，所以針對會發生該狀況的圖片，不實作lazy-load（詳細說明註解於[程式碼內](https://github.com/mirror-media/Lilith/pull/431/commits/d3d1f3a373ebbad1696092ad529ea7525eae7d7d#diff-bb63b5da313f4e59069c01475bda6c39bee2277e88e2025e66e7fe1014a44025R204-R215)。）
3. 一閃狀況如影片所示

https://github.com/mirror-media/Lilith/assets/85677992/6458e496-6047-41eb-ac1d-169ce9adab16

