### PR TITLE
feat(mirrormedia): implement the lock on Posts

### DIFF
--- a/packages/mirrormedia/keystone.ts
+++ b/packages/mirrormedia/keystone.ts
@@ -10,7 +10,7 @@ import { createPreviewMiniApp } from './express-mini-apps/preview/app'
 const { withAuth } = createAuth({
   listKey: 'User',
   identityField: 'email',
-  sessionData: 'name role',
+  sessionData: 'id name role',
   secretField: 'password',
   initFirstItem: {
     // If there are no items in the database, keystone will ask you to create

--- a/packages/mirrormedia/lists/Category.ts
+++ b/packages/mirrormedia/lists/Category.ts
@@ -58,6 +58,9 @@ const listConfigurations = list({
       defaultValue: false,
     }),
   },
+  ui: {
+    labelField: 'slug',
+  },
   access: {
     operation: {
       query: allowRoles(admin, moderator, editor),

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -58,8 +58,74 @@ function filterPosts(roles: string[]) {
   }
 }
 
+type FieldMode = 'edit' | 'read' | 'hidden'
+
+type ListTypeInfo = {
+  session: Session
+  context: KeystoneContext
+  item: Record<string, any>
+}
+
+type MaybeItemFunction<T extends FieldMode, ListTypeInfo> =
+  | T
+  | ((args: ListTypeInfo) => Promise<T>)
+
+const itemViewFunction: MaybeItemFunction<FieldMode, ListTypeInfo> = async ({
+  session,
+  context,
+  item,
+}) => {
+  if (session.data?.role == UserRole.Editor) {
+    const { lockBy } = await context.query.Post.findOne({
+      where: { id: item.id },
+      query: 'lockBy { id }',
+    })
+
+    if (!lockBy) {
+      const lockExpireAt = new Date(
+        new Date().setMinutes(new Date().getMinutes() + 30, 0, 0)
+      ).toISOString()
+      const updatedPost = await context.query.Post.updateOne({
+        where: { id: item.id },
+        data: {
+          lockBy: { connect: { id: session.data?.id } },
+          lockExpireAt: lockExpireAt,
+        },
+        query: 'lockBy { id }',
+      })
+      return updatedPost.lockBy?.id === session.data?.id ? 'edit' : 'read'
+    } else if (lockBy.id == session.data?.id) {
+      return 'edit'
+    }
+    return 'read'
+  }
+
+  return 'edit'
+}
+
 const listConfigurations = list({
   fields: {
+    lockBy: relationship({
+      ref: 'User',
+      label: '誰正在編輯',
+      ui: {
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'read' },
+        displayMode: 'cards',
+        cardFields: ['name'],
+      },
+    }),
+    lockExpireAt: timestamp({
+      isIndexed: true,
+      db: {
+        isNullable: true,
+      },
+      ui: {
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'hidden' },
+        listView: { fieldMode: 'hidden' },
+      },
+    }),
     slug: text({
       label: 'slug網址名稱（英文）',
       isIndexed: 'unique',
@@ -381,6 +447,9 @@ const listConfigurations = list({
       initialSort: { field: 'publishedDate', direction: 'DESC' },
       pageSize: 50,
     },
+    itemView: {
+      defaultFieldMode: itemViewFunction,
+    },
   },
   access: {
     operation: {
@@ -393,6 +462,18 @@ const listConfigurations = list({
     },
   },
   hooks: {
+    validateInput: async ({ operation, item, context, addValidationError }) => {
+      if (operation === 'update') {
+        const { lockBy } = await context.query.Post.findOne({
+          where: { id: item.id.toString() },
+          query: 'lockBy { id }',
+        })
+
+        if (lockBy?.id && lockBy?.id !== context.session?.data?.id) {
+          addValidationError('可能有其他人正在編輯，請重新整理頁面。')
+        }
+      }
+    },
     resolveInput: async ({ operation, resolvedData }) => {
       const { publishedDate, content, brief } = resolvedData
       if (operation === 'create') {
@@ -409,6 +490,27 @@ const listConfigurations = list({
           .toJS()
       }
       return resolvedData
+    },
+    afterOperation: async ({ operation, inputData, item, context }) => {
+      if (operation === 'update') {
+        // If the operation is to update lockBy and lockExpireAt, then no need to do anything further.
+        // inputDate example:
+        // { lockBy: { connect: { id: '1' } }, lockExpireAt: 2023-09-01T09:37:00.000Z }
+        // { lockBy: { disconnect: true }, lockExpireAt: null }
+        if (Object.keys(inputData).length === 2 && inputData.lockBy) {
+          return
+        }
+
+        // The user saved changes, release the lock.
+        // This will trigger `afterOperation` again, so the above condition check is necessary.
+        await context.query.Post.updateOne({
+          where: { id: item.id.toString() },
+          data: {
+            lockBy: { disconnect: true },
+            lockExpireAt: null,
+          },
+        })
+      }
     },
   },
 })

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -90,9 +90,6 @@ const listConfigurations = list({
       label: '大分類',
       ref: 'Section.posts',
       many: true,
-      ui: {
-        labelField: 'slug',
-      },
     }),
     manualOrderOfSections: json({
       label: '大分類手動排序結果',
@@ -101,9 +98,6 @@ const listConfigurations = list({
       label: '小分類',
       ref: 'Category.posts',
       many: true,
-      ui: {
-        labelField: 'slug',
-      },
     }),
     writers: relationship({
       label: '作者',
@@ -285,9 +279,6 @@ const listConfigurations = list({
       label: '相關文章',
       ref: 'Post',
       many: true,
-      ui: {
-        labelField: 'slug',
-      },
     }),
     manualOrderOfRelateds: json({
       label: '相關文章手動排序結果',
@@ -384,7 +375,7 @@ const listConfigurations = list({
     }),
   },
   ui: {
-    labelField: 'title',
+    labelField: 'slug',
     listView: {
       initialColumns: ['title', 'slug', 'state', 'publishedDate'],
       initialSort: { field: 'publishedDate', direction: 'DESC' },

--- a/packages/mirrormedia/lists/Section.ts
+++ b/packages/mirrormedia/lists/Section.ts
@@ -1,14 +1,14 @@
 import { utils } from '@mirrormedia/lilith-core'
-import { list } from '@keystone-6/core';
-import { text, select, checkbox, relationship, integer } from '@keystone-6/core/fields';
+import { list } from '@keystone-6/core'
+import {
+  text,
+  select,
+  checkbox,
+  relationship,
+  integer,
+} from '@keystone-6/core/fields'
 
-const {
-  allowRoles,
-  admin,
-  moderator,
-  editor,
-  owner,
-} = utils.accessControl
+const { allowRoles, admin, moderator, editor } = utils.accessControl
 
 const listConfigurations = list({
   fields: {
@@ -22,10 +22,10 @@ const listConfigurations = list({
     slug: text({
       label: 'slug',
       isIndexed: 'unique',
-      validation: { isRequired: true }
+      validation: { isRequired: true },
     }),
-    order: integer({ 
-      label: '排序', 
+    order: integer({
+      label: '排序',
       validation: {
         min: 1,
         max: 9999,
@@ -53,21 +53,24 @@ const listConfigurations = list({
       many: true,
     }),
     posts: relationship({
-      ref: "Post.sections",
+      ref: 'Post.sections',
       many: true,
       ui: {
-        createView: { fieldMode: 'hidden'},
+        createView: { fieldMode: 'hidden' },
         itemView: { fieldMode: 'hidden' },
-      }
+      },
     }),
     topics: relationship({
-      ref: "Topic.sections",
+      ref: 'Topic.sections',
       many: true,
       ui: {
-        createView: { fieldMode: 'hidden'},
+        createView: { fieldMode: 'hidden' },
         itemView: { fieldMode: 'hidden' },
-      }
+      },
     }),
+  },
+  ui: {
+    labelField: 'slug',
   },
   access: {
     operation: {

--- a/packages/mirrormedia/migrations/20230904061617_add_lock_post_fields/migration.sql
+++ b/packages/mirrormedia/migrations/20230904061617_add_lock_post_fields/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "lockBy" INTEGER,
+ADD COLUMN     "lockExpireAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "Post_lockBy_idx" ON "Post"("lockBy");
+
+-- CreateIndex
+CREATE INDEX "Post_lockExpireAt_idx" ON "Post"("lockExpireAt");
+
+-- AddForeignKey
+ALTER TABLE "Post" ADD CONSTRAINT "Post_lockBy_fkey" FOREIGN KEY ("lockBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -1082,6 +1082,8 @@ input PhotoCreateInput {
 
 type Post {
   id: ID!
+  lockBy: User
+  lockExpireAt: DateTime
   slug: String
   title: String
   state: String
@@ -1155,6 +1157,8 @@ input PostWhereInput {
   OR: [PostWhereInput!]
   NOT: [PostWhereInput!]
   id: IDFilter
+  lockBy: UserWhereInput
+  lockExpireAt: DateTimeNullableFilter
   slug: StringFilter
   title: StringFilter
   state: StringNullableFilter
@@ -1213,6 +1217,7 @@ input VideoManyRelationFilter {
 
 input PostOrderByInput {
   id: OrderDirection
+  lockExpireAt: OrderDirection
   slug: OrderDirection
   title: OrderDirection
   state: OrderDirection
@@ -1235,6 +1240,8 @@ input PostOrderByInput {
 }
 
 input PostUpdateInput {
+  lockBy: UserRelateToOneForUpdateInput
+  lockExpireAt: DateTime
   slug: String
   title: String
   state: String
@@ -1320,6 +1327,8 @@ input PostUpdateArgs {
 }
 
 input PostCreateInput {
+  lockBy: UserRelateToOneForCreateInput
+  lockExpireAt: DateTime
   slug: String
   title: String
   state: String

--- a/packages/mirrormedia/schema.prisma
+++ b/packages/mirrormedia/schema.prisma
@@ -264,6 +264,9 @@ model Photo {
 
 model Post {
   id                         Int            @id @default(autoincrement())
+  lockBy                     User?          @relation("Post_lockBy", fields: [lockById], references: [id])
+  lockById                   Int?           @map("lockBy")
+  lockExpireAt               DateTime?
   slug                       String         @unique @default("")
   title                      String         @default("")
   state                      String?        @default("draft")
@@ -317,6 +320,8 @@ model Post {
   from_EditorChoice_choices  EditorChoice[] @relation("EditorChoice_choices")
   from_Post_relateds         Post[]         @relation("Post_relateds")
 
+  @@index([lockById])
+  @@index([lockExpireAt])
   @@index([state])
   @@index([publishedDate])
   @@index([heroVideoId])
@@ -444,6 +449,7 @@ model User {
   from_Partner_updatedBy      Partner[]      @relation("Partner_updatedBy")
   from_Photo_createdBy        Photo[]        @relation("Photo_createdBy")
   from_Photo_updatedBy        Photo[]        @relation("Photo_updatedBy")
+  from_Post_lockBy            Post[]         @relation("Post_lockBy")
   from_Post_createdBy         Post[]         @relation("Post_createdBy")
   from_Post_updatedBy         Post[]         @relation("Post_updatedBy")
   from_Section_createdBy      Section[]      @relation("Section_createdBy")


### PR DESCRIPTION
此 PR 包含兩個 commits
第一個 commit 屬於 refactor，與實作 lock 無關。

以下根據第二個 commit，詳細說明 lock 的實作細節。

主要需求：
避免東西被覆蓋。
例如 A, B 都進入同一篇文章，A 辛苦編輯完後，存檔並離開編輯頁面。而 B 的編輯畫面仍是舊的，所以沒有看到 A 寫的東西，然後 B 也寫完存檔離開，把 A 的東西完全覆蓋掉了。

實作上考慮到的使用情境
A 進入編輯 -> B 進入後會看到 `A 正在編輯`，並回給 B read mode
A 進入編輯 -> 編輯完，save changes，鎖釋放
A 進入編輯 -> 編輯完，save changes，鎖釋放，但仍停在原畫面 -> B 進入編輯，B 得到鎖 -> A 在原畫面突然又想編輯 -> A 編輯完按儲存 -> 會得到錯誤警告（因為目前是 B 的編輯時間）
A 進入編輯 -> 突然不想編輯就返回 -> 沒觸發 hooks -> 鎖沒釋放 -> 30 分鐘後由 [mirror-media-cronjobs](https://github.com/mirror-media/mirror-media-cronjobs/commit/cde07c2e98c332792e21cd64a2ec13636db8867e) 去釋放鎖

新增兩個欄位：`lockBy` 及 `lockExpireAt`
並在 `itemViewFunction` 決定要返回 edit or read mode
如果是 edit mode 此時也會賦值給 `lockBy` 及 `lockExpireAt` (目前設定 30 分鐘後，lock 失效)

lock 持有者在 after update operation，更新 `lockBy` 及 `lockExpireAt`。

如果不小心進入別人正在編輯的 Post，有 `validateInput` 這道關卡避免覆蓋別人編輯中的文章。

lock 持有者沒有 update，目前找不到方式釋放 lock，因此設定 30 分鐘後鎖會自動釋放。
