### PR TITLE
fix(mirrormedia): add jsx back to fix the custom view

### DIFF
--- a/packages/mirrormedia/lists/views/sorted-relationship/RelationshipSelect.tsx
+++ b/packages/mirrormedia/lists/views/sorted-relationship/RelationshipSelect.tsx
@@ -1,5 +1,7 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
 import 'intersection-observer'
-import React from 'react'
 import {
   RefObject,
   useEffect,
@@ -10,6 +12,8 @@ import {
   useRef,
 } from 'react'
 
+// eslint-disable-next-line
+import { jsx } from '@keystone-ui/core';
 import { MultiSelect, Select, selectComponents } from '@keystone-ui/fields'
 import { validate as validateUUID } from 'uuid'
 import { IdFieldConfig, ListMeta } from '@keystone-6/core/types'

--- a/packages/mirrormedia/lists/views/sorted-relationship/cards/InlineCreate.tsx
+++ b/packages/mirrormedia/lists/views/sorted-relationship/cards/InlineCreate.tsx
@@ -1,5 +1,9 @@
-import React, { FormEvent, useState } from 'react'
-import { Stack } from '@keystone-ui/core'
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { FormEvent, useState } from 'react'
+// eslint-disable-next-line
+import { jsx, Stack } from '@keystone-ui/core';
 import isDeepEqual from 'fast-deep-equal'
 import { useToasts } from '@keystone-ui/toast'
 import { Button } from '@keystone-ui/button'

--- a/packages/mirrormedia/lists/views/sorted-relationship/cards/InlineEdit.tsx
+++ b/packages/mirrormedia/lists/views/sorted-relationship/cards/InlineEdit.tsx
@@ -1,7 +1,11 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
 import { Button } from '@keystone-ui/button'
-import { Stack } from '@keystone-ui/core'
+// eslint-disable-next-line
+import { jsx, Stack } from '@keystone-ui/core';
 import { useToasts } from '@keystone-ui/toast'
-import React, { useCallback, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { ListMeta } from '@keystone-6/core/types'
 import {
   deserializeValue,

--- a/packages/mirrormedia/lists/views/sorted-relationship/cards/index.tsx
+++ b/packages/mirrormedia/lists/views/sorted-relationship/cards/index.tsx
@@ -1,4 +1,9 @@
-import React, { ReactNode } from 'react'
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { ReactNode } from 'react'
+// eslint-disable-next-line
+import { jsx } from '@keystone-ui/core';
 import {
   Box,
   BoxProps,

--- a/packages/mirrormedia/lists/views/sorted-relationship/index.tsx
+++ b/packages/mirrormedia/lists/views/sorted-relationship/index.tsx
@@ -1,7 +1,11 @@
-import React, { Fragment, useState } from 'react'
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { Fragment, useState } from 'react'
 
 import { Button } from '@keystone-ui/button'
-import { Stack, useTheme } from '@keystone-ui/core'
+// eslint-disable-next-line
+import { jsx, Stack, useTheme } from '@keystone-ui/core';
 import {
   FieldContainer,
   FieldDescription,


### PR DESCRIPTION
此為 [custom relationship field view](https://github.com/mirror-media/Lilith/pull/570) 的後續修正

在複製 keystone 原始碼過來改時，因為有些 eslint error，所以就把程式碼做了一些改動，以便通過 eslint check。
結果發現部分 UI 受影響，按鈕圖片都擠在一起，故將 jsx 加回來，並在有 eslint error 的上方補上
`// eslint-disable-next-line`，作為 workaround。