### PR TITLE
feat(mirrormedia): add virtual field `apiDataTrimmed` in `Post` list

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -362,6 +362,26 @@ const listConfigurations = list({
         itemView: { fieldMode: 'hidden' },
       },
     }),
+    trimmedApiData: virtual({
+      label: '擷取apiData中的前五段內容',
+      ui: {
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'hidden' },
+      },
+      field: graphql.field({
+        type: graphql.JSON,
+        resolve: async (
+          item: Record<string, unknown>
+        ): Promise<JSONValue | undefined> => {
+          const apiData = item?.apiData
+          if (Array.isArray(apiData)) {
+            return apiData.slice(0, 5)
+          } else {
+            return undefined
+          }
+        },
+      }),
+    }),
   },
   ui: {
     labelField: 'title',

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -1134,6 +1134,7 @@ type Post {
   css: String
   apiDataBrief: JSON
   apiData: JSON
+  trimmedApiData: JSON
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User


### PR DESCRIPTION
## Notable Change 
新增virtual field `apiDataTrimmed`，其計算基礎為 field `apiData`的前五段內容。