### PR TITLE
feat(mm): show image url when relation to List `Photos`

### DIFF
--- a/packages/mirrormedia/lists/views/sorted-relationship/RelationshipSelect.tsx
+++ b/packages/mirrormedia/lists/views/sorted-relationship/RelationshipSelect.tsx
@@ -79,8 +79,9 @@ export function useFilter(
   return useMemo(() => {
     if (!search.length) return { OR: [] }
 
-    const idFieldKind: IdFieldConfig['kind'] = (list.fields.id
-      .controller as any).idFieldKind
+    const idFieldKind: IdFieldConfig['kind'] = (
+      list.fields.id.controller as any
+    ).idFieldKind
     const trimmedSearch = search.trim()
     const isValidId = idValidators[idFieldKind](trimmedSearch)
 
@@ -165,10 +166,8 @@ export const RelationshipSelect = ({
   // because we want a re-render if the element changes
   // so that we can register the intersection observer
   // on the right element
-  const [
-    loadingIndicatorElement,
-    setLoadingIndicatorElement,
-  ] = useState<null | HTMLElement>(null)
+  const [loadingIndicatorElement, setLoadingIndicatorElement] =
+    useState<null | HTMLElement>(null)
 
   const QUERY: TypedDocumentNode<
     {
@@ -400,6 +399,25 @@ export const RelationshipSelect = ({
         controlShouldRenderValue={controlShouldRenderValue}
         isClearable={controlShouldRenderValue}
         isDisabled={isDisabled}
+        // The parameter `formatOptionLabel` is added specifically for this project
+        // and is not copied from the codebase of keystone-6/core.
+        // This parameter controls the appearance of element in drop-down list component, make it display image if needed.
+        // See [Pull Request](https://github.com/mirror-media/Lilith/pull/698) to get more details.
+        formatOptionLabel={(option) => {
+          return (
+            <div style={{ display: 'flex', flexDirection: 'row' }}>
+              <span>{option.label}</span>
+              {list.label === 'Photos' && (
+                <img
+                  src={option?.data?.imageFile?.url}
+                  width={50}
+                  height={50}
+                  style={{ objectFit: 'cover', marginLeft: 'auto' }}
+                ></img>
+              )}
+            </div>
+          )
+        }}
       />
     </LoadingIndicatorContext.Provider>
   )

--- a/packages/mirrormedia/lists/views/sorted-relationship/cards/index.tsx
+++ b/packages/mirrormedia/lists/views/sorted-relationship/cards/index.tsx
@@ -105,7 +105,11 @@ export function Cards({
     selectedFields += `\n${foreignList.labelField}`
   }
 
-  const { items, setItems, state: itemsState } = useItemState({
+  const {
+    items,
+    setItems,
+    state: itemsState,
+  } = useItemState({
     selectedFields,
     localList,
     id,
@@ -317,6 +321,13 @@ export function Cards({
               isLoading={isLoadingLazyItems}
               placeholder={`Select a ${foreignList.singular}`}
               portalMenu
+              // The parameter `extraSelection` is added specifically for this project
+              // and is not copied from the codebase of keystone-6/core.
+              // This parameter controls the extra GraphQL query we need to fetch.
+              // See [Pull Request](https://github.com/mirror-media/Lilith/pull/698) to get more details.
+              extraSelection={
+                foreignList.label === 'Photos' ? 'imageFile {url}' : ''
+              }
               state={{
                 kind: 'many',
                 async onChange(options) {


### PR DESCRIPTION
## Notable Change
1. 修改custom-view `sorted-relationship` 的相關元件，使關聯到List `Photo` 的field，可以於下拉式選單顯示圖片樣貌。

## Implement Details
使用者希望在選取圖片時，可以於下拉式選單中同步看到圖片的樣子，而非只有圖片名稱。
而依據需求，則具體拆成兩個步驟：
1. 取得圖片的url
2. 將圖片的url顯示在下拉式選單中


就第一步而言，發現在元件`<RelationshipSelect>`中有一個參數[`extraSelection`](https://github.com/mirror-media/Lilith/blob/main/packages/mirrormedia/lists/views/sorted-relationship/RelationshipSelect.tsx#L133)。
而該參數的用途用於[調整gql query 所請求的field](https://github.com/mirror-media/Lilith/blob/main/packages/mirrormedia/lists/views/sorted-relationship/RelationshipSelect.tsx#L299)，也就是可以額外抓取特定欄位的資料。
因此，本次改動使用該參數來抓取 List `Photos`的 Field [`imageFile`](https://github.com/mirror-media/Lilith/blob/main/packages/mirrormedia/lists/views/sorted-relationship/RelationshipSelect.tsx#L299)。另外有加上條件判斷，只有特定的List 才會傳入該參數，避免造成非預期的錯誤。

而就第二步而言，由於keystone使用了第三方套件 `react-select` 來實作下拉式選單，而該套件提供的元件`<MultiSelect>`有提供一個props [`formatOptionLabel`](https://react-select.com/props#select-props)，用途是控制選項呈現的UI，並且可以傳入React component。
因此，本次改動[使用了這個props](https://github.com/mirror-media/Lilith/pull/698/commits/99d1e6b4b957d552bff94b00422a09abdd6d59ec#diff-68f470e2f8978f072e766ca4474d0d65b663bbe7bc772731688c9b23962a73ddR402-R416)，來讓圖片顯示在下拉式選單的選項中。同樣有加上條件判斷，只有特定的List 才會顯示圖片。
需要注意的是，除了`<MultiSelect>`外，其實元件 `<Select>` 也有 props `formatOptionLabel`，但因為關聯到 List `Photos` 都僅使用`<MultiSelect>`，因此無調整傳入 `<Select>` 的props。

完成後的UI會長這樣：
<img width="559" alt="Screen Shot 2024-01-15 at 7 35 07 PM" src="https://github.com/mirror-media/Lilith/assets/85677992/b65bb78a-99fe-4dbc-9315-95247d1ad24b">
