### PR TITLE
feat(draft-renderer): render webp image in image and slideshow block

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -22,7 +22,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@readr-media/react-image": "1.6.0",
+    "@readr-media/react-image": "2.1.3",
     "body-scroll-lock": "3.1.5",
     "draft-js": "^0.11.7",
     "node-html-parser": "^6.1.5"

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.2.0-alpha.36",
+  "version": "1.2.0-alpha.37",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
@@ -181,7 +181,8 @@ export function ImageBlock(
   const isAmp = contentLayout === 'amp'
 
   const [shouldOpenLightBox, setShouldOpenLightBox] = useState(false)
-  const { name, desc, resized, url } = entity.getData()
+  const { name, desc, resized, url, resizedWebp = null } = entity.getData()
+
   const hasDescription = Boolean(desc)
   useEffect(() => {
     if (lightBoxRef && lightBoxRef.current) {
@@ -213,6 +214,7 @@ export function ImageBlock(
   ) : (
     <CustomImage
       images={resized}
+      imagesWebP={resizedWebp}
       defaultImage={defaultImage}
       loadingImage={loadingImage}
       width={''}
@@ -247,6 +249,7 @@ export function ImageBlock(
       <Figure ref={lightBoxRef} onClick={(e) => e.stopPropagation()}>
         <CustomImage
           images={resized}
+          imagesWebP={resizedWebp}
           defaultImage={defaultImage}
           loadingImage={loadingImage}
           alt={name}

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/slideshow-block.tsx
@@ -6,6 +6,13 @@ import CustomImage from '@readr-media/react-image'
 import defaultImage from '../assets/default-og-img.png'
 import loadingImage from '../assets/loading.gif'
 
+type ImageType = Record<
+  'w480' | 'w800' | 'w1200' | 'w1600' | 'w2400' | 'original',
+  string
+>
+
+type ImageResized = ImageType
+type ImageResizedWebp = ImageType | null
 import AmpSlideshowBlockV2 from './amp/amp-slideshow-block'
 
 const Image = styled.img`
@@ -168,9 +175,21 @@ export function SlideshowBlockV2(
   /** Position of slide box */
   const slideBoxPosition = `calc(${sliderWidth} * ${slidesOffset +
     indexOfCurrentImage} * -1 + ${dragDistance}px)`
+  /**
+   * TODO: add type in images
+   */
   const { images } = useMemo(() => entity.getData(), [entity])
-  const displayedImage = useMemo(
-    () => images.map((image) => image.resized),
+
+  type DisplayedImage = {
+    resized: ImageResized
+    resizedWebp: ImageResizedWebp
+  }
+  const displayedImage: Array<DisplayedImage> = useMemo(
+    () =>
+      images.map((image) => {
+        const { resized, resizedWebp } = image
+        return { resized, resizedWebp }
+      }),
     images
   )
   const slidesLength = images.length
@@ -199,14 +218,14 @@ export function SlideshowBlockV2(
    * The amount of item need to clone is decided by variable `slidesOffset`
    */
   const slidesWithClone = useMemo(
-    () =>
-      [].concat(
-        displayedImage?.slice(-slidesOffset),
-        displayedImage,
-        displayedImage?.slice(0, slidesOffset)
-      ),
+    () => [
+      ...displayedImage.slice(-slidesOffset),
+      ...displayedImage,
+      ...displayedImage?.slice(0, slidesOffset),
+    ],
     [displayedImage]
   )
+
   const slidesJsx = useMemo(
     () =>
       slidesWithClone.map((item, index) => {
@@ -226,7 +245,8 @@ export function SlideshowBlockV2(
           index === slidesLength + slidesOffset - 1
         return (
           <CustomImage
-            images={item}
+            images={item.resized}
+            imagesWebP={item.resizedWebp}
             key={index}
             loadingImage={loadingImage}
             defaultImage={defaultImage}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3799,10 +3799,10 @@
     styled-components "5.3.5"
     uuid "^8.3.2"
 
-"@readr-media/react-image@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-1.6.0.tgz#1bff81cdaa8b14f255c22b2504df1d09fc783223"
-  integrity sha512-k4FOxVlAdvsFY5zP7nczs11LrJ3mA2T6Y7rwoTjpA9GMhlf3wtLWD84/XwcsGXNvHg0gbxQtmOcNvKE1LsZxwg==
+"@readr-media/react-image@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.1.3.tgz#97834255b39f42d15b93449637131d28a3aca168"
+  integrity sha512-XAuKKSqRNSvH/CJAfbBhVE7Ezkaetc0pM3AEKUPydYJP51N6fp8mWfPR0HUSw/7QLElHSGXVKCvyuOpVIXa5eQ==
 
 "@readr-media/react-image@^1.5.1":
   version "1.5.1"


### PR DESCRIPTION
## Notable Change
調整draft-renderer中元件image-block與slideshow-block，使其使用2.1.3版本的@readr-media/react-image，並取得資料`resizedWebp`，並將其作為參數`imagesWebp`，傳入`@readr-media/react-image`