### PR TITLE
feat(mesh): add new status processing to transaction related lists

### DIFF
--- a/packages/mesh/lists/exchange.ts
+++ b/packages/mesh/lists/exchange.ts
@@ -29,6 +29,7 @@ const listConfigurations = list({
         options: [
             {label: "成功", value: "Success"},
             {label: "失敗", value: "Failed"},
+            {label: "處理中", value: "Processing"},
         ]
     }),
     complement: text({

--- a/packages/mesh/lists/sponsorship.ts
+++ b/packages/mesh/lists/sponsorship.ts
@@ -34,6 +34,7 @@ const listConfigurations = list({
         options: [
             {label: "成功", value: "Success"},
             {label: "失敗", value: "Failed"},
+            {label: "處理中", value: "Processing"},
         ]
     }),
     complement: text({

--- a/packages/mesh/lists/transaction.ts
+++ b/packages/mesh/lists/transaction.ts
@@ -47,6 +47,7 @@ const listConfigurations = list({
         options: [
             {label: "成功", value: "Success"},
             {label: "失敗", value: "Failed"},
+            {label: "處理中", value: "Processing"},
         ]
     }),
     complement: text({

--- a/packages/mesh/migrations/20241220023445_add_status_processing_transaction/migration.sql
+++ b/packages/mesh/migrations/20241220023445_add_status_processing_transaction/migration.sql
@@ -1,0 +1,8 @@
+-- AlterEnum
+ALTER TYPE "ExchangeStatusType" ADD VALUE 'Processing';
+
+-- AlterEnum
+ALTER TYPE "SponsorshipStatusType" ADD VALUE 'Processing';
+
+-- AlterEnum
+ALTER TYPE "TransactionStatusType" ADD VALUE 'Processing';

--- a/packages/mesh/schema.graphql
+++ b/packages/mesh/schema.graphql
@@ -2505,6 +2505,7 @@ type Transaction {
 enum TransactionStatusType {
   Success
   Failed
+  Processing
 }
 
 input TransactionWhereUniqueInput {
@@ -2615,6 +2616,7 @@ type Sponsorship {
 enum SponsorshipStatusType {
   Success
   Failed
+  Processing
 }
 
 input SponsorshipWhereUniqueInput {
@@ -2702,6 +2704,7 @@ type Exchange {
 enum ExchangeStatusType {
   Success
   Failed
+  Processing
 }
 
 input ExchangeWhereUniqueInput {

--- a/packages/mesh/schema.prisma
+++ b/packages/mesh/schema.prisma
@@ -641,14 +641,17 @@ enum PolicyTypeType {
 enum TransactionStatusType {
   Success
   Failed
+  Processing
 }
 
 enum SponsorshipStatusType {
   Success
   Failed
+  Processing
 }
 
 enum ExchangeStatusType {
   Success
   Failed
+  Processing
 }


### PR DESCRIPTION
因應接下來交易驗證的更版，此次PR針對交易相關的欄位新增狀態(status): Processing。

後續相關交易驗證的更版流程，請參考以下文件：
https://paper.dropbox.com/doc/Payment--Cc1iH_~Oes6Vr6cXVhd2xWVKAQ-nqZHuR0SkiPpqrXwdpXZH