### PR TITLE
feat(mm): hide algorithm auto-calculated fields in posts

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -433,18 +433,26 @@ const listConfigurations = list({
     }),
     from_External_relateds: relationship({
       label: '相關外部文章(發佈後由演算法自動計算)',
+      isFilterable: false,
       ref: 'External.relateds',
       many: true,
       ui: {
         views: './lists/views/sorted-relationship/index',
+        createView: { fieldMode: 'hidden', },
+        itemView: { fieldMode: 'hidden', },
+        listView: { fieldMode: 'hidden', },
       },
     }),
     groups: relationship({
       label: "群組(發佈後由演算法自動計算)",
+      isFilterable: false,
       ref: 'Group.posts',
       many: true,
       ui: {
         views: './lists/views/sorted-relationship/index',
+        createView: { fieldMode: 'hidden', },
+        itemView: { fieldMode: 'hidden', },
+        listView: { fieldMode: 'hidden', },
       },
     }),
     manualOrderOfRelateds: json({
@@ -461,10 +469,14 @@ const listConfigurations = list({
     }),
     tags_algo: relationship({
       label: '演算法標籤',
+      isFilterable: false,
       ref: 'Tag.posts_algo',
       many: true,
       ui: {
         views: './lists/views/sorted-relationship/index',
+        createView: { fieldMode: 'hidden', },
+        itemView: { fieldMode: 'hidden', },
+        listView: { fieldMode: 'hidden', },
       },
     }),
     og_title: text({

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -1227,10 +1227,7 @@ input PostWhereInput {
   isMember: BooleanFilter
   topics: TopicWhereInput
   relateds: PostManyRelationFilter
-  from_External_relateds: ExternalManyRelationFilter
-  groups: GroupManyRelationFilter
   tags: TagManyRelationFilter
-  tags_algo: TagManyRelationFilter
   og_title: StringFilter
   isFeatured: BooleanFilter
   isAdvertised: BooleanFilter
@@ -1255,12 +1252,6 @@ input ContactManyRelationFilter {
   every: ContactWhereInput
   some: ContactWhereInput
   none: ContactWhereInput
-}
-
-input ExternalManyRelationFilter {
-  every: ExternalWhereInput
-  some: ExternalWhereInput
-  none: ExternalWhereInput
 }
 
 input PostOrderByInput {
@@ -1633,6 +1624,12 @@ input TagWhereInput {
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
   updatedBy: UserWhereInput
+}
+
+input ExternalManyRelationFilter {
+  every: ExternalWhereInput
+  some: ExternalWhereInput
+  none: ExternalWhereInput
 }
 
 input TagOrderByInput {


### PR DESCRIPTION
由於演算法計算的欄位不應該一般使用者看見及使用，這邊將在Posts list裡面與算法相關的欄位隱藏起來，並設定isFilterable: false。
由於該次沒有schema變更，所以沒有migration檔案產生。
