### PR TITLE
feat(mirrormedia): add announcement lists

### DIFF
--- a/packages/mirrormedia/keystone.ts
+++ b/packages/mirrormedia/keystone.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import { config } from '@keystone-6/core'
 import { listDefinition as lists } from './lists'
 import envVar from './environment-variables'

--- a/packages/mirrormedia/lists/Announcement.ts
+++ b/packages/mirrormedia/lists/Announcement.ts
@@ -1,0 +1,124 @@
+import { utils } from '@mirrormedia/lilith-core'
+import { graphql, list } from '@keystone-6/core'
+import {
+  relationship,
+  text,
+  timestamp,
+  virtual,
+  select,
+} from '@keystone-6/core/fields'
+
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+const listConfigurations = list({
+  fields: {
+    title: text({
+      label: '公告標題',
+      db: {
+        isNullable: false,
+      },
+      validation: {
+        isRequired: true,
+      },
+      ui: {
+        displayMode: 'input',
+      },
+    }),
+    description: text({
+      label: '公告內容',
+      db: {
+        isNullable: false,
+      },
+      validation: {
+        isRequired: true,
+      },
+      ui: {
+        displayMode: 'textarea',
+      },
+    }),
+    startDate: timestamp({
+      label: '公告起始日期',
+      db: {
+        isNullable: true,
+      },
+      validation: {
+        isRequired: false,
+      },
+    }),
+    endDate: timestamp({
+      label: '公告結束日期',
+      db: {
+        isNullable: true,
+      },
+      validation: {
+        isRequired: false,
+      },
+    }),
+    isActive: virtual({
+      label: '公告是否生效中',
+      field: graphql.field({
+        type: graphql.Boolean,
+        async resolve(item) {
+          const now = Date.now()
+          const startDate = item.startDate as Date | null | undefined
+          const endDate = item.endDate as Date | null | undefined
+
+          if (startDate && endDate) {
+            return startDate.valueOf() < now && now < endDate.valueOf()
+          } else if (startDate) {
+            return startDate.valueOf() < now
+          } else if (endDate) {
+            return now < endDate.valueOf()
+          } else {
+            return true
+          }
+        },
+      }),
+    }),
+    level: select({
+      label: '公告重要程度',
+      type: 'enum',
+      defaultValue: 'info',
+      options: [
+        {
+          label: '一般',
+          value: 'info',
+        },
+        {
+          label: '重要',
+          value: 'warning',
+        },
+      ],
+      validation: {
+        isRequired: true,
+      },
+    }),
+    scope: relationship({
+      label: '公告要顯示的範圍',
+      ref: 'AnnouncementScope',
+      many: true,
+      ui: {
+        labelField: 'name',
+      },
+    }),
+  },
+  hooks: {},
+  ui: {
+    labelField: 'id',
+    listView: {
+      initialColumns: ['id', 'title', 'isActive', 'level'],
+      initialSort: { field: 'id', direction: 'DESC' },
+      pageSize: 50,
+    },
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator, editor),
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  },
+})
+
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/mirrormedia/lists/AnnouncementScope.ts
+++ b/packages/mirrormedia/lists/AnnouncementScope.ts
@@ -1,0 +1,54 @@
+import { utils } from '@mirrormedia/lilith-core'
+import { list } from '@keystone-6/core'
+import { text } from '@keystone-6/core/fields'
+
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+const listConfigurations = list({
+  fields: {
+    name: text({
+      label: '範圍名稱',
+      isIndexed: 'unique',
+      db: {
+        isNullable: false,
+      },
+      validation: {
+        isRequired: true,
+      },
+      ui: {
+        displayMode: 'input',
+      },
+    }),
+    description: text({
+      label: '範圍說明',
+      db: {
+        isNullable: false,
+      },
+      validation: {
+        isRequired: true,
+      },
+      ui: {
+        displayMode: 'textarea',
+      },
+    }),
+  },
+  hooks: {},
+  ui: {
+    labelField: 'name',
+    listView: {
+      initialColumns: ['id', 'name', 'description'],
+      initialSort: { field: 'id', direction: 'DESC' },
+      pageSize: 50,
+    },
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator, editor),
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  },
+})
+
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/mirrormedia/lists/index.ts
+++ b/packages/mirrormedia/lists/index.ts
@@ -15,9 +15,13 @@ import Topic from './Topic'
 import External from './External'
 import Header from './Header'
 import Group from './Group'
