### PR TITLE
feat(mesh): modify tid of transaction related list isRequired to false

### DIFF
--- a/packages/mesh/lists/exchange.ts
+++ b/packages/mesh/lists/exchange.ts
@@ -14,7 +14,7 @@ const listConfigurations = list({
     tid: text({
         label: '交易編號(TransactionID)',
         validation: {
-            isRequired: true,
+            isRequired: false,
         },
     }),
     exchangeVolume: float({

--- a/packages/mesh/lists/sponsorship.ts
+++ b/packages/mesh/lists/sponsorship.ts
@@ -9,7 +9,7 @@ const listConfigurations = list({
     tid: text({
         label: '交易編號(TransactionID)',
         validation: {
-            isRequired: true,
+            isRequired: false,
         },
     }),
     sponsor: relationship({ 

--- a/packages/mesh/lists/transaction.ts
+++ b/packages/mesh/lists/transaction.ts
@@ -19,7 +19,7 @@ const listConfigurations = list({
     tid: text({
         label: '交易編號(TransactionID)',
         validation: {
-            isRequired: true,
+            isRequired: false,
         },
     }),
     depositVolume: float({


### PR DESCRIPTION
因應交易驗證的流程更動，將交易相關的lists的TID(區塊鏈交易編號)改為非必須，
使交易開始前能夠預先建立交易訂單。