### PR TITLE
refactor(draft-editor): update table apiData structure

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-core",
-  "version": "2.0.0-alpha.25",
+  "version": "2.0.0-alpha.26",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -33,7 +33,7 @@
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
     "@twreporter/errors": "^1.1.1",
-    "@mirrormedia/lilith-draft-editor": "1.1.0-alpha.33",
+    "@mirrormedia/lilith-draft-editor": "1.1.0-alpha.34",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",
     "draft-js": "^0.11.7",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-editor",
-  "version": "1.1.0-alpha.33",
+  "version": "1.1.0-alpha.34",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-editor/src/draft-js/draft-converter/atomic-block-processor.js
+++ b/packages/draft-editor/src/draft-js/draft-converter/atomic-block-processor.js
@@ -1,10 +1,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import _ from 'lodash'
-import React from 'react'
 // import sizeOf from 'image-size';
 import ApiDataInstance from './api-data-instance'
 import ENTITY from './entities'
-import ReactDOMServer from 'react-dom/server'
 import { RawDraftContentState, convertFromRaw } from 'draft-js' // eslint-disable-line
 import { convertToHTML } from 'draft-convert'
 
@@ -62,37 +60,17 @@ const processor = {
         // About TABLE atomic block entity data structure,
         // see `../views/editor/table.tsx` for more information.
         content = entity?.data
-        /** @type DraftEditor.TableEntity.TableStyles */
-        const tableStyles = content?.tableStyles
         /** @type DraftEditor.TableEntity.TableData */
+        // since apiData is now only for app,
+        // keep the rows data structure for app to style the table
         const tableData = content?.tableData
-        const rowsJsx = tableData?.map((row, rIndex) => {
-          const colsJsx = row?.map((col, cIndex) => {
-            const colStyle = tableStyles?.columns?.[cIndex]
-            const cellStyle = tableStyles?.cells?.[rIndex]?.[cIndex]
-            return (
-              <td
-                key={`col_${cIndex}`}
-                style={Object.assign({}, colStyle, cellStyle)}
-                dangerouslySetInnerHTML={{
-                  __html: convertToHTML(convertFromRaw(col)),
-                }}
-              />
-            )
+        const rows = tableData?.map((row) => {
+          const cols = row?.map((col) => {
+            return { html: convertToHTML(convertFromRaw(col)) }
           })
-          return (
-            <tr key={`row_${rIndex}`} style={tableStyles?.rows?.[rIndex]}>
-              {colsJsx}
-            </tr>
-          )
+          return cols
         })
-        // Use `React.renderToStsaticMarkup` to generate plain HTML string
-        const html = ReactDOMServer.renderToStaticMarkup(
-          <table>
-            <tbody>{rowsJsx}</tbody>
-          </table>
-        )
-        content = [{ html }]
+        content = rows
         break
       }
       case ENTITY.DIVIDER.type:

--- a/packages/mirrormedia/package.json
+++ b/packages/mirrormedia/package.json
@@ -22,7 +22,7 @@
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.2.0",
     "@keyv/redis": "^2.7.0",
-    "@mirrormedia/lilith-core": "2.0.0-alpha.25",
+    "@mirrormedia/lilith-core": "2.0.0-alpha.26",
     "@twreporter/errors": "^1.1.2",
     "express": "^4.17.1",
     "firebase-admin": "^11.4.1",


### PR DESCRIPTION
Since apiData is now only for App to use, re-structure the apiData from only HTML to two dimension array. First dimension stores rows and the second dimension stores cells with HTML converted from draft.js blocks.

Now App side can use the data structure to custom the style of the table.

```
            "content": [
              [
                {
                  "html": "<p>R1C1</p>"
                },
                {
                  "html": "<p>R1C2</p>"
                }
              ],
              [
                {
                  "html": "<p>R2C1</p>"
                },
                {
                  "html": "<p>R2C2</p>"
                }
              ],
              [
                {
                  "html": "<p></p>"
                },
                {
                  "html": "<p></p>"
                }
              ]
            ],
```