### PR TITLE
feat(mesh): add policy and transaction lists

### DIFF
--- a/packages/mesh/lists/index.ts
+++ b/packages/mesh/lists/index.ts
@@ -13,6 +13,8 @@ import InvitationCode from './invitation_code'
 import Image from './image'
 import Notify from './notify'
 import Announcement from './announcement'
+import Policy from './policy'
+import Transaction from './transaction'
 
 export const listDefinition = {
   User,
@@ -30,4 +32,6 @@ export const listDefinition = {
   Notify,
   Announcement,
   Photo: Image,
+  Policy,
+  Transaction
 }

--- a/packages/mesh/lists/policy.ts
+++ b/packages/mesh/lists/policy.ts
@@ -7,8 +7,9 @@ const { allowRoles, admin, moderator, editor } = utils.accessControl
 const listConfigurations = list({
   fields: {
     name: text({
-      label: '政策名稱',
+      label: '政策名稱(須符合[name]-(single)-[duration]格式)',
       validation: {
+        match: { regex: /^(?:deposit|[a-zA-Z0-9]+(?:-single)?-[0-9]+)$/i },
         isRequired: true,
       },
     }),

--- a/packages/mesh/lists/policy.ts
+++ b/packages/mesh/lists/policy.ts
@@ -46,7 +46,7 @@ const listConfigurations = list({
   },
   ui: {
     listView: {
-      initialColumns: ['name', 'type', 'unlockSingle', 'duration'],
+      initialColumns: ['name', 'type', 'unlockSingle', 'publisher', 'duration'],
     },
   },
   access: {

--- a/packages/mesh/lists/policy.ts
+++ b/packages/mesh/lists/policy.ts
@@ -1,0 +1,62 @@
+import { utils } from '@mirrormedia/lilith-core'
+import { list } from '@keystone-6/core'
+import { text, relationship, checkbox, select, integer, float } from '@keystone-6/core/fields'
+
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+const listConfigurations = list({
+  fields: {
+    name: text({
+      label: '政策名稱',
+      validation: {
+        isRequired: true,
+      },
+    }),
+    explanation: text({
+      label: '政策說明',
+      validation: {
+        isRequired: false,
+      },
+    }),
+    type: select({
+        label: '選擇政策類型',
+        type: 'enum',
+        options: [
+            {label: "儲值", value: "deposit"},
+            {label: "解鎖所有媒體", value: "unlock_all_publishers"},
+            {label: "解鎖單一媒體", value: "unlock_one_publisher"}
+        ]
+    }),
+    unlockSingle: checkbox({
+        label: "為解鎖單篇文章的政策",
+        defaultValue: false
+    }),
+    publisher: relationship({ 
+        label: "選擇政策影響之媒體",
+        ref: 'Publisher', 
+        many: false 
+    }),
+    duration: integer({
+        label: "解鎖時間(天)"
+    }),
+    charge: float({
+        label: "解鎖費用",
+        defaultValue: 0,
+    })
+  },
+  ui: {
+    listView: {
+      initialColumns: ['name', 'type', 'unlockSingle', 'duration'],
+    },
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator, editor),
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  }
+})
+
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/mesh/lists/transaction.ts
+++ b/packages/mesh/lists/transaction.ts
@@ -1,0 +1,75 @@
+import { utils } from '@mirrormedia/lilith-core'
+import { list } from '@keystone-6/core'
+import { text, relationship, checkbox, select, float, timestamp } from '@keystone-6/core/fields'
+
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+const listConfigurations = list({
+  fields: {
+    member: relationship({ 
+        label: "會員",
+        ref: 'Member', 
+        many: true 
+    }),
+    policy: relationship({ 
+        label: "交易政策",
+        ref: 'Policy', 
+        many: false 
+    }),
+    tid: text({
+        label: '交易編號(TransactionID)',
+        validation: {
+            isRequired: false,
+        },
+    }),
+    depositVolume: float({
+        label: "儲值金額",
+        validation: {
+            isRequired: false,
+        }
+    }),
+    unlockStory: relationship({ 
+        label: "解鎖文章",
+        ref: 'Story', 
+        many: false 
+    }),
+    expireDate: timestamp({
+        label: "到期日期",
+        validation: { isRequired: false },
+    }),
+    active: checkbox({
+        label: "是否仍於有效日期內",
+        defaultValue: true,
+    }),
+    status: select({
+        label: '交易狀態',
+        type: 'enum',
+        options: [
+            {label: "成功", value: "Success"},
+            {label: "失敗", value: "Failed"},
+        ]
+    }),
+    complement: text({
+        label: "備註",
+        validation: {
+            isRequired: false
+        }
+    }),
+
+  },
+  ui: {
+    listView: {
+      initialColumns: ['id', 'member', 'status'],
+    },
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator, editor),
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  }
+})
+
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/mesh/lists/transaction.ts
+++ b/packages/mesh/lists/transaction.ts
@@ -9,7 +9,7 @@ const listConfigurations = list({
     member: relationship({ 
         label: "會員",
         ref: 'Member', 
-        many: true 
+        many: false
     }),
     policy: relationship({ 
         label: "交易政策",
@@ -59,7 +59,7 @@ const listConfigurations = list({
   },
   ui: {
     listView: {
-      initialColumns: ['id', 'member', 'status'],
+      initialColumns: ['id', 'member', 'status', 'policy', 'tid'],
     },
   },
   access: {

--- a/packages/mesh/lists/transaction.ts
+++ b/packages/mesh/lists/transaction.ts
@@ -19,7 +19,7 @@ const listConfigurations = list({
     tid: text({
         label: '交易編號(TransactionID)',
         validation: {
-            isRequired: false,
+            isRequired: true,
         },
     }),
     depositVolume: float({

--- a/packages/mesh/migrations/20240710083124_add_policy_transaction_list/migration.sql
+++ b/packages/mesh/migrations/20240710083124_add_policy_transaction_list/migration.sql
@@ -1,0 +1,102 @@
+-- CreateEnum
+CREATE TYPE "PolicyTypeType" AS ENUM ('deposit', 'unlock_all_publishers', 'unlock_one_publisher');
+
+-- CreateEnum
+CREATE TYPE "TransactionStatusType" AS ENUM ('Success', 'Failed');
+
+-- CreateTable
+CREATE TABLE "Policy" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL DEFAULT E'',
+    "explanation" TEXT NOT NULL DEFAULT E'',
+    "type" "PolicyTypeType",
+    "unlockSingle" BOOLEAN NOT NULL DEFAULT false,
+    "publisher" INTEGER,
+    "duration" INTEGER,
+    "charge" DOUBLE PRECISION DEFAULT 0,
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "Policy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Transaction" (
+    "id" SERIAL NOT NULL,
+    "policy" INTEGER,
+    "tid" TEXT NOT NULL DEFAULT E'',
+    "depositVolume" DOUBLE PRECISION,
+    "unlockStory" INTEGER,
+    "expireDate" TIMESTAMP(3),
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "status" "TransactionStatusType",
+    "complement" TEXT NOT NULL DEFAULT E'',
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "Transaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_Transaction_member" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE INDEX "Policy_publisher_idx" ON "Policy"("publisher");
+
+-- CreateIndex
+CREATE INDEX "Policy_createdBy_idx" ON "Policy"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "Policy_updatedBy_idx" ON "Policy"("updatedBy");
+
+-- CreateIndex
+CREATE INDEX "Transaction_policy_idx" ON "Transaction"("policy");
+
+-- CreateIndex
+CREATE INDEX "Transaction_unlockStory_idx" ON "Transaction"("unlockStory");
+
+-- CreateIndex
+CREATE INDEX "Transaction_createdBy_idx" ON "Transaction"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "Transaction_updatedBy_idx" ON "Transaction"("updatedBy");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Transaction_member_AB_unique" ON "_Transaction_member"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Transaction_member_B_index" ON "_Transaction_member"("B");
+
+-- AddForeignKey
+ALTER TABLE "Policy" ADD CONSTRAINT "Policy_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Policy" ADD CONSTRAINT "Policy_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Policy" ADD CONSTRAINT "Policy_publisher_fkey" FOREIGN KEY ("publisher") REFERENCES "Publisher"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_unlockStory_fkey" FOREIGN KEY ("unlockStory") REFERENCES "Story"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_policy_fkey" FOREIGN KEY ("policy") REFERENCES "Policy"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Transaction_member" ADD FOREIGN KEY ("A") REFERENCES "Member"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Transaction_member" ADD FOREIGN KEY ("B") REFERENCES "Transaction"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/mesh/migrations/20240711025115_fix_transaction_member_relation/migration.sql
+++ b/packages/mesh/migrations/20240711025115_fix_transaction_member_relation/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - You are about to drop the `_Transaction_member` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "_Transaction_member" DROP CONSTRAINT "_Transaction_member_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Transaction_member" DROP CONSTRAINT "_Transaction_member_B_fkey";
+
+-- AlterTable
+ALTER TABLE "Transaction" ADD COLUMN     "member" INTEGER;
+
+-- DropTable
+DROP TABLE "_Transaction_member";
+
+-- CreateIndex
+CREATE INDEX "Transaction_member_idx" ON "Transaction"("member");
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_member_fkey" FOREIGN KEY ("member") REFERENCES "Member"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/mesh/schema.graphql
+++ b/packages/mesh/schema.graphql
@@ -1991,6 +1991,231 @@ input PhotoCreateInput {
   updatedBy: UserRelateToOneForCreateInput
 }
 
+type Policy {
+  id: ID!
+  name: String
+  explanation: String
+  type: PolicyTypeType
+  unlockSingle: Boolean
+  publisher: Publisher
+  duration: Int
+  charge: Float
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+enum PolicyTypeType {
+  deposit
+  unlock_all_publishers
+  unlock_one_publisher
+}
+
+input PolicyWhereUniqueInput {
+  id: ID
+}
+
+input PolicyWhereInput {
+  AND: [PolicyWhereInput!]
+  OR: [PolicyWhereInput!]
+  NOT: [PolicyWhereInput!]
+  id: IDFilter
+  name: StringFilter
+  explanation: StringFilter
+  type: PolicyTypeTypeNullableFilter
+  unlockSingle: BooleanFilter
+  publisher: PublisherWhereInput
+  duration: IntNullableFilter
+  charge: FloatNullableFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input PolicyTypeTypeNullableFilter {
+  equals: PolicyTypeType
+  in: [PolicyTypeType!]
+  notIn: [PolicyTypeType!]
+  not: PolicyTypeTypeNullableFilter
+}
+
+input FloatNullableFilter {
+  equals: Float
+  in: [Float!]
+  notIn: [Float!]
+  lt: Float
+  lte: Float
+  gt: Float
+  gte: Float
+  not: FloatNullableFilter
+}
+
+input PolicyOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  explanation: OrderDirection
+  type: OrderDirection
+  unlockSingle: OrderDirection
+  duration: OrderDirection
+  charge: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input PolicyUpdateInput {
+  name: String
+  explanation: String
+  type: PolicyTypeType
+  unlockSingle: Boolean
+  publisher: PublisherRelateToOneForUpdateInput
+  duration: Int
+  charge: Float
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input PolicyUpdateArgs {
+  where: PolicyWhereUniqueInput!
+  data: PolicyUpdateInput!
+}
+
+input PolicyCreateInput {
+  name: String
+  explanation: String
+  type: PolicyTypeType
+  unlockSingle: Boolean
+  publisher: PublisherRelateToOneForCreateInput
+  duration: Int
+  charge: Float
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
+type Transaction {
+  id: ID!
+  member(
+    where: MemberWhereInput! = {}
+    orderBy: [MemberOrderByInput!]! = []
+    take: Int
+    skip: Int! = 0
+  ): [Member!]
+  memberCount(where: MemberWhereInput! = {}): Int
+  policy: Policy
+  tid: String
+  depositVolume: Float
+  unlockStory: Story
+  expireDate: DateTime
+  active: Boolean
+  status: TransactionStatusType
+  complement: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+enum TransactionStatusType {
+  Success
+  Failed
+}
+
+input TransactionWhereUniqueInput {
+  id: ID
+}
+
+input TransactionWhereInput {
+  AND: [TransactionWhereInput!]
+  OR: [TransactionWhereInput!]
+  NOT: [TransactionWhereInput!]
+  id: IDFilter
+  member: MemberManyRelationFilter
+  policy: PolicyWhereInput
+  tid: StringFilter
+  depositVolume: FloatNullableFilter
+  unlockStory: StoryWhereInput
+  expireDate: DateTimeNullableFilter
+  active: BooleanFilter
+  status: TransactionStatusTypeNullableFilter
+  complement: StringFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input TransactionStatusTypeNullableFilter {
+  equals: TransactionStatusType
+  in: [TransactionStatusType!]
+  notIn: [TransactionStatusType!]
+  not: TransactionStatusTypeNullableFilter
+}
+
+input TransactionOrderByInput {
+  id: OrderDirection
+  tid: OrderDirection
+  depositVolume: OrderDirection
+  expireDate: OrderDirection
+  active: OrderDirection
+  status: OrderDirection
+  complement: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input TransactionUpdateInput {
+  member: MemberRelateToManyForUpdateInput
+  policy: PolicyRelateToOneForUpdateInput
+  tid: String
+  depositVolume: Float
+  unlockStory: StoryRelateToOneForUpdateInput
+  expireDate: DateTime
+  active: Boolean
+  status: TransactionStatusType
+  complement: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input PolicyRelateToOneForUpdateInput {
+  create: PolicyCreateInput
+  connect: PolicyWhereUniqueInput
+  disconnect: Boolean
+}
+
+input TransactionUpdateArgs {
+  where: TransactionWhereUniqueInput!
+  data: TransactionUpdateInput!
+}
+
+input TransactionCreateInput {
+  member: MemberRelateToManyForCreateInput
+  policy: PolicyRelateToOneForCreateInput
+  tid: String
+  depositVolume: Float
+  unlockStory: StoryRelateToOneForCreateInput
+  expireDate: DateTime
+  active: Boolean
+  status: TransactionStatusType
+  complement: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
+input PolicyRelateToOneForCreateInput {
+  create: PolicyCreateInput
+  connect: PolicyWhereUniqueInput
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -2126,6 +2351,21 @@ type Mutation {
   updatePhotos(data: [PhotoUpdateArgs!]!): [Photo]
   deletePhoto(where: PhotoWhereUniqueInput!): Photo
   deletePhotos(where: [PhotoWhereUniqueInput!]!): [Photo]
+  createPolicy(data: PolicyCreateInput!): Policy
+  createPolicies(data: [PolicyCreateInput!]!): [Policy]
+  updatePolicy(where: PolicyWhereUniqueInput!, data: PolicyUpdateInput!): Policy
+  updatePolicies(data: [PolicyUpdateArgs!]!): [Policy]
+  deletePolicy(where: PolicyWhereUniqueInput!): Policy
+  deletePolicies(where: [PolicyWhereUniqueInput!]!): [Policy]
+  createTransaction(data: TransactionCreateInput!): Transaction
+  createTransactions(data: [TransactionCreateInput!]!): [Transaction]
+  updateTransaction(
+    where: TransactionWhereUniqueInput!
+    data: TransactionUpdateInput!
+  ): Transaction
+  updateTransactions(data: [TransactionUpdateArgs!]!): [Transaction]
+  deleteTransaction(where: TransactionWhereUniqueInput!): Transaction
+  deleteTransactions(where: [TransactionWhereUniqueInput!]!): [Transaction]
   endSession: Boolean!
   authenticateUserWithPassword(
     email: String!
@@ -2277,6 +2517,22 @@ type Query {
   ): [Photo!]
   photo(where: PhotoWhereUniqueInput!): Photo
   photosCount(where: PhotoWhereInput! = {}): Int
+  policies(
+    where: PolicyWhereInput! = {}
+    orderBy: [PolicyOrderByInput!]! = []
+    take: Int
+    skip: Int! = 0
+  ): [Policy!]
+  policy(where: PolicyWhereUniqueInput!): Policy
+  policiesCount(where: PolicyWhereInput! = {}): Int
+  transactions(
+    where: TransactionWhereInput! = {}
+    orderBy: [TransactionOrderByInput!]! = []
+    take: Int
+    skip: Int! = 0
+  ): [Transaction!]
+  transaction(where: TransactionWhereUniqueInput!): Transaction
+  transactionsCount(where: TransactionWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
 }

--- a/packages/mesh/schema.graphql
+++ b/packages/mesh/schema.graphql
@@ -2099,13 +2099,7 @@ input PolicyCreateInput {
 
 type Transaction {
   id: ID!
-  member(
-    where: MemberWhereInput! = {}
-    orderBy: [MemberOrderByInput!]! = []
-    take: Int
-    skip: Int! = 0
-  ): [Member!]
-  memberCount(where: MemberWhereInput! = {}): Int
+  member: Member
   policy: Policy
   tid: String
   depositVolume: Float
@@ -2134,7 +2128,7 @@ input TransactionWhereInput {
   OR: [TransactionWhereInput!]
   NOT: [TransactionWhereInput!]
   id: IDFilter
-  member: MemberManyRelationFilter
+  member: MemberWhereInput
   policy: PolicyWhereInput
   tid: StringFilter
   depositVolume: FloatNullableFilter
@@ -2169,7 +2163,7 @@ input TransactionOrderByInput {
 }
 
 input TransactionUpdateInput {
-  member: MemberRelateToManyForUpdateInput
+  member: MemberRelateToOneForUpdateInput
   policy: PolicyRelateToOneForUpdateInput
   tid: String
   depositVolume: Float
@@ -2196,7 +2190,7 @@ input TransactionUpdateArgs {
 }
 
 input TransactionCreateInput {
-  member: MemberRelateToManyForCreateInput
+  member: MemberRelateToOneForCreateInput
   policy: PolicyRelateToOneForCreateInput
   tid: String
   depositVolume: Float

--- a/packages/mesh/schema.prisma
+++ b/packages/mesh/schema.prisma
@@ -481,7 +481,8 @@ model Policy {
 
 model Transaction {
   id            Int                    @id @default(autoincrement())
-  member        Member[]               @relation("Transaction_member")
+  member        Member?                @relation("Transaction_member", fields: [memberId], references: [id])
+  memberId      Int?                   @map("member")
   policy        Policy?                @relation("Transaction_policy", fields: [policyId], references: [id])
   policyId      Int?                   @map("policy")
   tid           String                 @default("")
@@ -499,6 +500,7 @@ model Transaction {
   updatedBy     User?                  @relation("Transaction_updatedBy", fields: [updatedById], references: [id])
   updatedById   Int?                   @map("updatedBy")
 
+  @@index([memberId])
   @@index([policyId])
   @@index([unlockStoryId])
   @@index([createdById])

--- a/packages/mesh/schema.prisma
+++ b/packages/mesh/schema.prisma
@@ -46,6 +46,10 @@ model User {
   from_Announcement_updatedBy     Announcement[]     @relation("Announcement_updatedBy")
   from_Photo_createdBy            Photo[]            @relation("Photo_createdBy")
   from_Photo_updatedBy            Photo[]            @relation("Photo_updatedBy")
+  from_Policy_createdBy           Policy[]           @relation("Policy_createdBy")
+  from_Policy_updatedBy           Policy[]           @relation("Policy_updatedBy")
+  from_Transaction_createdBy      Transaction[]      @relation("Transaction_createdBy")
+  from_Transaction_updatedBy      Transaction[]      @relation("Transaction_updatedBy")
 }
 
 model Category {
@@ -140,28 +144,29 @@ model Pick {
 }
 
 model Publisher {
-  id                Int       @id @default(autoincrement())
-  title             String    @default("")
-  official_site     String    @default("")
-  rss               String    @default("")
-  summary           String    @default("")
-  logo              String    @default("")
-  description       String    @default("")
-  customId          String    @default("")
-  lang              String?   @default("zh-TW")
-  full_content      Boolean   @default(false)
-  full_screen_ad    String?   @default("none")
-  source_type       String?   @default("empty")
-  paywall           Boolean   @default(false)
-  follower          Member[]  @relation("Member_follow_publisher")
-  wallet            String    @default("")
-  createdAt         DateTime?
-  updatedAt         DateTime?
-  createdBy         User?     @relation("Publisher_createdBy", fields: [createdById], references: [id])
-  createdById       Int?      @map("createdBy")
-  updatedBy         User?     @relation("Publisher_updatedBy", fields: [updatedById], references: [id])
-  updatedById       Int?      @map("updatedBy")
-  from_Story_source Story[]   @relation("Story_source")
+  id                    Int       @id @default(autoincrement())
+  title                 String    @default("")
+  official_site         String    @default("")
+  rss                   String    @default("")
+  summary               String    @default("")
+  logo                  String    @default("")
+  description           String    @default("")
+  customId              String    @default("")
+  lang                  String?   @default("zh-TW")
+  full_content          Boolean   @default(false)
+  full_screen_ad        String?   @default("none")
+  source_type           String?   @default("empty")
+  paywall               Boolean   @default(false)
+  follower              Member[]  @relation("Member_follow_publisher")
+  wallet                String    @default("")
+  createdAt             DateTime?
+  updatedAt             DateTime?
+  createdBy             User?     @relation("Publisher_createdBy", fields: [createdById], references: [id])
+  createdById           Int?      @map("createdBy")
+  updatedBy             User?     @relation("Publisher_updatedBy", fields: [updatedById], references: [id])
+  updatedById           Int?      @map("updatedBy")
+  from_Story_source     Story[]   @relation("Story_source")
+  from_Policy_publisher Policy[]  @relation("Policy_publisher")
 
   @@index([createdById])
   @@index([updatedById])
@@ -277,43 +282,44 @@ model InvitationCode {
 }
 
 model Story {
-  id                        Int              @id @default(autoincrement())
-  title                     String           @default("")
-  url                       String           @unique @default("")
-  summary                   String           @default("")
-  content                   String           @default("")
-  trimContent               String           @default("")
-  writer                    String           @default("")
-  apiData                   Json?
-  trimApiData               Json?
-  source                    Publisher?       @relation("Story_source", fields: [sourceId], references: [id])
-  sourceId                  Int?             @map("source")
-  author                    Member?          @relation("Story_author", fields: [authorId], references: [id])
-  authorId                  Int?             @map("author")
-  category                  Category?        @relation("Story_category", fields: [categoryId], references: [id])
-  categoryId                Int?             @map("category")
-  pick                      Pick[]           @relation("Pick_story")
-  comment                   Comment[]        @relation("Comment_story")
-  related                   Story[]          @relation("Story_related")
-  published_date            DateTime?
-  og_title                  String           @default("")
-  og_image                  String           @default("")
-  og_description            String           @default("")
-  full_content              Boolean          @default(false)
-  paywall                   Boolean          @default(false)
-  origid                    String           @default("")
-  full_screen_ad            String?          @default("none")
-  is_active                 Boolean          @default(true)
-  tag                       Tag[]            @relation("Story_tag")
-  createdAt                 DateTime?
-  updatedAt                 DateTime?
-  createdBy                 User?            @relation("Story_createdBy", fields: [createdById], references: [id])
-  createdById               Int?             @map("createdBy")
-  updatedBy                 User?            @relation("Story_updatedBy", fields: [updatedById], references: [id])
-  updatedById               Int?             @map("updatedBy")
-  from_CollectionPick_story CollectionPick[] @relation("CollectionPick_story")
-  from_Story_related        Story[]          @relation("Story_related")
-  from_Tag_story            Tag[]            @relation("Tag_story")
+  id                           Int              @id @default(autoincrement())
+  title                        String           @default("")
+  url                          String           @unique @default("")
+  summary                      String           @default("")
+  content                      String           @default("")
+  trimContent                  String           @default("")
+  writer                       String           @default("")
+  apiData                      Json?
+  trimApiData                  Json?
+  source                       Publisher?       @relation("Story_source", fields: [sourceId], references: [id])
+  sourceId                     Int?             @map("source")
+  author                       Member?          @relation("Story_author", fields: [authorId], references: [id])
+  authorId                     Int?             @map("author")
+  category                     Category?        @relation("Story_category", fields: [categoryId], references: [id])
+  categoryId                   Int?             @map("category")
+  pick                         Pick[]           @relation("Pick_story")
+  comment                      Comment[]        @relation("Comment_story")
+  related                      Story[]          @relation("Story_related")
+  published_date               DateTime?
+  og_title                     String           @default("")
+  og_image                     String           @default("")
+  og_description               String           @default("")
+  full_content                 Boolean          @default(false)
+  paywall                      Boolean          @default(false)
+  origid                       String           @default("")
+  full_screen_ad               String?          @default("none")
+  is_active                    Boolean          @default(true)
+  tag                          Tag[]            @relation("Story_tag")
+  createdAt                    DateTime?
+  updatedAt                    DateTime?
+  createdBy                    User?            @relation("Story_createdBy", fields: [createdById], references: [id])
+  createdById                  Int?             @map("createdBy")
+  updatedBy                    User?            @relation("Story_updatedBy", fields: [updatedById], references: [id])
+  updatedById                  Int?             @map("updatedBy")
+  from_CollectionPick_story    CollectionPick[] @relation("CollectionPick_story")
+  from_Story_related           Story[]          @relation("Story_related")
+  from_Tag_story               Tag[]            @relation("Tag_story")
+  from_Transaction_unlockStory Transaction[]    @relation("Transaction_unlockStory")
 
   @@index([sourceId])
   @@index([authorId])
@@ -379,6 +385,7 @@ model Member {
   from_Story_author            Story[]            @relation("Story_author")
   from_Notify_member           Notify[]           @relation("Notify_member")
   from_Notify_sender           Notify[]           @relation("Notify_sender")
+  from_Transaction_member      Transaction[]      @relation("Transaction_member")
 
   @@index([avatar_imageId])
   @@index([createdById])
@@ -447,4 +454,64 @@ model Photo {
   @@index([createdById])
   @@index([updatedById])
   @@map("Image")
+}
+
+model Policy {
+  id                      Int             @id @default(autoincrement())
+  name                    String          @default("")
+  explanation             String          @default("")
+  type                    PolicyTypeType?
+  unlockSingle            Boolean         @default(false)
+  publisher               Publisher?      @relation("Policy_publisher", fields: [publisherId], references: [id])
+  publisherId             Int?            @map("publisher")
+  duration                Int?
+  charge                  Float?          @default(0)
+  createdAt               DateTime?
+  updatedAt               DateTime?
+  createdBy               User?           @relation("Policy_createdBy", fields: [createdById], references: [id])
+  createdById             Int?            @map("createdBy")
+  updatedBy               User?           @relation("Policy_updatedBy", fields: [updatedById], references: [id])
+  updatedById             Int?            @map("updatedBy")
+  from_Transaction_policy Transaction[]   @relation("Transaction_policy")
+
+  @@index([publisherId])
+  @@index([createdById])
+  @@index([updatedById])
+}
+
+model Transaction {
+  id            Int                    @id @default(autoincrement())
+  member        Member[]               @relation("Transaction_member")
+  policy        Policy?                @relation("Transaction_policy", fields: [policyId], references: [id])
+  policyId      Int?                   @map("policy")
+  tid           String                 @default("")
+  depositVolume Float?
+  unlockStory   Story?                 @relation("Transaction_unlockStory", fields: [unlockStoryId], references: [id])
+  unlockStoryId Int?                   @map("unlockStory")
+  expireDate    DateTime?
+  active        Boolean                @default(true)
+  status        TransactionStatusType?
+  complement    String                 @default("")
+  createdAt     DateTime?
+  updatedAt     DateTime?
+  createdBy     User?                  @relation("Transaction_createdBy", fields: [createdById], references: [id])
+  createdById   Int?                   @map("createdBy")
+  updatedBy     User?                  @relation("Transaction_updatedBy", fields: [updatedById], references: [id])
+  updatedById   Int?                   @map("updatedBy")
+
+  @@index([policyId])
+  @@index([unlockStoryId])
+  @@index([createdById])
+  @@index([updatedById])
+}
+
+enum PolicyTypeType {
+  deposit
+  unlock_all_publishers
+  unlock_one_publisher
+}
+
+enum TransactionStatusType {
+  Success
+  Failed
 }


### PR DESCRIPTION
### 說明
新增Policy(政策)和Transaction(交易紀錄)的Lists，用來管理儲值與付費解鎖相關資料。

### 使用方式
在Policy(政策)制定不同媒體的文章收費方式，並藉由設定Unlock single控制該政策負責的是"單一文章解鎖"或"解鎖該媒體所有文章"，並設定Duration設定解鎖後的有效期限。
Transaction(交易紀錄)則是使用者在Client-side藉由錢包完成支付後需要寫入到CMS的資料，在後台我們會參考Transaction綁定的Policy得知為儲值或解鎖文章，我們會拿TID至鏈上進行交易查詢比對金額是否符合，若符合的話將status設定為成功。
另外，使用者仍在有效期限內的Transaction紀錄後續會包在JWT裡面作為AccessToken的驗證資訊。

### 限制
此次更動僅支援加密貨幣的支付方式，若需要支援一般支付方式(Linepay, Googlepay......)需額外再設計。

### 資料欄位
詳細欄位說明請參考Dropbox文件如下
https://paper.dropbox.com/doc/CMSMesh--CSrQ8xSjjbTdeCyjVbAudO_fAg-bEsabOAeV6VzR52lYfyHm



