### PR TITLE
feat(mesh): add apidata related features

### DIFF
--- a/packages/mesh/environment-variables.ts
+++ b/packages/mesh/environment-variables.ts
@@ -13,7 +13,6 @@ const {
   IMAGES_STORAGE_PATH,
   MEMORY_CACHE_TTL,
   MEMORY_CACHE_SIZE,
-  READR_GQL_ENDPOINT
 } = process.env
 
 enum DatabaseProvider {
@@ -55,5 +54,4 @@ export default {
     baseUrl: IMAGES_BASE_URL || '/images',
     storagePath: IMAGES_STORAGE_PATH || 'public/images',
   },
-  readr_gql_endpoint: READR_GQL_ENDPOINT || '', // endpoint should be secret
 }

--- a/packages/mesh/environment-variables.ts
+++ b/packages/mesh/environment-variables.ts
@@ -13,6 +13,7 @@ const {
   IMAGES_STORAGE_PATH,
   MEMORY_CACHE_TTL,
   MEMORY_CACHE_SIZE,
+  READR_GQL_ENDPOINT
 } = process.env
 
 enum DatabaseProvider {
@@ -54,4 +55,5 @@ export default {
     baseUrl: IMAGES_BASE_URL || '/images',
     storagePath: IMAGES_STORAGE_PATH || 'public/images',
   },
+  readr_gql_endpoint: READR_GQL_ENDPOINT || '', // endpoint should be secret
 }

--- a/packages/mesh/lists/publisher.ts
+++ b/packages/mesh/lists/publisher.ts
@@ -22,6 +22,14 @@ const listConfigurations = list ({
     title: text({ validation: { isRequired: false } }),
     official_site: text({ validation: { isRequired: true } }),
     rss: text({ validation: { isRequired: true } }),
+    apidata_endpoint: text({
+      label: 'APIDATA Endpoint',
+      validation: {isRequired: false},
+    }),
+    need_apidata: checkbox({
+      label: '需抓取APIDATA',
+      defaultValue: false,
+    }),
     summary: text({ validation: { isRequired: false } }),
     logo: text({ validation: { isRequired: false } }),
     description: text({ validation: { isRequired: false } }),
@@ -58,7 +66,7 @@ const listConfigurations = list ({
 	}),
 	source_type: select({
 	  label: '資料來源',
-	  datatype: 'enum',
+	  // datatype: 'enum',
 	  options: [ 
 		{ label: '鏡週刊', value: 'mirrormedia' }, 
 		{ label: 'READr', value: 'readr' },
@@ -67,9 +75,9 @@ const listConfigurations = list ({
       ],
 	  defaultValue: 'rss',
 	}),
-    paywall: checkbox({
-      defaultValue: false,
-    }),
+  paywall: checkbox({
+    defaultValue: false,
+  }),
 	follower: relationship({
 	  ref: 'Member.follow_publisher',
 	  many: true,

--- a/packages/mesh/migrations/20240503084719_add_apidata_fields/migration.sql
+++ b/packages/mesh/migrations/20240503084719_add_apidata_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Publisher" ADD COLUMN     "apidata_endpoint" TEXT NOT NULL DEFAULT E'',
+ADD COLUMN     "need_apidata" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -21,6 +21,7 @@
     "@keystone-6/fields-document": "1.0.1",
     "@mirrormedia/lilith-core": "1.2.5",
     "express": "^4.17.1",
+    "graphql-request": "^6.1.0",
     "http-proxy-middleware": "^2.0.3",
     "patch-package": "^6.4.7"
   },

--- a/packages/mesh/schema.graphql
+++ b/packages/mesh/schema.graphql
@@ -523,6 +523,8 @@ type Publisher {
   title: String
   official_site: String
   rss: String
+  apidata_endpoint: String
+  need_apidata: Boolean
   summary: String
   logo: String
   description: String
@@ -558,6 +560,8 @@ input PublisherWhereInput {
   title: StringFilter
   official_site: StringFilter
   rss: StringFilter
+  apidata_endpoint: StringFilter
+  need_apidata: BooleanFilter
   summary: StringFilter
   logo: StringFilter
   description: StringFilter
@@ -580,6 +584,8 @@ input PublisherOrderByInput {
   title: OrderDirection
   official_site: OrderDirection
   rss: OrderDirection
+  apidata_endpoint: OrderDirection
+  need_apidata: OrderDirection
   summary: OrderDirection
   logo: OrderDirection
   description: OrderDirection
@@ -598,6 +604,8 @@ input PublisherUpdateInput {
   title: String
   official_site: String
   rss: String
+  apidata_endpoint: String
+  need_apidata: Boolean
   summary: String
   logo: String
   description: String
@@ -624,6 +632,8 @@ input PublisherCreateInput {
   title: String
   official_site: String
   rss: String
+  apidata_endpoint: String
+  need_apidata: Boolean
   summary: String
   logo: String
   description: String

--- a/packages/mesh/schema.prisma
+++ b/packages/mesh/schema.prisma
@@ -143,6 +143,8 @@ model Publisher {
   title             String    @default("")
   official_site     String    @default("")
   rss               String    @default("")
+  apidata_endpoint  String    @default("")
+  need_apidata      Boolean   @default(false)
   summary           String    @default("")
   logo              String    @default("")
   description       String    @default("")


### PR DESCRIPTION
在這個PR裡面，主要新增apidata的處理程序，使我們可以在MESH CMS當中儲存其他來源的apidata。

### List更動部分
1. Publisher: 因應須**可彈性選擇是否抓apidata**，新增need_apidata(Type: checkbox)及apidata_endpoint(Type: string)兩個欄位，使可手動設定在後續hook時是否要從apidata_endpoint抓取資料存為API DATA。
2. Story: 新增resolveInput的hook，當有Story建立時檢查是否需要抓取apidata，若有則做後續處理。

### ApiData抓取流程
ApiData處理的流程如下，括號表示部屬實體
1.  (Cloud Run) feed-parser -> (Mesh)Story: 呼叫createStories，觸發Hook函式
2.  (Mesh)Story -> (Mesh)Publisher: 藉由source: {connect: id}關聯到Publisher的資訊，取得need_apidata及apidata_endpoint。若需要抓取apidata的話則會進到下一步，假設要抓取Readr的apidata資訊。
3.  (Mesh)Story -> (Readr)Post: 抓取Post當中的content，並使用customFields.draftConverter將其轉為apidata儲存。
簡單的流程圖如下
![APIDATA](https://github.com/mirror-media/Lilith/assets/34787189/3f4a8d07-dc5f-4d2a-8a40-f22d0933b634)

> 為什麼不在feed-parser上傳時寫入apidata? => 因為apidata資料量過大，KeystoneJS內API資料的接收上限為1MB，所以須轉為在hook底下額外抓取資料。

### 其他事項
在TS當中有兩個套件可以操作GQL Queries，一種是[apollo/client](https://www.apollographql.com/docs/react/)，另一種是[graphql-request](https://www.npmjs.com/package/graphql-request)。需要注意的是在KeystoneJS的環境中，安裝apollo/client會與KeystoneJS伺服器端套件衝突，導致在執行期間實際上抓不到資料回來。有鑑於此，這邊使用graphql-request套件來進行操作。

**※由於資料庫有所更動，故有新增db migration檔案。**
