### PR TITLE
feat(mesh): add balance column to member list

### DIFF
--- a/packages/mesh/lists/member.ts
+++ b/packages/mesh/lists/member.ts
@@ -1,6 +1,6 @@
 import { utils } from '@mirrormedia/lilith-core'
 import { list } from '@keystone-6/core'
-import { text, relationship, checkbox } from '@keystone-6/core/fields'
+import { text, relationship, checkbox, integer } from '@keystone-6/core/fields'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
 
@@ -120,6 +120,13 @@ const listConfigurations = list({
     modify_collection: relationship({
       ref: 'CollectionMember.updated_by',
       many: true,
+    }),
+    balance: integer({
+      label: '錢包餘額(此為後端寫入之鏈下資料)',
+      defaultValue: 0,
+      ui: {
+        createView: {fieldMode: "hidden"},
+      }
     }),
   },
   ui: {

--- a/packages/mesh/migrations/20250124061551_add_member_balance/migration.sql
+++ b/packages/mesh/migrations/20250124061551_add_member_balance/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Member" ADD COLUMN     "balance" INTEGER DEFAULT 0;

--- a/packages/mesh/schema.graphql
+++ b/packages/mesh/schema.graphql
@@ -1716,6 +1716,7 @@ type Member {
     skip: Int! = 0
   ): [CollectionMember!]
   modify_collectionCount(where: CollectionMemberWhereInput! = {}): Int
+  balance: Int
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User
@@ -1763,6 +1764,7 @@ input MemberWhereInput {
   invited_by: InvitationCodeWhereInput
   create_collection: CollectionMemberManyRelationFilter
   modify_collection: CollectionMemberManyRelationFilter
+  balance: IntNullableFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
@@ -1817,6 +1819,7 @@ input MemberOrderByInput {
   email: OrderDirection
   is_active: OrderDirection
   verified: OrderDirection
+  balance: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
@@ -1851,6 +1854,7 @@ input MemberUpdateInput {
   invited_by: InvitationCodeRelateToOneForUpdateInput
   create_collection: CollectionMemberRelateToManyForUpdateInput
   modify_collection: CollectionMemberRelateToManyForUpdateInput
+  balance: Int
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
@@ -1940,6 +1944,7 @@ input MemberCreateInput {
   invited_by: InvitationCodeRelateToOneForCreateInput
   create_collection: CollectionMemberRelateToManyForCreateInput
   modify_collection: CollectionMemberRelateToManyForCreateInput
+  balance: Int
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput

--- a/packages/mesh/schema.prisma
+++ b/packages/mesh/schema.prisma
@@ -422,6 +422,7 @@ model Member {
   invited_by                   InvitationCode?    @relation("InvitationCode_receive")
   create_collection            CollectionMember[] @relation("CollectionMember_added_by")
   modify_collection            CollectionMember[] @relation("CollectionMember_updated_by")
+  balance                      Int?               @default(0)
   createdAt                    DateTime?
   updatedAt                    DateTime?
   createdBy                    User?              @relation("Member_createdBy", fields: [createdById], references: [id])


### PR DESCRIPTION
為了避免在產生財報時需在鏈上查詢大量的餘額資料，
在此次更新中為member新增balance欄位，該欄位會在空投與交易行為完成後將用戶更新後的餘額寫入，
使在進行財報計算時便可以直接從GQL快速拉出餘額資料進行統計。

