### PR TITLE
feat(mirrormedia): add virtual field for resized webp images

### DIFF
--- a/packages/mirrormedia/lists/Image.ts
+++ b/packages/mirrormedia/lists/Image.ts
@@ -97,6 +97,81 @@ const listConfigurations = list({
         query: '{ original w480 w800 w1200 w1600 w2400 }',
       },
     }),
+    resizedWebp: virtual({
+      field: graphql.field({
+        type: graphql.object<{
+          original: string
+          w480: string
+          w800: string
+          w1200: string
+          w1600: string
+          w2400: string
+        }>()({
+          name: 'ResizedWebPImages',
+          fields: {
+            original: graphql.field({ type: graphql.String }),
+            w480: graphql.field({ type: graphql.String }),
+            w800: graphql.field({ type: graphql.String }),
+            w1200: graphql.field({ type: graphql.String }),
+            w1600: graphql.field({ type: graphql.String }),
+            w2400: graphql.field({ type: graphql.String }),
+          },
+        }),
+        resolve(item: Record<string, unknown>) {
+          const empty = {
+            original: '',
+            w480: '',
+            w800: '',
+            w1200: '',
+            w1600: '',
+            w2400: '',
+          }
+
+          // For backward compatibility,
+          // this image item is uploaded via `GCSFile` custom field.
+          if (item?.urlOriginal) {
+            return Object.assign(empty, {
+              original: item.urlOriginal,
+            })
+          }
+
+          const rtn: Record<string, string> = {}
+          const filename = item?.imageFile_id
+
+          if (!filename) {
+            return empty
+          }
+
+          const extension = '.webP'
+
+          const width =
+            typeof item?.imageFile_width === 'number' ? item.imageFile_width : 0
+          const height =
+            typeof item?.imageFile_height === 'number'
+              ? item.imageFile_height
+              : 0
+
+          const resizedTargets =
+            width >= height
+              ? ['w480', 'w800', 'w1600', 'w2400']
+              : ['w480', 'w800', 'w1200', 'w1600']
+
+          resizedTargets.forEach((target) => {
+            rtn[
+              target
+            ] = `${config.googleCloudStorage.origin}/${config.googleCloudStorage.bucket}/images/${filename}-${target}${extension}`
+          })
+
+          rtn[
+            'original'
+          ] = `${config.googleCloudStorage.origin}/${config.googleCloudStorage.bucket}/images/${filename}${extension}`
+          return Object.assign(empty, rtn)
+        },
+      }),
+      ui: {
+        query: '{ original w480 w800 w1200 w1600 w2400 }',
+      },
+    }),
     file: file({
       label: '檔案（建議長邊大於 2000 pixel）',
       storage: 'files',

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -1237,6 +1237,7 @@ type Photo {
   imageFile: ImageFieldOutput
   waterMark: Boolean
   resized: ResizedImages
+  resizedWebp: ResizedWebPImages
   file: FileFieldOutput
   urlOriginal: String
   topicKeywords: String
@@ -1264,6 +1265,15 @@ enum ImageExtension {
 }
 
 type ResizedImages {
+  original: String
+  w480: String
+  w800: String
+  w1200: String
+  w1600: String
+  w2400: String
+}
+
+type ResizedWebPImages {
   original: String
   w480: String
   w800: String


### PR DESCRIPTION
仿照 Resized 
新增了一個 ResizedWebp

Image processor 那邊也處理好
同樣尺寸的圖檔會有兩種格式可用
原檔格式及 webP