### PR TITLE
refactor(mirrormedia): remove _next route

### DIFF
--- a/packages/mirrormedia/express-mini-apps/preview/app.js
+++ b/packages/mirrormedia/express-mini-apps/preview/app.js
@@ -49,13 +49,5 @@ export function createPreviewMiniApp({ previewServerOrigin, keystoneContext }) {
   // Proxy requests with `/news/:id` url path to preview nuxt server
   router.get('/projects/:slug', authenticationMw, previewProxyMiddleware)
 
-  // Proxy requests with `/_next/*` url path to preview nuxt server
-  router.use(
-    '/_next/*',
-    createProxyMiddleware({
-      target: previewServerOrigin,
-      changeOrigin: true,
-    })
-  )
   return router
 }


### PR DESCRIPTION
## Notable Changes
* refactor(mirrormedia): remove `/_next` route

## Reminders
* There is a route collision between CMS and preview next server