### PR TITLE
fix(editools): update `ecg` version & fix `dual-slide` error 

### DIFF
--- a/packages/editools/lists/DualSlides.ts
+++ b/packages/editools/lists/DualSlides.ts
@@ -55,43 +55,10 @@ const listConfigurations = list({
             embedCodeWebpackAssets
           )
 
-          const shiftLeft = item?.shiftLeft
-
-          if (shiftLeft) {
-            const style = `
-            <style>
-              .embedded-code-container {
-                margin-top: -32px;
-                margin-left: -20px;
-                z-index: 1000;
-                position: relative;
-              }
-
-              @media (max-width:767px) {
-                .embedded-code-container {
-                  width: 100vw;
-                }
-              }
-
-              @media (min-width:768px) {
-                .embedded-code-container {
-                  margin-left: calc((100vw - 568px)/2 * -1);
-                }
-              }
-              @media (min-width:1200px) {
-                .embedded-code-container {
-                  margin-left: calc((100vw - 600px)/2 * -1);
-                }
-              }
-            </style>
-          `
-            return code.replace(
-              /(<div id=.*><\/div>)/,
-              `${style}<div class='embedded-code-container'>$1</div>`
-            )
-          }
-
-          return code
+          return code.replace(
+            /(<div id=.*><\/div>)/,
+            `<div class='embedded-code-container'>$1</div>`
+          )
         },
       }),
       ui: {

--- a/packages/editools/package.json
+++ b/packages/editools/package.json
@@ -20,7 +20,7 @@
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.2.0",
     "@mirrormedia/lilith-core": "2.0.0-alpha.7",
-    "@readr-media/react-embed-code-generator": "2.4.1-alpha.1",
+    "@readr-media/react-embed-code-generator": "2.4.3-alpha.1",
     "body-parser": "^1.20.2",
     "cheerio": "^1.0.0-rc.12",
     "default-import": "^1.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3710,12 +3710,11 @@
     matter-js "^0.19.0"
     react-intersection-observer "^9.3.5"
 
-"@readr-media/react-dual-slides@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-dual-slides/-/react-dual-slides-1.0.1.tgz#aa06718a79f650d938c2cfb9b079b5e14f8dff90"
-  integrity sha512-COKaEMiFzCDs+nhxjf6P1LHNfSZJvY88/IjrFwR5VFsKsQy9cwJWgqBmoYYesiS0AiKgwY4xX7Rub6hEbS6qng==
+"@readr-media/react-dual-slides@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-dual-slides/-/react-dual-slides-1.1.0.tgz#89fff82f38e9bf0aa777b4ccc80aadf173dba1ea"
+  integrity sha512-wHSseX7OkU61MWdXrgzehLzSBnQVNXOfU5Gcvx0dbz57CMXQgAFYE+tpChEU0S1HFhm64d/DG7iebqUVxU/3Mg==
   dependencies:
-    default-import "^1.1.5"
     react-intersection-observer "^9.3.5"
     react-transition-group "^4.4.5"
 
@@ -3727,13 +3726,13 @@
     "@twreporter/errors" "^1.1.1"
     axios "^0.27.2"
 
-"@readr-media/react-embed-code-generator@2.4.1-alpha.1":
-  version "2.4.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-embed-code-generator/-/react-embed-code-generator-2.4.1-alpha.1.tgz#dd30faedb6d1cdef2adad7682449ddd982d6242a"
-  integrity sha512-UNF26Ab/yaNulKEp+00kew+CF6r75roIunp5eLHGwrwPdnwRLKHLOfUVbj61AE8Ro48bu2cAxjqlpG0KtEQklQ==
+"@readr-media/react-embed-code-generator@2.4.3-alpha.1":
+  version "2.4.3-alpha.1"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-embed-code-generator/-/react-embed-code-generator-2.4.3-alpha.1.tgz#092054926b2b1f9469b4570fdbd11c15823223a0"
+  integrity sha512-a9gTRzXDI1PNEhcyjeQUHXzFABIGF3WTbVxShXjaGwg9p3nLEZ8s9a6j7eO7bNFU0wPIn0GoeY11Ilbj8GVEzQ==
   dependencies:
     "@readr-media/react-dropping-text" "1.0.6"
-    "@readr-media/react-dual-slides" "1.0.1"
+    "@readr-media/react-dual-slides" "^1.1.0"
     "@readr-media/react-election-widgets" "1.0.2"
     "@readr-media/react-feedback" "^3.0.2"
     "@readr-media/react-full-screen-video" "1.0.5-beta.0"
@@ -8202,7 +8201,7 @@ new-github-issue-url@0.2.1:
   resolved "https://registry.yarnpkg.com/new-github-issue-url/-/new-github-issue-url-0.2.1.tgz#e17be1f665a92de465926603e44b9f8685630c1d"
   integrity sha512-md4cGoxuT4T4d/HDOXbrUHkTKrp/vp+m3aOA7XXVYwNsUNMK49g3SQicTSeV5GIz/5QVGAeYRAOlyp9OvlgsYA==
 
-next@13.3.4, next@^13.3.0:
+next@^13.3.0:
   version "13.3.4"
   resolved "https://registry.yarnpkg.com/next/-/next-13.3.4.tgz#ce2d96053cabfca092cc829941efe5dfbe015d16"
   integrity sha512-sod7HeokBSvH5QV0KB+pXeLfcXUlLrGnVUXxHpmhilQ+nQYT3Im2O8DswD5e4uqbR8Pvdu9pcWgb1CbXZQZlmQ==
@@ -9032,13 +9031,13 @@ react-day-picker@^8.0.4:
   resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-8.2.0.tgz#f6cac34d53e1ce963e561940e33fadec874e48cb"
   integrity sha512-6sI9+qk1xXSvV94WOz0H4FVGFaGquwMLQGw9WXoOZajMY/CVrLsautRFwkdjZ9jWj7WZR2Se1mTMrEpmcB6BEQ==
 
-react-dom@18.2.0, react-dom@^18.1.0, react-dom@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
+react-dom@18.1.0, react-dom@^18.1.0, react-dom@^18.2.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.1.0.tgz#7f6dd84b706408adde05e1df575b3a024d7e8a2f"
+  integrity sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.23.0"
+    scheduler "^0.22.0"
 
 react-fast-compare@^3.0.1:
   version "3.2.0"
@@ -9143,10 +9142,10 @@ react-virtualized@^9.22.4:
     prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.4"
 
-react@18.1.0, react@18.2.0, react@^18.1.0, react@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+react@18.1.0, react@^18.1.0, react@^18.2.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.1.0.tgz#6f8620382decb17fdc5cc223a115e2adbf104890"
+  integrity sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -9445,10 +9444,10 @@ saslprep@^1.0.3:
   dependencies:
     sparse-bitfield "^3.0.3"
 
-scheduler@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
-  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+scheduler@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.22.0.tgz#83a5d63594edf074add9a7198b1bae76c3db01b8"
+  integrity sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==
   dependencies:
     loose-envify "^1.1.0"
 


### PR DESCRIPTION
### Notable Changes 
- 更新 `embed-code-generator` 版本：
   - 此版本 `dual-slide` 已修復背景跑位問題。
   - 此版本 `timeline` 先降版至穩定版本 `1.1.0-alpha.1`。
 
- 目前 `dual-slide` 套件已修正為：
   - 不再需要透過勾選「READr 版型」checkbox 來調整位移問題，在任何版型都適用（顯示 100vw）
   - 因此移除 `shiftLeft` 對於 dual-slide 的樣式設定。

TODO：
- [ ] 移除 「READr 版型」checkbox 欄位
- [x] 等 deepfake prod 貼文確認更新後再進行 merge，以免影響現有 embedded-code