### PR TITLE
refactor(mm-next): add convertIframesToAmp

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.3.0-alpha.11",
+  "version": "1.3.0-alpha.11.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.3.0-alpha.10",
+  "version": "1.3.0-alpha.11",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/embedded-code-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/embedded-code-block.tsx
@@ -82,10 +82,35 @@ export const EmbeddedCodeBlock = (
     node.appendChild(fragment)
   }, [embeddedCode])
 
+  function convertIframesToAmp(embeddedCode) {
+    // 使用 regex 拿到 iframe tag，並取得內容和 attribute
+    const iframeRegex = /<iframe([^>]*)><\/iframe>/g
+    const ampEmbeddedCode = embeddedCode.replace(
+      iframeRegex,
+      (match, attributes) => {
+        // 检查 iframe 是否包含 allowfullscreen='true'
+        if (attributes.includes('allowfullscreen="true"')) {
+          // 将 allowfullscreen 替换为 allow
+          attributes = attributes.replace(
+            'allowfullscreen="true"',
+            'allow="fullscreen"'
+          )
+        }
+        // 使用 amp-iframe tag 替換原來的 iframe tag
+        return `<amp-iframe${attributes}></amp-iframe>`
+      }
+    )
+
+    return ampEmbeddedCode
+  }
+
   if (contentLayout === 'amp') {
     return (
       <div>
-        <AmpEmbeddedCodeBlock embeddedCode={embeddedCode} />
+        i am amp 3
+        <AmpEmbeddedCodeBlock
+          embeddedCode={convertIframesToAmp(embeddedCode)}
+        />
         {caption ? <Caption>{caption}</Caption> : null}
       </div>
     )

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/embedded-code-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/embedded-code-block.tsx
@@ -107,7 +107,6 @@ export const EmbeddedCodeBlock = (
   if (contentLayout === 'amp') {
     return (
       <div>
-        i am amp 3
         <AmpEmbeddedCodeBlock
           embeddedCode={convertIframesToAmp(embeddedCode)}
         />


### PR DESCRIPTION
### Notable change
- 為了處理錯誤訊息 `error  The tag 'iframe' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-iframe'?  https://amp.dev/documentation/components/amp-iframe/` 而將 <iframe> 統一替換成 <amp-iframe>。
- 使用 fb embed 測試時出現了不允許 `allowfullscreen="true"` 在 <amp-iframe> 中，因此也替換成 `allow="fullscreen"`