### PR TITLE
refactor(mirrormedia): add virtual field and checkbox for update time

### DIFF
--- a/packages/mirrormedia/lists/views/now-button.tsx
+++ b/packages/mirrormedia/lists/views/now-button.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { FieldProps } from '@keystone-6/core/types'
+import { Button } from '@keystone-ui/button'
+import { FieldContainer } from '@keystone-ui/fields'
+import { controller } from '@keystone-6/core/fields/types/json/views'
+import { updateTimestamp } from '../../utils/updateTimestamp'
+
+export const Field = ({ value }: FieldProps<typeof controller>) => {
+  const label = 'Now'
+  const handleOnClickBtn = () => {
+    updateTimestamp(value.mutation, value.time)
+  }
+  return (
+    <FieldContainer>
+      <Button onClick={handleOnClickBtn}>{label}</Button>
+    </FieldContainer>
+  )
+}

--- a/packages/mirrormedia/migrations/20230915003248_add_now_button/migration.sql
+++ b/packages/mirrormedia/migrations/20230915003248_add_now_button/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "updateTimeStamp" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -1088,6 +1088,8 @@ type Post {
   title: String
   state: String
   publishedDate: DateTime
+  updateTimeStamp: Boolean
+  now: JSON
   sections(where: SectionWhereInput! = {}, orderBy: [SectionOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: SectionWhereUniqueInput): [Section!]
   sectionsCount(where: SectionWhereInput! = {}): Int
   manualOrderOfSections: JSON
@@ -1166,6 +1168,7 @@ input PostWhereInput {
   title: StringFilter
   state: StringNullableFilter
   publishedDate: DateTimeFilter
+  updateTimeStamp: BooleanFilter
   sections: SectionManyRelationFilter
   categories: CategoryManyRelationFilter
   writers: ContactManyRelationFilter
@@ -1225,6 +1228,7 @@ input PostOrderByInput {
   title: OrderDirection
   state: OrderDirection
   publishedDate: OrderDirection
+  updateTimeStamp: OrderDirection
   extend_byline: OrderDirection
   heroCaption: OrderDirection
   style: OrderDirection
@@ -1249,6 +1253,7 @@ input PostUpdateInput {
   title: String
   state: String
   publishedDate: DateTime
+  updateTimeStamp: Boolean
   sections: SectionRelateToManyForUpdateInput
   manualOrderOfSections: JSON
   categories: CategoryRelateToManyForUpdateInput
@@ -1337,6 +1342,7 @@ input PostCreateInput {
   title: String
   state: String
   publishedDate: DateTime
+  updateTimeStamp: Boolean
   sections: SectionRelateToManyForCreateInput
   manualOrderOfSections: JSON
   categories: CategoryRelateToManyForCreateInput

--- a/packages/mirrormedia/schema.prisma
+++ b/packages/mirrormedia/schema.prisma
@@ -271,6 +271,7 @@ model Post {
   title                      String         @default("")
   state                      String?        @default("draft")
   publishedDate              DateTime       @default(now())
+  updateTimeStamp            Boolean        @default(false)
   sections                   Section[]      @relation("Post_sections")
   manualOrderOfSections      Json?
   categories                 Category[]     @relation("Category_posts")

--- a/packages/mirrormedia/utils/updateTimestamp.js
+++ b/packages/mirrormedia/utils/updateTimestamp.js
@@ -1,0 +1,24 @@
+async function updateTimestamp(mutation, time) {
+  try {
+    const response = await fetch(`/api/graphql`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: mutation,
+        variable: { time },
+      }),
+    })
+
+    if (response.ok) {
+      alert('已更新時間為現在，重新整理後即可看到！')
+    } else {
+      console.error('Mutation request failed:', response.status)
+    }
+  } catch (error) {
+    console.error('Error updating timestamp:', error)
+  }
+}
+
+export { updateTimestamp }


### PR DESCRIPTION
### Notable Change
- 3.0 k6 CMS 發布日期旁新增「現在時間」點選後發布日期跳為現在時間。
- 學電視直接挖一個 custom field >> k6 使用 ts 導致搬遷過於複雜，未來也不好維護，故先不考慮該方案。
- 使用 virtual field，點擊按鈕後新增欄位 >> 目前可以 migrate 了，只是不會馬上更新，若沒重新整理儲存可能會衝突，覺得不是很好的使用者體驗。
- 新增一個 checkbox 決定是否在儲存時將時間改為現在 >> 不是本來的需求，不過若比較直覺也可採用。

### 參考資料
- [Asana 卡片](https://app.asana.com/0/1181156545719626/1205419959719889/f)