### PR TITLE
fix(mirrormedia): adjust the relationship between Video and Post

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -296,7 +296,7 @@ const listConfigurations = list({
     }),
     related_videos: relationship({
       label: '相關影片',
-      ref: 'Video',
+      ref: 'Video.related_posts',
       many: true,
     }),
     manualOrderOfRelatedVideos: json({

--- a/packages/mirrormedia/lists/Video.ts
+++ b/packages/mirrormedia/lists/Video.ts
@@ -52,7 +52,7 @@ const listConfigurations = list({
     }),
     related_posts: relationship({
       label: '相關文章',
-      ref: 'Post',
+      ref: 'Post.related_videos',
       many: true,
     }),
     manualOrderOfRelatedPosts: json({

--- a/packages/mirrormedia/migrations/20230707042603_adjust_relationship_between_videos_and_posts/migration.sql
+++ b/packages/mirrormedia/migrations/20230707042603_adjust_relationship_between_videos_and_posts/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the `_Video_related_posts` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "_Video_related_posts" DROP CONSTRAINT "_Video_related_posts_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Video_related_posts" DROP CONSTRAINT "_Video_related_posts_B_fkey";
+
+-- DropTable
+DROP TABLE "_Video_related_posts";

--- a/packages/mirrormedia/schema.prisma
+++ b/packages/mirrormedia/schema.prisma
@@ -65,7 +65,6 @@ model Post {
   updatedById                Int?           @map("updatedBy")
   from_Post_relateds         Post[]         @relation("Post_relateds")
   from_EditorChoice_choices  EditorChoice[] @relation("EditorChoice_choices")
-  from_Video_related_posts   Video[]        @relation("Video_related_posts")
 
   @@index([state])
   @@index([publishedDate])
@@ -315,7 +314,7 @@ model Video {
   heroImage                 Photo?    @relation("Video_heroImage", fields: [heroImageId], references: [id])
   heroImageId               Int?      @map("heroImage")
   isFeed                    Boolean   @default(false)
-  related_posts             Post[]    @relation("Video_related_posts")
+  related_posts             Post[]    @relation("Post_related_videos")
   manualOrderOfRelatedPosts Json?
   state                     String?   @default("draft")
   publishedDate             DateTime?
@@ -328,7 +327,6 @@ model Video {
   updatedBy                 User?     @relation("Video_updatedBy", fields: [updatedById], references: [id])
   updatedById               Int?      @map("updatedBy")
   from_Post_heroVideo       Post[]    @relation("Post_heroVideo")
-  from_Post_related_videos  Post[]    @relation("Post_related_videos")
 
   @@index([heroImageId])
   @@index([state])


### PR DESCRIPTION
Take the relationship between Post and Tag for reference.

Thank Tsuki for providing the following references:
> https://github.com/mirror-media/Lilith/blob/e458a562af733b8b7a6a4cdf2f12c67383ea1816/packages/mirrormedia/lists/Tag.ts#L26
> https://github.com/mirror-media/Lilith/blob/e458a562af733b8b7a6a4cdf2f12c67383ea1816/packages/mirrormedia/lists/Post.ts#L282