### PR TITLE
fix(mirrordaily): add missing 'quote' on migrations file and 's' in description

### DIFF
--- a/packages/mirrordaily/lists/EditorChoice.ts
+++ b/packages/mirrordaily/lists/EditorChoice.ts
@@ -43,8 +43,15 @@ const listConfigurations = list({
       isIndexed: true,
     }),
     heroImage: relationship({
-      ref: 'Photo',
       label: '首圖',
+      ref: 'Photo',
+      ui: {
+        displayMode: 'cards',
+        cardFields: ['imageFile'],
+        linkToItem: true,
+        inlineConnect: true,
+        views: './lists/views/sorted-relationship/index',
+      },
     }),
   },
   ui: {

--- a/packages/mirrordaily/lists/Game.ts
+++ b/packages/mirrordaily/lists/Game.ts
@@ -48,7 +48,7 @@ const listConfigurations = list({
       label: '置頂',
       defaultValue: false,
     }),
-    description: text({
+    descriptions: text({
       label: '說明',
       isFilterable: false,
       validation: { isRequired: false },

--- a/packages/mirrordaily/migrations/20240724161735_add&remove_game&editorchoice_list/migration.sql
+++ b/packages/mirrordaily/migrations/20240724161735_add&remove_game&editorchoice_list/migration.sql
@@ -1,9 +1,9 @@
 ALTER TABLE "Game"
-ADD COLUMN descriptions TEXT NOT NULL DEFAULT '',
-ADD COLUMN sortOrder INTEGER;
+ADD COLUMN "descriptions" TEXT NOT NULL DEFAULT '',
+ADD COLUMN "sortOrder" INTEGER;
 
 ALTER TABLE "EditorChoice"
-ADD COLUMN heroImage INTEGER;
+ADD COLUMN "heroImage" INTEGER;
 
 ALTER TABLE "EditorChoice"
-DROP COLUMN publishedDate;
+DROP COLUMN "publishedDate";

--- a/packages/mirrordaily/schema.graphql
+++ b/packages/mirrordaily/schema.graphql
@@ -2040,7 +2040,7 @@ type Game {
   heroImage: Photo
   link: String
   isFeatured: Boolean
-  description: String
+  descriptions: String
   sortOrder: Int
   createdAt: DateTime
   updatedAt: DateTime
@@ -2077,7 +2077,7 @@ input GameOrderByInput {
   publishedDate: OrderDirection
   link: OrderDirection
   isFeatured: OrderDirection
-  description: OrderDirection
+  descriptions: OrderDirection
   sortOrder: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
@@ -2090,7 +2090,7 @@ input GameUpdateInput {
   heroImage: PhotoRelateToOneForUpdateInput
   link: String
   isFeatured: Boolean
-  description: String
+  descriptions: String
   sortOrder: Int
   createdAt: DateTime
   updatedAt: DateTime
@@ -2110,7 +2110,7 @@ input GameCreateInput {
   heroImage: PhotoRelateToOneForCreateInput
   link: String
   isFeatured: Boolean
-  description: String
+  descriptions: String
   sortOrder: Int
   createdAt: DateTime
   updatedAt: DateTime

--- a/packages/mirrordaily/schema.prisma
+++ b/packages/mirrordaily/schema.prisma
@@ -515,7 +515,7 @@ model Game {
   heroImageId   Int?      @map("heroImage")
   link          String    @default("")
   isFeatured    Boolean   @default(false)
-  description   String    @default("")
+  descriptions  String    @default("")
   sortOrder     Int?
   createdAt     DateTime?
   updatedAt     DateTime?


### PR DESCRIPTION
1. 補上migration file 上沒有在欄位加上quote 的 bug 以及 description 加上s
2. Improve EditorChoice 的首圖欄位使用者體驗