### PR TITLE
feat(draft-renderer): add AmpSlideshowBlockV2

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.2.0-alpha.33",
+  "version": "1.2.0-alpha.34",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderer-fn.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderer-fn.tsx
@@ -16,6 +16,7 @@ const {
   VideoBlock,
   AudioBlock,
   YoutubeBlock,
+  AmpSlideshowBlockV2,
 } = blockRenderers
 
 const AtomicBlock = (props) => {
@@ -36,7 +37,9 @@ const AtomicBlock = (props) => {
       return SlideshowBlock(entity)
     }
     case 'slideshow-v2': {
-      return SlideshowBlockV2(entity)
+      return contentLayout === 'amp'
+        ? AmpSlideshowBlockV2(entity)
+        : SlideshowBlockV2(entity)
     }
     case 'EMBEDDEDCODE': {
       return EmbeddedCodeBlock(entity, contentLayout)

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
@@ -27,14 +27,13 @@ const Wrapper = styled.figure`
       outline: none;
     }
     &::before {
+      position: absolute;
       content: '';
       width: 16px;
       height: 16px;
       top: 50%;
-      transform: rotate(45deg) translateY(-50%);
       cursor: pointer;
       display: block;
-      position: absolute;
     }
   }
 

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
@@ -105,18 +105,17 @@ export function AmpSlideshowBlockV2(entity: EntityInstance) {
       >
         {images.map((slide) => {
           return (
-            <div key={slide.id}>
+            <figure key={slide.id}>
               <SlideImage>
                 <amp-img
                   class="contain"
                   src={slide?.resized?.original || defaultImage}
                   layout="fill"
-                  alt={slide?.name}
+                  alt={slide?.name || 'slide'}
                 ></amp-img>
               </SlideImage>
-
               <Desc>{slide.desc}</Desc>
-            </div>
+            </figure>
           )
         })}
       </amp-carousel>

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import styled from 'styled-components'
+import { EntityInstance } from 'draft-js'
+import { defaultMarginTop, defaultMarginBottom } from '../../shared-style'
+import defaultImage from '../../assets/default-og-img.png'
+
+const sliderWidth = '100%'
+
+const Wrapper = styled.figure`
+  ${defaultMarginTop}
+  ${defaultMarginBottom}
+  position: relative;
+  min-height: 58.75vw;
+  ${({ theme }) => theme.breakpoint.md} {
+    min-height: 428px;
+  }
+
+  .amp-carousel-button {
+    position: absolute;
+    top: 50%;
+    z-index: 1;
+    transform: translateY(-50%);
+    color: white;
+    height: 100%;
+    width: 40px;
+    background: none;
+    &:focus {
+      border: none;
+      outline: none;
+    }
+    &::before {
+      content: '';
+      width: 16px;
+      height: 16px;
+      top: 50%
+      transform: rotate(45deg) translateY(-50%);
+      cursor: pointer;
+      display: block;
+      position: absolute;
+    }
+  }
+
+  .amp-carousel-button-prev {
+    left: 0;
+    &::before {
+      border-left: 2px solid #fff;
+      border-bottom: 2px solid #fff;
+      left: 9px;
+      transform: rotate(45deg) translate(0, -50%);
+    }
+  }
+
+  .amp-carousel-button-next {
+    right: 0;
+    &::before {
+      content: ' ';
+      border-right: 2px solid #fff;
+      border-top: 2px solid #fff;
+      left: unset;
+      transform: rotate(45deg) translate(-50%, 0);
+      right: 9px;
+    }
+  }
+`
+
+const SlideImage = styled.div`
+  position: relative;
+  object-position: center center;
+  background-color: rgba(0, 0, 0, 0.1);
+  max-width: ${sliderWidth};
+  min-width: ${sliderWidth};
+  max-height: 58.75vw;
+  min-height: 58.75vw;
+  ${({ theme }) => theme.breakpoint.md} {
+    min-width: 100%;
+    min-height: 428px;
+    max-width: 100%;
+    max-height: 428px;
+  }
+
+  .contain img {
+    object-fit: contain;
+  }
+`
+
+// const Desc = styled('amp-fit-text')`
+//   font-size: 14px;
+//   line-height: 1.8;
+//   font-weight: 400;
+//   color: rgba(0, 0, 0, 0.5);
+//   margin-top: 20px;
+//   min-height: 1.8rem;
+//   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+//     'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+//     'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+// `
+
+export function AmpSlideshowBlockV2(entity: EntityInstance) {
+  const { images = [], delay = 2 } = entity.getData()
+
+  return (
+    <>
+      <Wrapper>
+        <amp-carousel
+          class="carousel1"
+          layout="fill"
+          type="slides"
+          autoplay=""
+          loop=""
+          control=""
+          delay={delay * 1000}
+          aria-label="Carousel"
+        >
+          {images.map((slide) => {
+            return (
+              <div key={slide.id} className="slide">
+                <SlideImage>
+                  <amp-img
+                    class="contain"
+                    src={slide?.resized?.original ?? defaultImage}
+                    layout="fill"
+                    alt={slide?.name}
+                  ></amp-img>
+                </SlideImage>
+
+                {/* <Desc layout="responsive" width="500" height="150">
+          {slide.desc}
+        </Desc> */}
+              </div>
+            )
+          })}
+        </amp-carousel>
+      </Wrapper>
+    </>
+  )
+}

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
@@ -4,15 +4,13 @@ import { EntityInstance } from 'draft-js'
 import { defaultMarginTop, defaultMarginBottom } from '../../shared-style'
 import defaultImage from '../../assets/default-og-img.png'
 
-const sliderWidth = '100%'
-
 const Wrapper = styled.figure`
   ${defaultMarginTop}
   ${defaultMarginBottom}
   position: relative;
-  min-height: 58.75vw;
+  height: 58.75vw;
   ${({ theme }) => theme.breakpoint.md} {
-    min-height: 428px;
+    height: 428px;
   }
 
   .amp-carousel-button {
@@ -67,15 +65,10 @@ const SlideImage = styled.div`
   position: relative;
   object-position: center center;
   background-color: rgba(0, 0, 0, 0.1);
-  max-width: ${sliderWidth};
-  min-width: ${sliderWidth};
-  max-height: 58.75vw;
-  min-height: 58.75vw;
+  width: 100%;
+  height: 58.75vw;
   ${({ theme }) => theme.breakpoint.md} {
-    min-width: 100%;
-    min-height: 428px;
-    max-width: 100%;
-    max-height: 428px;
+    height: 428px;
   }
 
   .contain img {
@@ -99,38 +92,35 @@ export function AmpSlideshowBlockV2(entity: EntityInstance) {
   const { images = [], delay = 2 } = entity.getData()
 
   return (
-    <>
-      <Wrapper>
-        <amp-carousel
-          class="carousel1"
-          layout="fill"
-          type="slides"
-          autoplay=""
-          loop=""
-          control=""
-          delay={delay * 1000}
-          aria-label="Carousel"
-        >
-          {images.map((slide) => {
-            return (
-              <div key={slide.id} className="slide">
-                <SlideImage>
-                  <amp-img
-                    class="contain"
-                    src={slide?.resized?.original ?? defaultImage}
-                    layout="fill"
-                    alt={slide?.name}
-                  ></amp-img>
-                </SlideImage>
+    <Wrapper>
+      <amp-carousel
+        layout="fill"
+        type="slides"
+        autoplay=""
+        loop=""
+        control=""
+        delay={delay * 1000}
+        aria-label="Carousel"
+      >
+        {images.map((slide) => {
+          return (
+            <div key={slide.id}>
+              <SlideImage>
+                <amp-img
+                  class="contain"
+                  src={slide?.resized?.original ?? defaultImage}
+                  layout="fill"
+                  alt={slide?.name}
+                ></amp-img>
+              </SlideImage>
 
-                {/* <Desc layout="responsive" width="500" height="150">
+              {/* <Desc layout="responsive" width="500" height="150">
           {slide.desc}
         </Desc> */}
-              </div>
-            )
-          })}
-        </amp-carousel>
-      </Wrapper>
-    </>
+            </div>
+          )
+        })}
+      </amp-carousel>
+    </Wrapper>
   )
 }

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
@@ -8,18 +8,18 @@ const Wrapper = styled.figure`
   ${defaultMarginTop}
   ${defaultMarginBottom}
   position: relative;
-  height: 58.75vw;
+  height: calc(58.75vw + 80px);
   ${({ theme }) => theme.breakpoint.md} {
-    height: 428px;
+    height: 508px;
   }
 
   .amp-carousel-button {
     position: absolute;
-    top: 50%;
+    top: calc(50% - 40px);
     z-index: 1;
     transform: translateY(-50%);
     color: white;
-    height: 100%;
+    height: calc(100% - 80px);
     width: 40px;
     background: none;
     &:focus {
@@ -75,17 +75,19 @@ const SlideImage = styled.div`
   }
 `
 
-// const Desc = styled('amp-fit-text')`
-//   font-size: 14px;
-//   line-height: 1.8;
-//   font-weight: 400;
-//   color: rgba(0, 0, 0, 0.5);
-//   margin-top: 20px;
-//   min-height: 1.8rem;
-//   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-//     'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-//     'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-// `
+const Desc = styled.figcaption`
+  font-size: 14px;
+  line-height: 1.8;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.5);
+  margin-top: 20px;
+  min-height: 1.8rem;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  max-height: 60px;
+  overflow: scroll;
+`
 
 export function AmpSlideshowBlockV2(entity: EntityInstance) {
   const { images = [], delay = 2 } = entity.getData()
@@ -113,9 +115,7 @@ export function AmpSlideshowBlockV2(entity: EntityInstance) {
                 ></amp-img>
               </SlideImage>
 
-              {/* <Desc layout="responsive" width="500" height="150">
-          {slide.desc}
-        </Desc> */}
+              <Desc>{slide.desc}</Desc>
             </div>
           )
         })}

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
@@ -30,7 +30,7 @@ const Wrapper = styled.figure`
       content: '';
       width: 16px;
       height: 16px;
-      top: 50%
+      top: 50%;
       transform: rotate(45deg) translateY(-50%);
       cursor: pointer;
       display: block;

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
@@ -109,7 +109,7 @@ export function AmpSlideshowBlockV2(entity: EntityInstance) {
               <SlideImage>
                 <amp-img
                   class="contain"
-                  src={slide?.resized?.original ?? defaultImage}
+                  src={slide?.resized?.original || defaultImage}
                   layout="fill"
                   alt={slide?.name}
                 ></amp-img>

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/index.ts
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/index.ts
@@ -13,6 +13,7 @@ import { TableBlock } from './table-block'
 import { VideoBlock } from './video-block'
 import { AudioBlock } from './audio-block'
 import { YoutubeBlock } from './youtube-block'
+import { AmpSlideshowBlockV2 } from './amp/amp-slideshow-block'
 
 export const blockRenderers = {
   BGImageBlock,
@@ -31,4 +32,5 @@ export const blockRenderers = {
   VideoBlock,
   AudioBlock,
   YoutubeBlock,
+  AmpSlideshowBlockV2,
 }


### PR DESCRIPTION
### 描述
- 新增 amp 用的 slideshow

### 問題
1. 還沒新增圖解部分，應該是因為 amp 主打載入比較快，蠻多地方都希望直接寫死高度。目前看起來無法達到「隨著文字行數變化高度」。[官方文件](https://amp.dev/documentation/examples/multimedia-animations/image_galleries_with_amp-carousel/) 的 `Caption with text overlay` 和 `Collapsible Image Captions with amp-bind` 感覺是妥協方法，另外也可參考 [該 codepen 範例](https://codepen.io/TwisterMc/pen/jLOrZL)，留個一點五行讓使用者 scroll。這裡想先進行技術詢問，如果 reviewer 也覺得沒有其他方法，我會再與需求方協調。
2. 希望有滑動效果！目前 [amp-carousel v0.2](https://amp.dev/documentation/components/amp-carousel-v0.2) 已經有了，但目前不確定在該專案中，該如何引入比較妥當？感謝！