### PR TITLE
feat(mm): add group list and modify the relationship of external and post

### DIFF
--- a/packages/mirrormedia/lists/External.ts
+++ b/packages/mirrormedia/lists/External.ts
@@ -123,8 +123,16 @@ const listConfigurations = list({
       },
     }),
     relateds: relationship({
-      label: '相關外部文章',
-      ref: 'External',
+      label: '相關內部文章',
+      ref: 'Post.from_External_relateds',
+      many: true,
+      ui: {
+        views: './lists/views/sorted-relationship/index',
+      },
+    }),
+    groups: relationship({
+      label: "群組",
+      ref: 'Group.externals',
       many: true,
       ui: {
         views: './lists/views/sorted-relationship/index',

--- a/packages/mirrormedia/lists/Group.ts
+++ b/packages/mirrormedia/lists/Group.ts
@@ -8,6 +8,9 @@ const listConfigurations = list({
   fields: {
     keyword: text({
         label: '關鍵詞',
+        validation: {
+            isRequired: true,
+        },
     }),
     posts: relationship({
         ref: 'Post.groups',
@@ -38,14 +41,6 @@ const listConfigurations = list({
       create: allowRoles(admin, moderator),
       delete: allowRoles(admin),
     },
-  },
-  hooks: {
-    validateInput: ({ resolvedData, addValidationError }) => {
-        const { keyword } = resolvedData
-        if (keyword === '') {
-          addValidationError('keyword 不得為空值')
-        }
-      },
   },
 })
 export default utils.addTrackingFields(listConfigurations)

--- a/packages/mirrormedia/lists/Group.ts
+++ b/packages/mirrormedia/lists/Group.ts
@@ -1,0 +1,51 @@
+import { utils } from '@mirrormedia/lilith-core'
+import { list } from '@keystone-6/core'
+import { text, timestamp, relationship } from '@keystone-6/core/fields'
+
+const { allowRoles, admin, moderator } = utils.accessControl
+
+const listConfigurations = list({
+  fields: {
+    keyword: text({
+        label: '關鍵詞',
+    }),
+    posts: relationship({
+        ref: 'Post.groups',
+        many: true,
+        ui: {
+        views: './lists/views/sorted-relationship/index',
+        },
+    }),
+    externals: relationship({
+        ref: 'External.groups',
+        many: true,
+        ui: {
+            views: './lists/views/sorted-relationship/index',
+        },
+    }),
+  },
+  ui: {
+    labelField: 'keyword',
+    listView: {
+      initialColumns: ['id', 'keyword', 'createdAt'],
+      initialSort: { field: 'id', direction: 'DESC' },
+      pageSize: 50,
+    },
+  },
+  access: {
+    operation: {
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  },
+  hooks: {
+    validateInput: ({ resolvedData, addValidationError }) => {
+        const { keyword } = resolvedData
+        if (keyword === '') {
+          addValidationError('keyword 不得為空值')
+        }
+      },
+  },
+})
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -431,6 +431,22 @@ const listConfigurations = list({
         views: './lists/views/sorted-relationship/index',
       },
     }),
+    from_External_relateds: relationship({
+      label: '相關外部文章(發佈後由演算法自動計算)',
+      ref: 'External.relateds',
+      many: true,
+      ui: {
+        views: './lists/views/sorted-relationship/index',
+      },
+    }),
+    groups: relationship({
+      label: "群組(發佈後由演算法自動計算)",
+      ref: 'Group.posts',
+      many: true,
+      ui: {
+        views: './lists/views/sorted-relationship/index',
+      },
+    }),
     manualOrderOfRelateds: json({
       label: '相關文章手動排序結果',
       isFilterable: false,

--- a/packages/mirrormedia/lists/index.ts
+++ b/packages/mirrormedia/lists/index.ts
@@ -14,6 +14,7 @@ import Partner from './Partner'
 import Topic from './Topic'
 import External from './External'
 import Header from './Header'
+import Group from './Group'
 
 export const listDefinition = {
   AudioFile: Audio,
@@ -32,4 +33,5 @@ export const listDefinition = {
   Topic,
   User,
   Video,
+  Group,
 }

--- a/packages/mirrormedia/migrations/20240410062250_add_group_list/migration.sql
+++ b/packages/mirrormedia/migrations/20240410062250_add_group_list/migration.sql
@@ -1,0 +1,65 @@
+-- DropForeignKey
+ALTER TABLE "_External_relateds" DROP CONSTRAINT "_External_relateds_B_fkey";
+
+-- CreateTable
+CREATE TABLE "Group" (
+    "id" SERIAL NOT NULL,
+    "keyword" TEXT NOT NULL DEFAULT '',
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "Group_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_External_groups" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Group_posts" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE INDEX "Group_createdBy_idx" ON "Group"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "Group_updatedBy_idx" ON "Group"("updatedBy");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_External_groups_AB_unique" ON "_External_groups"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_External_groups_B_index" ON "_External_groups"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Group_posts_AB_unique" ON "_Group_posts"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Group_posts_B_index" ON "_Group_posts"("B");
+
+-- AddForeignKey
+ALTER TABLE "Group" ADD CONSTRAINT "Group_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Group" ADD CONSTRAINT "Group_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_External_relateds" ADD CONSTRAINT "_External_relateds_B_fkey" FOREIGN KEY ("B") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_External_groups" ADD CONSTRAINT "_External_groups_A_fkey" FOREIGN KEY ("A") REFERENCES "External"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_External_groups" ADD CONSTRAINT "_External_groups_B_fkey" FOREIGN KEY ("B") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Group_posts" ADD CONSTRAINT "_Group_posts_A_fkey" FOREIGN KEY ("A") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Group_posts" ADD CONSTRAINT "_Group_posts_B_fkey" FOREIGN KEY ("B") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -628,6 +628,12 @@ type External {
   brief: String
   content: String
   source: String
+  tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
+  tagsCount(where: TagWhereInput! = {}): Int
+  relateds(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
+  relatedsCount(where: PostWhereInput! = {}): Int
+  groups(where: GroupWhereInput! = {}, orderBy: [GroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: GroupWhereUniqueInput): [Group!]
+  groupsCount(where: GroupWhereInput! = {}): Int
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User
@@ -655,10 +661,19 @@ input ExternalWhereInput {
   brief: StringFilter
   content: StringFilter
   source: StringFilter
+  tags: TagManyRelationFilter
+  relateds: PostManyRelationFilter
+  groups: GroupManyRelationFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
   updatedBy: UserWhereInput
+}
+
+input GroupManyRelationFilter {
+  every: GroupWhereInput
+  some: GroupWhereInput
+  none: GroupWhereInput
 }
 
 input ExternalOrderByInput {
@@ -689,6 +704,9 @@ input ExternalUpdateInput {
   brief: String
   content: String
   source: String
+  tags: TagRelateToManyForUpdateInput
+  relateds: PostRelateToManyForUpdateInput
+  groups: GroupRelateToManyForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
@@ -699,6 +717,13 @@ input PartnerRelateToOneForUpdateInput {
   create: PartnerCreateInput
   connect: PartnerWhereUniqueInput
   disconnect: Boolean
+}
+
+input GroupRelateToManyForUpdateInput {
+  disconnect: [GroupWhereUniqueInput!]
+  set: [GroupWhereUniqueInput!]
+  create: [GroupCreateInput!]
+  connect: [GroupWhereUniqueInput!]
 }
 
 input ExternalUpdateArgs {
@@ -718,6 +743,9 @@ input ExternalCreateInput {
   brief: String
   content: String
   source: String
+  tags: TagRelateToManyForCreateInput
+  relateds: PostRelateToManyForCreateInput
+  groups: GroupRelateToManyForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput
@@ -727,6 +755,11 @@ input ExternalCreateInput {
 input PartnerRelateToOneForCreateInput {
   create: PartnerCreateInput
   connect: PartnerWhereUniqueInput
+}
+
+input GroupRelateToManyForCreateInput {
+  create: [GroupCreateInput!]
+  connect: [GroupWhereUniqueInput!]
 }
 
 type Header {
@@ -1125,6 +1158,10 @@ type Post {
   topics: Topic
   relateds(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
   relatedsCount(where: PostWhereInput! = {}): Int
+  from_External_relateds(where: ExternalWhereInput! = {}, orderBy: [ExternalOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ExternalWhereUniqueInput): [External!]
+  from_External_relatedsCount(where: ExternalWhereInput! = {}): Int
+  groups(where: GroupWhereInput! = {}, orderBy: [GroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: GroupWhereUniqueInput): [Group!]
+  groupsCount(where: GroupWhereInput! = {}): Int
   manualOrderOfRelateds: JSON
   tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
   tagsCount(where: TagWhereInput! = {}): Int
@@ -1188,6 +1225,8 @@ input PostWhereInput {
   isMember: BooleanFilter
   topics: TopicWhereInput
   relateds: PostManyRelationFilter
+  from_External_relateds: ExternalManyRelationFilter
+  groups: GroupManyRelationFilter
   tags: TagManyRelationFilter
   og_title: StringFilter
   isFeatured: BooleanFilter
@@ -1213,6 +1252,12 @@ input ContactManyRelationFilter {
   every: ContactWhereInput
   some: ContactWhereInput
   none: ContactWhereInput
+}
+
+input ExternalManyRelationFilter {
+  every: ExternalWhereInput
+  some: ExternalWhereInput
+  none: ExternalWhereInput
 }
 
 input PostOrderByInput {
@@ -1273,6 +1318,8 @@ input PostUpdateInput {
   isMember: Boolean
   topics: TopicRelateToOneForUpdateInput
   relateds: PostRelateToManyForUpdateInput
+  from_External_relateds: ExternalRelateToManyForUpdateInput
+  groups: GroupRelateToManyForUpdateInput
   manualOrderOfRelateds: JSON
   tags: TagRelateToManyForUpdateInput
   og_title: String
@@ -1321,6 +1368,13 @@ input TopicRelateToOneForUpdateInput {
   disconnect: Boolean
 }
 
+input ExternalRelateToManyForUpdateInput {
+  disconnect: [ExternalWhereUniqueInput!]
+  set: [ExternalWhereUniqueInput!]
+  create: [ExternalCreateInput!]
+  connect: [ExternalWhereUniqueInput!]
+}
+
 input VideoRelateToManyForUpdateInput {
   disconnect: [VideoWhereUniqueInput!]
   set: [VideoWhereUniqueInput!]
@@ -1364,6 +1418,8 @@ input PostCreateInput {
   isMember: Boolean
   topics: TopicRelateToOneForCreateInput
   relateds: PostRelateToManyForCreateInput
+  from_External_relateds: ExternalRelateToManyForCreateInput
+  groups: GroupRelateToManyForCreateInput
   manualOrderOfRelateds: JSON
   tags: TagRelateToManyForCreateInput
   og_title: String
@@ -1404,6 +1460,11 @@ input VideoRelateToOneForCreateInput {
 input TopicRelateToOneForCreateInput {
   create: TopicCreateInput
   connect: TopicWhereUniqueInput
+}
+
+input ExternalRelateToManyForCreateInput {
+  create: [ExternalCreateInput!]
+  connect: [ExternalWhereUniqueInput!]
 }
 
 input VideoRelateToManyForCreateInput {
@@ -1534,6 +1595,8 @@ type Tag {
   name: String
   posts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
   postsCount(where: PostWhereInput! = {}): Int
+  externals(where: ExternalWhereInput! = {}, orderBy: [ExternalOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ExternalWhereUniqueInput): [External!]
+  externalsCount(where: ExternalWhereInput! = {}): Int
   topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
   topicsCount(where: TopicWhereInput! = {}): Int
   createdAt: DateTime
@@ -1556,6 +1619,7 @@ input TagWhereInput {
   slug: StringFilter
   name: StringFilter
   posts: PostManyRelationFilter
+  externals: ExternalManyRelationFilter
   topics: TopicManyRelationFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
@@ -1575,6 +1639,7 @@ input TagUpdateInput {
   slug: String
   name: String
   posts: PostRelateToManyForUpdateInput
+  externals: ExternalRelateToManyForUpdateInput
   topics: TopicRelateToManyForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
@@ -1591,6 +1656,7 @@ input TagCreateInput {
   slug: String
   name: String
   posts: PostRelateToManyForCreateInput
+  externals: ExternalRelateToManyForCreateInput
   topics: TopicRelateToManyForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
@@ -1935,6 +2001,69 @@ input VideoCreateInput {
   updatedBy: UserRelateToOneForCreateInput
 }
 
+type Group {
+  id: ID!
+  keyword: String
+  posts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
+  postsCount(where: PostWhereInput! = {}): Int
+  externals(where: ExternalWhereInput! = {}, orderBy: [ExternalOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ExternalWhereUniqueInput): [External!]
+  externalsCount(where: ExternalWhereInput! = {}): Int
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+input GroupWhereUniqueInput {
+  id: ID
+}
+
+input GroupWhereInput {
+  AND: [GroupWhereInput!]
+  OR: [GroupWhereInput!]
+  NOT: [GroupWhereInput!]
+  id: IDFilter
+  keyword: StringFilter
+  posts: PostManyRelationFilter
+  externals: ExternalManyRelationFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input GroupOrderByInput {
+  id: OrderDirection
+  keyword: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input GroupUpdateInput {
+  keyword: String
+  posts: PostRelateToManyForUpdateInput
+  externals: ExternalRelateToManyForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input GroupUpdateArgs {
+  where: GroupWhereUniqueInput!
+  data: GroupUpdateInput!
+}
+
+input GroupCreateInput {
+  keyword: String
+  posts: PostRelateToManyForCreateInput
+  externals: ExternalRelateToManyForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -2037,6 +2166,12 @@ type Mutation {
   updateVideos(data: [VideoUpdateArgs!]!): [Video]
   deleteVideo(where: VideoWhereUniqueInput!): Video
   deleteVideos(where: [VideoWhereUniqueInput!]!): [Video]
+  createGroup(data: GroupCreateInput!): Group
+  createGroups(data: [GroupCreateInput!]!): [Group]
+  updateGroup(where: GroupWhereUniqueInput!, data: GroupUpdateInput!): Group
+  updateGroups(data: [GroupUpdateArgs!]!): [Group]
+  deleteGroup(where: GroupWhereUniqueInput!): Group
+  deleteGroups(where: [GroupWhereUniqueInput!]!): [Group]
   endSession: Boolean!
   authenticateUserWithPassword(email: String!, password: String!): UserAuthenticationWithPasswordResult
   createInitialUser(data: CreateInitialUserInput!): UserAuthenticationWithPasswordSuccess!
@@ -2109,6 +2244,9 @@ type Query {
   videos(where: VideoWhereInput! = {}, orderBy: [VideoOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: VideoWhereUniqueInput): [Video!]
   video(where: VideoWhereUniqueInput!): Video
   videosCount(where: VideoWhereInput! = {}): Int
+  groups(where: GroupWhereInput! = {}, orderBy: [GroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: GroupWhereUniqueInput): [Group!]
+  group(where: GroupWhereUniqueInput!): Group
+  groupsCount(where: GroupWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
 }

--- a/packages/mirrormedia/schema.prisma
+++ b/packages/mirrormedia/schema.prisma
@@ -146,16 +146,15 @@ model External {
   brief               String    @default("")
   content             String    @default("")
   source              String    @default("")
+  tags                Tag[]     @relation("External_tags")
+  relateds            Post[]    @relation("External_relateds")
+  groups              Group[]   @relation("External_groups")
   createdAt           DateTime?
   updatedAt           DateTime?
-  createdBy           User?      @relation("External_createdBy", fields: [createdById], references: [id])
-  createdById         Int?       @map("createdBy")
-  updatedBy           User?      @relation("External_updatedBy", fields: [updatedById], references: [id])
-  updatedById         Int?       @map("updatedBy")
-  tags                Tag[]      @relation("External_tags")
-  relateds            External[] @relation("External_relateds")
-
-  from_External_relateds External[] @relation("External_relateds")
+  createdBy           User?     @relation("External_createdBy", fields: [createdById], references: [id])
+  createdById         Int?      @map("createdBy")
+  updatedBy           User?     @relation("External_updatedBy", fields: [updatedById], references: [id])
+  updatedById         Int?      @map("updatedBy")
 
   @@index([partnerId])
   @@index([state])
@@ -303,6 +302,8 @@ model Post {
   topics                     Topic?         @relation("Post_topics", fields: [topicsId], references: [id])
   topicsId                   Int?           @map("topics")
   relateds                   Post[]         @relation("Post_relateds")
+  from_External_relateds     External[]     @relation("External_relateds")
+  groups                     Group[]        @relation("Group_posts")
   manualOrderOfRelateds      Json?
   tags                       Tag[]          @relation("Post_tags")
   og_title                   String         @default("")
@@ -472,6 +473,8 @@ model User {
   from_Topic_updatedBy        Topic[]        @relation("Topic_updatedBy")
   from_Video_createdBy        Video[]        @relation("Video_createdBy")
   from_Video_updatedBy        Video[]        @relation("Video_updatedBy")
+  from_Group_createdBy        Group[]        @relation("Group_createdBy")
+  from_Group_updatedBy        Group[]        @relation("Group_updatedBy")
 }
 
 model Video {
@@ -501,6 +504,22 @@ model Video {
   @@index([heroImageId])
   @@index([state])
   @@index([publishedDate])
+  @@index([createdById])
+  @@index([updatedById])
+}
+
+model Group {
+  id          Int        @id @default(autoincrement())
+  keyword     String     @default("")
+  posts       Post[]     @relation("Group_posts")
+  externals   External[] @relation("External_groups")
+  createdAt   DateTime?
+  updatedAt   DateTime?
+  createdBy   User?      @relation("Group_createdBy", fields: [createdById], references: [id])
+  createdById Int?       @map("createdBy")
+  updatedBy   User?      @relation("Group_updatedBy", fields: [updatedById], references: [id])
+  updatedById Int?       @map("updatedBy")
+
   @@index([createdById])
   @@index([updatedById])
 }


### PR DESCRIPTION
新增Group list，用來記錄演算法分群的結果，裡面主要有幾個欄位
1. keyword: 演算法計算某一時間內的焦點關鍵詞
2. posts: 與該關鍵詞最為相關的近期內部文章
3. externals: 與該關鍵詞最為相關的近期外部文章
hook函式僅針對keyword為空的情形進行檢查。另外，調整外部文章相關文章功能為連結週刊內部文章。