### PR TITLE
feat(mm): add post tags_algo and modify updatedAt in Post list

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -672,6 +672,7 @@ const listConfigurations = list({
       const { publishedDate, content, brief, updateTimeStamp } = resolvedData
       if (operation === 'create') {
         resolvedData.publishedDate = new Date(publishedDate.setSeconds(0, 0))
+        resolvedData.updatedAt = new Date()
       }
       if (content) {
         resolvedData.apiData = customFields.draftConverter
@@ -686,6 +687,7 @@ const listConfigurations = list({
       if (updateTimeStamp) {
         const now = new Date()
         resolvedData.publishedDate = new Date(now.setSeconds(0, 0))
+        resolvedData.updatedAt = new Date()
         resolvedData.updateTimeStamp = false
       }
       return resolvedData
@@ -694,15 +696,15 @@ const listConfigurations = list({
       /* ... */
       if (operation === 'create' || operation === 'update') {
         if (resolvedData.slug) {
-			resolvedData.slug = resolvedData.slug.trim()
-			resolvedData.slug = resolvedData.slug.replace(" ", "_")
-		}
+          resolvedData.slug = resolvedData.slug.trim()
+          resolvedData.slug = resolvedData.slug.replace(" ", "_")
+        }
         if (resolvedData.publishedDate) {
-		  /* check the publishedDate */
-		  if (resolvedData.publishedDate > Date.now()) {
-			resolvedData.state = 'scheduled'
-		  }
-		  /* end publishedDate check */
+          /* check the publishedDate */
+          if (resolvedData.publishedDate > Date.now()) {
+            resolvedData.state = 'scheduled'
+          }
+          /* end publishedDate check */
           resolvedData.publishedDateString = new Date(
             resolvedData.publishedDate
           ).toLocaleDateString('zh-TW', {

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -459,6 +459,14 @@ const listConfigurations = list({
         views: './lists/views/sorted-relationship/index',
       },
     }),
+    tags_algo: relationship({
+      label: '演算法標籤',
+      ref: 'Tag.posts_algo',
+      many: true,
+      ui: {
+        views: './lists/views/sorted-relationship/index',
+      },
+    }),
     og_title: text({
       label: 'FB分享標題',
       validation: { isRequired: false },

--- a/packages/mirrormedia/lists/Tag.ts
+++ b/packages/mirrormedia/lists/Tag.ts
@@ -23,6 +23,14 @@ const listConfigurations = list({
         views: './lists/views/sorted-relationship/index',
       },
     }),
+    posts_algo: relationship({
+      ref: 'Post.tags_algo',
+      many: true,
+      ui: {
+        hideCreate: true,
+        views: './lists/views/sorted-relationship/index',
+      },
+    }),
     externals: relationship({
       ref: 'External.tags',
       many: true,

--- a/packages/mirrormedia/migrations/20240415022025_add_post_tags_algo/migration.sql
+++ b/packages/mirrormedia/migrations/20240415022025_add_post_tags_algo/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "_Post_tags_algo" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Post_tags_algo_AB_unique" ON "_Post_tags_algo"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Post_tags_algo_B_index" ON "_Post_tags_algo"("B");
+
+-- AddForeignKey
+ALTER TABLE "_Post_tags_algo" ADD CONSTRAINT "_Post_tags_algo_A_fkey" FOREIGN KEY ("A") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Post_tags_algo" ADD CONSTRAINT "_Post_tags_algo_B_fkey" FOREIGN KEY ("B") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -1165,6 +1165,8 @@ type Post {
   manualOrderOfRelateds: JSON
   tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
   tagsCount(where: TagWhereInput! = {}): Int
+  tags_algo(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
+  tags_algoCount(where: TagWhereInput! = {}): Int
   og_title: String
   og_description: String
   og_image: Photo
@@ -1228,6 +1230,7 @@ input PostWhereInput {
   from_External_relateds: ExternalManyRelationFilter
   groups: GroupManyRelationFilter
   tags: TagManyRelationFilter
+  tags_algo: TagManyRelationFilter
   og_title: StringFilter
   isFeatured: BooleanFilter
   isAdvertised: BooleanFilter
@@ -1322,6 +1325,7 @@ input PostUpdateInput {
   groups: GroupRelateToManyForUpdateInput
   manualOrderOfRelateds: JSON
   tags: TagRelateToManyForUpdateInput
+  tags_algo: TagRelateToManyForUpdateInput
   og_title: String
   og_description: String
   og_image: PhotoRelateToOneForUpdateInput
@@ -1422,6 +1426,7 @@ input PostCreateInput {
   groups: GroupRelateToManyForCreateInput
   manualOrderOfRelateds: JSON
   tags: TagRelateToManyForCreateInput
+  tags_algo: TagRelateToManyForCreateInput
   og_title: String
   og_description: String
   og_image: PhotoRelateToOneForCreateInput
@@ -1595,6 +1600,8 @@ type Tag {
   name: String
   posts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
   postsCount(where: PostWhereInput! = {}): Int
+  posts_algo(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
+  posts_algoCount(where: PostWhereInput! = {}): Int
   externals(where: ExternalWhereInput! = {}, orderBy: [ExternalOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ExternalWhereUniqueInput): [External!]
   externalsCount(where: ExternalWhereInput! = {}): Int
   topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
@@ -1619,6 +1626,7 @@ input TagWhereInput {
   slug: StringFilter
   name: StringFilter
   posts: PostManyRelationFilter
+  posts_algo: PostManyRelationFilter
   externals: ExternalManyRelationFilter
   topics: TopicManyRelationFilter
   createdAt: DateTimeNullableFilter
@@ -1639,6 +1647,7 @@ input TagUpdateInput {
   slug: String
   name: String
   posts: PostRelateToManyForUpdateInput
+  posts_algo: PostRelateToManyForUpdateInput
   externals: ExternalRelateToManyForUpdateInput
   topics: TopicRelateToManyForUpdateInput
   createdAt: DateTime
@@ -1656,6 +1665,7 @@ input TagCreateInput {
   slug: String
   name: String
   posts: PostRelateToManyForCreateInput
+  posts_algo: PostRelateToManyForCreateInput
   externals: ExternalRelateToManyForCreateInput
   topics: TopicRelateToManyForCreateInput
   createdAt: DateTime

--- a/packages/mirrormedia/schema.prisma
+++ b/packages/mirrormedia/schema.prisma
@@ -306,6 +306,7 @@ model Post {
   groups                     Group[]        @relation("Group_posts")
   manualOrderOfRelateds      Json?
   tags                       Tag[]          @relation("Post_tags")
+  tags_algo                  Tag[]          @relation("Post_tags_algo")
   og_title                   String         @default("")
   og_description             String         @default("")
   og_image                   Photo?         @relation("Post_og_image", fields: [og_imageId], references: [id])
@@ -376,6 +377,7 @@ model Tag {
   slug                String      @unique @default("")
   name                String      @unique @default("")
   posts               Post[]      @relation("Post_tags")
+  posts_algo          Post[]      @relation("Post_tags_algo")
   externals           External[]  @relation("External_tags")
   topics              Topic[]     @relation("Tag_topics")
   createdAt           DateTime?


### PR DESCRIPTION
在這個PR裡面主要做兩件事情，分別如下
1. 修正post的updatedAt：原先在建立文章時不會自動寫入updatedAt的欄位導致會有空值產生，這邊修改hook使文章建立時寫入updatedAt欄位為現在時間。
2. 新增演算法標籤tags_algo：為了與人工標籤分開，在Post新增演算法標籤的欄位。

updatedAt的相關issue為Asana的RSS邏輯調整任務，主要問題是若將篩選標準改為更新時間的情況下，直接建立狀態為已發佈的文章更新時間為空值，會導致排序錯誤。
[RSS抓取時間邏輯調整](https://app.asana.com/0/1206837560996882/1206848017516544/f)