+import AnnouncementScope from './AnnouncementScope'
+import Announcement from './Announcement'
 
 export const listDefinition = {
   AudioFile: Audio,
+  AnnouncementScope,
+  Announcement,
   Category,
   Contact,
   EditorChoice,

--- a/packages/mirrormedia/migrations/20250115031008_add_annoucement_list/migration.sql
+++ b/packages/mirrormedia/migrations/20250115031008_add_annoucement_list/migration.sql
@@ -1,0 +1,83 @@
+-- CreateEnum
+CREATE TYPE "AnnouncementLevelType" AS ENUM ('info', 'warning');
+
+-- CreateTable
+CREATE TABLE "AnnouncementScope" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL DEFAULT '',
+    "description" TEXT NOT NULL DEFAULT '',
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "AnnouncementScope_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Announcement" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL DEFAULT '',
+    "description" TEXT NOT NULL DEFAULT '',
+    "startDate" TIMESTAMP(3),
+    "endDate" TIMESTAMP(3),
+    "level" "AnnouncementLevelType" NOT NULL DEFAULT 'info',
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "Announcement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_Announcement_scope" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AnnouncementScope_name_key" ON "AnnouncementScope"("name");
+
+-- CreateIndex
+CREATE INDEX "AnnouncementScope_createdBy_idx" ON "AnnouncementScope"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "AnnouncementScope_updatedBy_idx" ON "AnnouncementScope"("updatedBy");
+
+-- CreateIndex
+CREATE INDEX "Announcement_createdBy_idx" ON "Announcement"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "Announcement_updatedBy_idx" ON "Announcement"("updatedBy");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Announcement_scope_AB_unique" ON "_Announcement_scope"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Announcement_scope_B_index" ON "_Announcement_scope"("B");
+
+-- AddForeignKey
+ALTER TABLE "AnnouncementScope" ADD CONSTRAINT "AnnouncementScope_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AnnouncementScope" ADD CONSTRAINT "AnnouncementScope_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Announcement" ADD CONSTRAINT "Announcement_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Announcement" ADD CONSTRAINT "Announcement_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Announcement_scope" ADD CONSTRAINT "_Announcement_scope_A_fkey" FOREIGN KEY ("A") REFERENCES "Announcement"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Announcement_scope" ADD CONSTRAINT "_Announcement_scope_B_fkey" FOREIGN KEY ("B") REFERENCES "AnnouncementScope"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Insert Initial AnnoucemnetScope records
+INSERT INTO "AnnouncementScope" ("name", "description")
+VALUES
+('all', '全站'),
+('papermag', '紙本雜誌')
+ON CONFLICT ("name") DO NOTHING;

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -194,6 +194,174 @@ input UserRelateToOneForCreateInput {
   connect: UserWhereUniqueInput
 }
 
+type AnnouncementScope {
+  id: ID!
+  name: String
+  description: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+input AnnouncementScopeWhereUniqueInput {
+  id: ID
+  name: String
+}
+
+input AnnouncementScopeWhereInput {
+  AND: [AnnouncementScopeWhereInput!]
+  OR: [AnnouncementScopeWhereInput!]
+  NOT: [AnnouncementScopeWhereInput!]
+  id: IDFilter
+  name: StringFilter
+  description: StringFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input AnnouncementScopeOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  description: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input AnnouncementScopeUpdateInput {
+  name: String
+  description: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input AnnouncementScopeUpdateArgs {
+  where: AnnouncementScopeWhereUniqueInput!
+  data: AnnouncementScopeUpdateInput!
+}
+
+input AnnouncementScopeCreateInput {
+  name: String
+  description: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
+type Announcement {
+  id: ID!
+  title: String
+  description: String
+  startDate: DateTime
+  endDate: DateTime
+  isActive: Boolean
+  level: AnnouncementLevelType
+  scope(where: AnnouncementScopeWhereInput! = {}, orderBy: [AnnouncementScopeOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AnnouncementScopeWhereUniqueInput): [AnnouncementScope!]
+  scopeCount(where: AnnouncementScopeWhereInput! = {}): Int
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+enum AnnouncementLevelType {
+  info
+  warning
+}
+
+input AnnouncementWhereUniqueInput {
+  id: ID
+}
+
+input AnnouncementWhereInput {
+  AND: [AnnouncementWhereInput!]
+  OR: [AnnouncementWhereInput!]
+  NOT: [AnnouncementWhereInput!]
+  id: IDFilter
+  title: StringFilter
+  description: StringFilter
+  startDate: DateTimeNullableFilter
+  endDate: DateTimeNullableFilter
+  level: AnnouncementLevelTypeNullableFilter
+  scope: AnnouncementScopeManyRelationFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input AnnouncementLevelTypeNullableFilter {
+  equals: AnnouncementLevelType
+  in: [AnnouncementLevelType!]
+  notIn: [AnnouncementLevelType!]
+  not: AnnouncementLevelTypeNullableFilter
+}
+
+input AnnouncementScopeManyRelationFilter {
+  every: AnnouncementScopeWhereInput
+  some: AnnouncementScopeWhereInput
+  none: AnnouncementScopeWhereInput
+}
+
+input AnnouncementOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+  description: OrderDirection
+  startDate: OrderDirection
+  endDate: OrderDirection
+  level: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input AnnouncementUpdateInput {
+  title: String
+  description: String
+  startDate: DateTime
+  endDate: DateTime
+  level: AnnouncementLevelType
+  scope: AnnouncementScopeRelateToManyForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input AnnouncementScopeRelateToManyForUpdateInput {
+  disconnect: [AnnouncementScopeWhereUniqueInput!]
+  set: [AnnouncementScopeWhereUniqueInput!]
+  create: [AnnouncementScopeCreateInput!]
+  connect: [AnnouncementScopeWhereUniqueInput!]
+}
+
+input AnnouncementUpdateArgs {
+  where: AnnouncementWhereUniqueInput!
+  data: AnnouncementUpdateInput!
+}
+
+input AnnouncementCreateInput {
+  title: String
+  description: String
+  startDate: DateTime
+  endDate: DateTime
+  level: AnnouncementLevelType
+  scope: AnnouncementScopeRelateToManyForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
+input AnnouncementScopeRelateToManyForCreateInput {
+  create: [AnnouncementScopeCreateInput!]
+  connect: [AnnouncementScopeWhereUniqueInput!]
+}
+
 type Category {
   id: ID!
   name: String
@@ -2099,6 +2267,18 @@ type Mutation {
   updateAudioFiles(data: [AudioFileUpdateArgs!]!): [AudioFile]
   deleteAudioFile(where: AudioFileWhereUniqueInput!): AudioFile
   deleteAudioFiles(where: [AudioFileWhereUniqueInput!]!): [AudioFile]
+  createAnnouncementScope(data: AnnouncementScopeCreateInput!): AnnouncementScope
+  createAnnouncementScopes(data: [AnnouncementScopeCreateInput!]!): [AnnouncementScope]
+  updateAnnouncementScope(where: AnnouncementScopeWhereUniqueInput!, data: AnnouncementScopeUpdateInput!): AnnouncementScope
+  updateAnnouncementScopes(data: [AnnouncementScopeUpdateArgs!]!): [AnnouncementScope]
+  deleteAnnouncementScope(where: AnnouncementScopeWhereUniqueInput!): AnnouncementScope
+  deleteAnnouncementScopes(where: [AnnouncementScopeWhereUniqueInput!]!): [AnnouncementScope]
+  createAnnouncement(data: AnnouncementCreateInput!): Announcement
+  createAnnouncements(data: [AnnouncementCreateInput!]!): [Announcement]
+  updateAnnouncement(where: AnnouncementWhereUniqueInput!, data: AnnouncementUpdateInput!): Announcement
+  updateAnnouncements(data: [AnnouncementUpdateArgs!]!): [Announcement]
+  deleteAnnouncement(where: AnnouncementWhereUniqueInput!): Announcement
+  deleteAnnouncements(where: [AnnouncementWhereUniqueInput!]!): [Announcement]
   createCategory(data: CategoryCreateInput!): Category
   createCategories(data: [CategoryCreateInput!]!): [Category]
   updateCategory(where: CategoryWhereUniqueInput!, data: CategoryUpdateInput!): Category
@@ -2222,6 +2402,12 @@ type Query {
   audioFiles(where: AudioFileWhereInput! = {}, orderBy: [AudioFileOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AudioFileWhereUniqueInput): [AudioFile!]
   audioFile(where: AudioFileWhereUniqueInput!): AudioFile
   audioFilesCount(where: AudioFileWhereInput! = {}): Int
+  announcementScopes(where: AnnouncementScopeWhereInput! = {}, orderBy: [AnnouncementScopeOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AnnouncementScopeWhereUniqueInput): [AnnouncementScope!]
+  announcementScope(where: AnnouncementScopeWhereUniqueInput!): AnnouncementScope
+  announcementScopesCount(where: AnnouncementScopeWhereInput! = {}): Int
+  announcements(where: AnnouncementWhereInput! = {}, orderBy: [AnnouncementOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AnnouncementWhereUniqueInput): [Announcement!]
+  announcement(where: AnnouncementWhereUniqueInput!): Announcement
+  announcementsCount(where: AnnouncementWhereInput! = {}): Int
   categories(where: CategoryWhereInput! = {}, orderBy: [CategoryOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CategoryWhereUniqueInput): [Category!]
   category(where: CategoryWhereUniqueInput!): Category
   categoriesCount(where: CategoryWhereInput! = {}): Int

--- a/packages/mirrormedia/schema.prisma
+++ b/packages/mirrormedia/schema.prisma
@@ -34,6 +34,41 @@ model AudioFile {
   @@index([updatedById])
 }
 
+model AnnouncementScope {
+  id                      Int            @id @default(autoincrement())
+  name                    String         @unique @default("")
+  description             String         @default("")
+  createdAt               DateTime?
+  updatedAt               DateTime?
+  createdBy               User?          @relation("AnnouncementScope_createdBy", fields: [createdById], references: [id])
+  createdById             Int?           @map("createdBy")
+  updatedBy               User?          @relation("AnnouncementScope_updatedBy", fields: [updatedById], references: [id])
+  updatedById             Int?           @map("updatedBy")
+  from_Announcement_scope Announcement[] @relation("Announcement_scope")
+
+  @@index([createdById])
+  @@index([updatedById])
+}
+
+model Announcement {
+  id          Int                   @id @default(autoincrement())
+  title       String                @default("")
+  description String                @default("")
+  startDate   DateTime?
+  endDate     DateTime?
+  level       AnnouncementLevelType @default(info)
+  scope       AnnouncementScope[]   @relation("Announcement_scope")
+  createdAt   DateTime?
+  updatedAt   DateTime?
+  createdBy   User?                 @relation("Announcement_createdBy", fields: [createdById], references: [id])
+  createdById Int?                  @map("createdBy")
+  updatedBy   User?                 @relation("Announcement_updatedBy", fields: [updatedById], references: [id])
+  updatedById Int?                  @map("updatedBy")
+
+  @@index([createdById])
+  @@index([updatedById])
+}
+
 model Category {
   id                   Int       @id @default(autoincrement())
   name                 String    @unique @default("")
@@ -441,45 +476,49 @@ model Topic {
 }
 
 model User {
-  id                          Int            @id @default(autoincrement())
-  name                        String         @default("")
-  email                       String         @unique @default("")
-  password                    String
-  role                        String
-  isProtected                 Boolean        @default(false)
-  from_AudioFile_createdBy    AudioFile[]    @relation("AudioFile_createdBy")
-  from_AudioFile_updatedBy    AudioFile[]    @relation("AudioFile_updatedBy")
-  from_Category_createdBy     Category[]     @relation("Category_createdBy")
-  from_Category_updatedBy     Category[]     @relation("Category_updatedBy")
-  from_Contact_createdBy      Contact[]      @relation("Contact_createdBy")
-  from_Contact_updatedBy      Contact[]      @relation("Contact_updatedBy")
-  from_EditorChoice_createdBy EditorChoice[] @relation("EditorChoice_createdBy")
-  from_EditorChoice_updatedBy EditorChoice[] @relation("EditorChoice_updatedBy")
-  from_Event_createdBy        Event[]        @relation("Event_createdBy")
-  from_Event_updatedBy        Event[]        @relation("Event_updatedBy")
-  from_External_createdBy     External[]     @relation("External_createdBy")
-  from_External_updatedBy     External[]     @relation("External_updatedBy")
-  from_Header_createdBy       Header[]       @relation("Header_createdBy")
-  from_Header_updatedBy       Header[]       @relation("Header_updatedBy")
-  from_Magazine_createdBy     Magazine[]     @relation("Magazine_createdBy")
-  from_Magazine_updatedBy     Magazine[]     @relation("Magazine_updatedBy")
-  from_Partner_createdBy      Partner[]      @relation("Partner_createdBy")
-  from_Partner_updatedBy      Partner[]      @relation("Partner_updatedBy")
-  from_Photo_createdBy        Photo[]        @relation("Photo_createdBy")
-  from_Photo_updatedBy        Photo[]        @relation("Photo_updatedBy")
-  from_Post_lockBy            Post[]         @relation("Post_lockBy")
-  from_Post_createdBy         Post[]         @relation("Post_createdBy")
-  from_Post_updatedBy         Post[]         @relation("Post_updatedBy")
-  from_Section_createdBy      Section[]      @relation("Section_createdBy")
-  from_Section_updatedBy      Section[]      @relation("Section_updatedBy")
-  from_Tag_createdBy          Tag[]          @relation("Tag_createdBy")
-  from_Tag_updatedBy          Tag[]          @relation("Tag_updatedBy")
-  from_Topic_createdBy        Topic[]        @relation("Topic_createdBy")
-  from_Topic_updatedBy        Topic[]        @relation("Topic_updatedBy")
-  from_Video_createdBy        Video[]        @relation("Video_createdBy")
-  from_Video_updatedBy        Video[]        @relation("Video_updatedBy")
-  from_Group_createdBy        Group[]        @relation("Group_createdBy")
-  from_Group_updatedBy        Group[]        @relation("Group_updatedBy")
+  id                               Int                 @id @default(autoincrement())
+  name                             String              @default("")
+  email                            String              @unique @default("")
+  password                         String
+  role                             String
+  isProtected                      Boolean             @default(false)
+  from_AudioFile_createdBy         AudioFile[]         @relation("AudioFile_createdBy")
+  from_AudioFile_updatedBy         AudioFile[]         @relation("AudioFile_updatedBy")
+  from_AnnouncementScope_createdBy AnnouncementScope[] @relation("AnnouncementScope_createdBy")
+  from_AnnouncementScope_updatedBy AnnouncementScope[] @relation("AnnouncementScope_updatedBy")
+  from_Announcement_createdBy      Announcement[]      @relation("Announcement_createdBy")
+  from_Announcement_updatedBy      Announcement[]      @relation("Announcement_updatedBy")
+  from_Category_createdBy          Category[]          @relation("Category_createdBy")
+  from_Category_updatedBy          Category[]          @relation("Category_updatedBy")
+  from_Contact_createdBy           Contact[]           @relation("Contact_createdBy")
+  from_Contact_updatedBy           Contact[]           @relation("Contact_updatedBy")
+  from_EditorChoice_createdBy      EditorChoice[]      @relation("EditorChoice_createdBy")
+  from_EditorChoice_updatedBy      EditorChoice[]      @relation("EditorChoice_updatedBy")
+  from_Event_createdBy             Event[]             @relation("Event_createdBy")
+  from_Event_updatedBy             Event[]             @relation("Event_updatedBy")
+  from_External_createdBy          External[]          @relation("External_createdBy")
+  from_External_updatedBy          External[]          @relation("External_updatedBy")
+  from_Header_createdBy            Header[]            @relation("Header_createdBy")
+  from_Header_updatedBy            Header[]            @relation("Header_updatedBy")
+  from_Magazine_createdBy          Magazine[]          @relation("Magazine_createdBy")
+  from_Magazine_updatedBy          Magazine[]          @relation("Magazine_updatedBy")
+  from_Partner_createdBy           Partner[]           @relation("Partner_createdBy")
+  from_Partner_updatedBy           Partner[]           @relation("Partner_updatedBy")
+  from_Photo_createdBy             Photo[]             @relation("Photo_createdBy")
+  from_Photo_updatedBy             Photo[]             @relation("Photo_updatedBy")
+  from_Post_lockBy                 Post[]              @relation("Post_lockBy")
+  from_Post_createdBy              Post[]              @relation("Post_createdBy")
+  from_Post_updatedBy              Post[]              @relation("Post_updatedBy")
+  from_Section_createdBy           Section[]           @relation("Section_createdBy")
+  from_Section_updatedBy           Section[]           @relation("Section_updatedBy")
+  from_Tag_createdBy               Tag[]               @relation("Tag_createdBy")
+  from_Tag_updatedBy               Tag[]               @relation("Tag_updatedBy")
+  from_Topic_createdBy             Topic[]             @relation("Topic_createdBy")
+  from_Topic_updatedBy             Topic[]             @relation("Topic_updatedBy")
+  from_Video_createdBy             Video[]             @relation("Video_createdBy")
+  from_Video_updatedBy             Video[]             @relation("Video_updatedBy")
+  from_Group_createdBy             Group[]             @relation("Group_createdBy")
+  from_Group_updatedBy             Group[]             @relation("Group_updatedBy")
 }
 
 model Video {
@@ -527,4 +566,9 @@ model Group {
 
   @@index([createdById])
   @@index([updatedById])
+}
+
+enum AnnouncementLevelType {
+  info
+  warning
 }


### PR DESCRIPTION
## Notable Changes
* 增加 Announcement 和 AnnouncementScope list，作為公告使用 ([參考](https://paper.dropbox.com/doc/--CecP_cSQcIbFfDIKiQdDQGkKAg-LtpvUSQx42SAOzCX9Dx00#:h2=CMS-%E5%A2%9E%E5%8A%A0-Announcement-%E5%92%8C-Announce))

## Notes
* AnnouncementScope 預設加入 `all` 和 `papermag` 的資料，並做碰撞處理 ([參考](https://docs.postgresql.tw/reference/sql-commands/insert#on-conflict-clause))

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209097125214556