### PR TITLE
refactor(draft-renderer): add fallback of amp-img and move amp component into SlideshowBlockV2

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.2.0-alpha.34",
+  "version": "1.2.0-alpha.35",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderer-fn.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderer-fn.tsx
@@ -16,7 +16,6 @@ const {
   VideoBlock,
   AudioBlock,
   YoutubeBlock,
-  AmpSlideshowBlockV2,
 } = blockRenderers
 
 const AtomicBlock = (props) => {
@@ -37,9 +36,7 @@ const AtomicBlock = (props) => {
       return SlideshowBlock(entity)
     }
     case 'slideshow-v2': {
-      return contentLayout === 'amp'
-        ? AmpSlideshowBlockV2(entity)
-        : SlideshowBlockV2(entity)
+      return SlideshowBlockV2(entity, contentLayout)
     }
     case 'EMBEDDEDCODE': {
       return EmbeddedCodeBlock(entity, contentLayout)

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
@@ -109,10 +109,17 @@ export function AmpSlideshowBlockV2(entity: EntityInstance) {
               <SlideImage>
                 <amp-img
                   class="contain"
-                  src={slide?.resized?.original || defaultImage}
+                  src={slide?.resized?.original}
                   layout="fill"
                   alt={slide?.name || 'slide'}
-                ></amp-img>
+                >
+                  <amp-img
+                    class="contain"
+                    src={defaultImage}
+                    layout="fill"
+                    alt={slide?.name || 'slide'}
+                  ></amp-img>
+                </amp-img>
               </SlideImage>
               <Desc>{slide.desc}</Desc>
             </figure>

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/amp/amp-slideshow-block.tsx
@@ -89,7 +89,11 @@ const Desc = styled.figcaption`
   overflow: scroll;
 `
 
-export function AmpSlideshowBlockV2(entity: EntityInstance) {
+export default function AmpSlideshowBlockV2({
+  entity,
+}: {
+  entity: EntityInstance
+}) {
   const { images = [], delay = 2 } = entity.getData()
 
   return (

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
@@ -206,7 +206,9 @@ export function ImageBlock(
 
   const imageJsx = isAmp ? (
     <AmpImgWrapper>
-      <amp-img src={resized?.original} alt={name} layout="fill" />
+      <amp-img src={resized?.original} alt={name} layout="fill">
+        <amp-img src={defaultImage} alt={name}></amp-img>
+      </amp-img>
     </AmpImgWrapper>
   ) : (
     <CustomImage

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/index.ts
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/index.ts
@@ -13,7 +13,6 @@ import { TableBlock } from './table-block'
 import { VideoBlock } from './video-block'
 import { AudioBlock } from './audio-block'
 import { YoutubeBlock } from './youtube-block'
-import { AmpSlideshowBlockV2 } from './amp/amp-slideshow-block'
 
 export const blockRenderers = {
   BGImageBlock,
@@ -32,5 +31,4 @@ export const blockRenderers = {
   VideoBlock,
   AudioBlock,
   YoutubeBlock,
-  AmpSlideshowBlockV2,
 }

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
@@ -6,6 +6,8 @@ import CustomImage from '@readr-media/react-image'
 import defaultImage from '../assets/default-og-img.png'
 import loadingImage from '../assets/loading.gif'
 
+import AmpSlideshowBlockV2 from './amp/amp-slideshow-block'
+
 const Image = styled.img`
   width: 100%;
 `
@@ -152,7 +154,10 @@ export function SlideshowBlock(entity: EntityInstance) {
  * Inspired by [Works of Claudia Conceicao](https://codepen.io/cconceicao/pen/PBQawy),
  * [twreporter slideshow component](https://github.com/twreporter/twreporter-npm-packages/blob/master/packages/react-article-components/src/components/body/slideshow/index.js)
  */
-export function SlideshowBlockV2(entity: EntityInstance) {
+export function SlideshowBlockV2(
+  entity: EntityInstance,
+  contentLayout: string
+) {
   const slidesBoxRef = useRef<HTMLDivElement>(null)
   /** Current index of the displayed slide */
   const [indexOfCurrentImage, setIndexOfCurrentImage] = useState(0)
@@ -170,6 +175,10 @@ export function SlideshowBlockV2(entity: EntityInstance) {
   )
   const slidesLength = images.length
   const descOfCurrentImage = images?.[indexOfCurrentImage]?.desc
+
+  if (contentLayout === 'amp') {
+    return <AmpSlideshowBlockV2 entity={entity} />
+  }
 
   /**
    * Clone first and last slide.


### PR DESCRIPTION
### 描述
- 新增 amp fallback 為 default image。
- 統一將 amp component 移至相同功能的 component 內，再用 content layout 選擇要 render 哪個。