### PR TITLE
feat: modify story and podcast list, the revision is to separate podcast text document and src

### DIFF
--- a/packages/mesh/lists/comment.ts
+++ b/packages/mesh/lists/comment.ts
@@ -22,7 +22,6 @@ const listConfigurations = list ({
   fields: {
 	member: relationship({ ref: 'Member.comment', many: false }),
 	story: relationship({ ref: 'Story.comment', many: false }),
-	podcast: relationship({ ref: 'Podcast.comment', many: false }),
     collection: relationship({ ref: 'Collection.comment', many: false }),
     content: text({ validation: { isRequired: false } }),
 	parent: relationship({ ref: 'Comment', many: false }),

--- a/packages/mesh/lists/pick.ts
+++ b/packages/mesh/lists/pick.ts
@@ -29,7 +29,6 @@ const listConfigurations = list ({
       ]
 	}),
     story: relationship({ ref: 'Story.pick', many: false }),
-    podcast: relationship({ ref: 'Podcast.pick', many: false }),
     collection: relationship({ ref: 'Collection.picks', many: false }),
     comment: relationship({ ref: 'Comment', many: false}),
     pick_comment: relationship({ ref: 'Comment', many: true }),

--- a/packages/mesh/lists/podcast.ts
+++ b/packages/mesh/lists/podcast.ts
@@ -14,39 +14,16 @@ const { allowRoles, admin, moderator, editor } = utils.accessControl
 
 const listConfigurations = list({
   fields: {
-    title: text({ validation: { isRequired: false } }),
     url: text({
       validation: { isRequired: true },
       isIndexed: 'unique',
     }),
-    description: text({
-      validation: { isRequired: false },
-      ui: { displayMode: 'textarea' },
-    }),
-    author: text({
-      validation: { isRequired: false },
-    }),
     source: relationship({ ref: 'Publisher', many: false }),
-    category: relationship({ ref: 'Category', many: false }),
-    duration: text({ validation: { isRequired: false } }),
-    pick: relationship({ ref: 'Pick.podcast', many: true }),
-    comment: relationship({ ref: 'Comment.podcast', many: true }),
-    published_date: timestamp({ validation: { isRequired: false } }),
-    og_title: text({ validation: { isRequired: false } }),
-    og_image: text({ validation: { isRequired: false } }),
-    og_description: text({ validation: { isRequired: false } }),
-    isMember: checkbox({
-      defaultValue: false,
-    }),
-    origid: text({}),
-    is_active: checkbox({
-      defaultValue: true,
-    }),
-    tag: relationship({ ref: 'Tag', many: true }),
+    document: relationship({ ref: 'Story', many: false }),
   },
   ui: {
     listView: {
-      initialColumns: ['title', 'url', "source", "author"],
+      initialColumns: ['url', "source"],
     },
   },
   access: {

--- a/packages/mesh/lists/podcast.ts
+++ b/packages/mesh/lists/podcast.ts
@@ -11,16 +11,29 @@ const { allowRoles, admin, moderator, editor } = utils.accessControl
 
 const listConfigurations = list({
   fields: {
+    author: text({ 
+      label: '作者', 
+      validation: { isRequired: false },
+    }),
     url: text({
+      label : '音源連結',
       validation: { isRequired: true },
       isIndexed: 'unique',
     }),
-    author: text({ validation: { isRequired: false },}),
+    file_size: integer({ 
+      label : '音源檔案大小',
+      validation: { isRequired: false },
+    }),
+    mime_type: text({ 
+      label : '音源檔案格式',
+      validation: { isRequired: false } 
+    }),
     duration: text({ validation: { isRequired: false } }),
     source: relationship({ ref: 'Publisher', many: false }),
-    story: relationship({ ref: 'Story', many: false }),
-    file_size: integer({ validation: { isRequired: false } }),
-    mime_type: text({ validation: { isRequired: false } }),
+    story: relationship({ 
+      label : '所屬文章',
+      ref: 'Story', many: false 
+    }),
   },
   ui: {
     listView: {

--- a/packages/mesh/lists/podcast.ts
+++ b/packages/mesh/lists/podcast.ts
@@ -3,10 +3,7 @@ import { list } from '@keystone-6/core'
 import {
   text,
   relationship,
-  select,
-  timestamp,
-  checkbox,
-  json,
+  integer,
 } from '@keystone-6/core/fields'
 import { checkAccessToken } from '../utils/accessToken'
 
@@ -18,8 +15,12 @@ const listConfigurations = list({
       validation: { isRequired: true },
       isIndexed: 'unique',
     }),
+    author: text({ validation: { isRequired: false },}),
+    duration: text({ validation: { isRequired: false } }),
     source: relationship({ ref: 'Publisher', many: false }),
-    document: relationship({ ref: 'Story', many: false }),
+    story: relationship({ ref: 'Story', many: false }),
+    file_size: integer({ validation: { isRequired: false } }),
+    mime_type: text({ validation: { isRequired: false } }),
   },
   ui: {
     listView: {

--- a/packages/mesh/lists/podcast.ts
+++ b/packages/mesh/lists/podcast.ts
@@ -37,7 +37,7 @@ const listConfigurations = list({
   },
   ui: {
     listView: {
-      initialColumns: ['url', "source"],
+      initialColumns: ['story','source', "url"],
     },
   },
   access: {

--- a/packages/mesh/lists/story.ts
+++ b/packages/mesh/lists/story.ts
@@ -76,7 +76,7 @@ const listConfigurations = list({
     origid: text({}),
     full_screen_ad: select({
       label: '蓋板',
-      datatype: 'enum',
+      type: 'enum',
       options: [
         { label: '手機', value: 'mobile' },
         { label: '桌機', value: 'desktop' },
@@ -91,15 +91,14 @@ const listConfigurations = list({
     tag: relationship({ ref: 'Tag.story', many: true }),
     story_type: select({
       label: '類型',
-      datatype: 'enum',
+      type: 'enum',
       options: [
         { label: 'Story', value: 'story' },
         { label: 'Podcast', value: 'podcast' },
       ],
       defaultValue: 'story',
-      isIndexed: true,
     }),
-    podcast_src: relationship({ ref: 'Podcast', many: false }),
+    podcast: relationship({ ref: 'Podcast', many: false }),
   },
   ui: {
     listView: {

--- a/packages/mesh/lists/story.ts
+++ b/packages/mesh/lists/story.ts
@@ -97,6 +97,7 @@ const listConfigurations = list({
         { label: 'Podcast', value: 'podcast' },
       ],
       defaultValue: 'story',
+      isIndexed: true,
     }),
     podcast: relationship({ ref: 'Podcast', many: false }),
   },

--- a/packages/mesh/lists/story.ts
+++ b/packages/mesh/lists/story.ts
@@ -89,6 +89,17 @@ const listConfigurations = list({
       defaultValue: true,
     }),
     tag: relationship({ ref: 'Tag.story', many: true }),
+    story_type: select({
+      label: '類型',
+      datatype: 'enum',
+      options: [
+        { label: 'Story', value: 'story' },
+        { label: 'Podcast', value: 'podcast' },
+      ],
+      defaultValue: 'story',
+      isIndexed: true,
+    }),
+    podcast_src: relationship({ ref: 'Podcast', many: false }),
   },
   ui: {
     listView: {

--- a/packages/mesh/migrations/20250208062324_modify_story_and_podcast_list_the_revision_is_to_separate_podcast_text_document_and_src/migration.sql
+++ b/packages/mesh/migrations/20250208062324_modify_story_and_podcast_list_the_revision_is_to_separate_podcast_text_document_and_src/migration.sql
@@ -1,0 +1,90 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `podcast` on the `Comment` table. All the data in the column will be lost.
+  - You are about to drop the column `podcast` on the `Pick` table. All the data in the column will be lost.
+  - You are about to drop the column `author` on the `Podcast` table. All the data in the column will be lost.
+  - You are about to drop the column `category` on the `Podcast` table. All the data in the column will be lost.
+  - You are about to drop the column `description` on the `Podcast` table. All the data in the column will be lost.
+  - You are about to drop the column `duration` on the `Podcast` table. All the data in the column will be lost.
+  - You are about to drop the column `isMember` on the `Podcast` table. All the data in the column will be lost.
+  - You are about to drop the column `is_active` on the `Podcast` table. All the data in the column will be lost.
+  - You are about to drop the column `og_description` on the `Podcast` table. All the data in the column will be lost.
+  - You are about to drop the column `og_image` on the `Podcast` table. All the data in the column will be lost.
+  - You are about to drop the column `og_title` on the `Podcast` table. All the data in the column will be lost.
+  - You are about to drop the column `origid` on the `Podcast` table. All the data in the column will be lost.
+  - You are about to drop the column `published_date` on the `Podcast` table. All the data in the column will be lost.
+  - You are about to drop the column `title` on the `Podcast` table. All the data in the column will be lost.
+  - You are about to drop the `_Podcast_tag` table. If the table is not empty, all the data it contains will be lost.
+  - A unique constraint covering the columns `[reason]` on the table `ReportReason` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Comment" DROP CONSTRAINT "Comment_podcast_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Pick" DROP CONSTRAINT "Pick_podcast_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Podcast" DROP CONSTRAINT "Podcast_category_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Podcast_tag" DROP CONSTRAINT "_Podcast_tag_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Podcast_tag" DROP CONSTRAINT "_Podcast_tag_B_fkey";
+
+-- DropIndex
+DROP INDEX "Comment_podcast_idx";
+
+-- DropIndex
+DROP INDEX "Pick_podcast_idx";
+
+-- DropIndex
+DROP INDEX "Podcast_category_idx";
+
+-- AlterTable
+ALTER TABLE "Comment" DROP COLUMN "podcast";
+
+-- AlterTable
+ALTER TABLE "Pick" DROP COLUMN "podcast";
+
+-- AlterTable
+ALTER TABLE "Podcast" DROP COLUMN "author",
+DROP COLUMN "category",
+DROP COLUMN "description",
+DROP COLUMN "duration",
+DROP COLUMN "isMember",
+DROP COLUMN "is_active",
+DROP COLUMN "og_description",
+DROP COLUMN "og_image",
+DROP COLUMN "og_title",
+DROP COLUMN "origid",
+DROP COLUMN "published_date",
+DROP COLUMN "title",
+ADD COLUMN     "document" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Story" ADD COLUMN     "podcast_src" INTEGER,
+ADD COLUMN     "story_type" TEXT DEFAULT E'story';
+
+-- DropTable
+DROP TABLE "_Podcast_tag";
+
+-- CreateIndex
+CREATE INDEX "Podcast_document_idx" ON "Podcast"("document");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReportReason_reason_key" ON "ReportReason"("reason");
+
+-- CreateIndex
+CREATE INDEX "Story_story_type_idx" ON "Story"("story_type");
+
+-- CreateIndex
+CREATE INDEX "Story_podcast_src_idx" ON "Story"("podcast_src");
+
+-- AddForeignKey
+ALTER TABLE "Story" ADD CONSTRAINT "Story_podcast_src_fkey" FOREIGN KEY ("podcast_src") REFERENCES "Podcast"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Podcast" ADD CONSTRAINT "Podcast_document_fkey" FOREIGN KEY ("document") REFERENCES "Story"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/mesh/migrations/20250208073215_modify_story_and_podcast_list_the_revision_is_to_separate_podcast_text_document_and_src/migration.sql
+++ b/packages/mesh/migrations/20250208073215_modify_story_and_podcast_list_the_revision_is_to_separate_podcast_text_document_and_src/migration.sql
@@ -3,10 +3,8 @@
 
   - You are about to drop the column `podcast` on the `Comment` table. All the data in the column will be lost.
   - You are about to drop the column `podcast` on the `Pick` table. All the data in the column will be lost.
-  - You are about to drop the column `author` on the `Podcast` table. All the data in the column will be lost.
   - You are about to drop the column `category` on the `Podcast` table. All the data in the column will be lost.
   - You are about to drop the column `description` on the `Podcast` table. All the data in the column will be lost.
-  - You are about to drop the column `duration` on the `Podcast` table. All the data in the column will be lost.
   - You are about to drop the column `isMember` on the `Podcast` table. All the data in the column will be lost.
   - You are about to drop the column `is_active` on the `Podcast` table. All the data in the column will be lost.
   - You are about to drop the column `og_description` on the `Podcast` table. All the data in the column will be lost.
@@ -15,10 +13,17 @@
   - You are about to drop the column `origid` on the `Podcast` table. All the data in the column will be lost.
   - You are about to drop the column `published_date` on the `Podcast` table. All the data in the column will be lost.
   - You are about to drop the column `title` on the `Podcast` table. All the data in the column will be lost.
+  - The `full_screen_ad` column on the `Story` table would be dropped and recreated. This will lead to data loss if there is data in the column.
   - You are about to drop the `_Podcast_tag` table. If the table is not empty, all the data it contains will be lost.
   - A unique constraint covering the columns `[reason]` on the table `ReportReason` will be added. If there are existing duplicate values, this will fail.
 
 */
+-- CreateEnum
+CREATE TYPE "StoryFullScreenAdType" AS ENUM ('mobile', 'desktop', 'all', 'none');
+
+-- CreateEnum
+CREATE TYPE "StoryStoryTypeType" AS ENUM ('story', 'podcast');
+
 -- DropForeignKey
 ALTER TABLE "Comment" DROP CONSTRAINT "Comment_podcast_fkey";
 
@@ -50,10 +55,8 @@ ALTER TABLE "Comment" DROP COLUMN "podcast";
 ALTER TABLE "Pick" DROP COLUMN "podcast";
 
 -- AlterTable
-ALTER TABLE "Podcast" DROP COLUMN "author",
-DROP COLUMN "category",
+ALTER TABLE "Podcast" DROP COLUMN "category",
 DROP COLUMN "description",
-DROP COLUMN "duration",
 DROP COLUMN "isMember",
 DROP COLUMN "is_active",
 DROP COLUMN "og_description",
@@ -62,29 +65,30 @@ DROP COLUMN "og_title",
 DROP COLUMN "origid",
 DROP COLUMN "published_date",
 DROP COLUMN "title",
-ADD COLUMN     "document" INTEGER;
+ADD COLUMN     "file_size" INTEGER,
+ADD COLUMN     "mime_type" TEXT NOT NULL DEFAULT E'',
+ADD COLUMN     "story" INTEGER;
 
 -- AlterTable
-ALTER TABLE "Story" ADD COLUMN     "podcast_src" INTEGER,
-ADD COLUMN     "story_type" TEXT DEFAULT E'story';
+ALTER TABLE "Story" ADD COLUMN     "podcast" INTEGER,
+ADD COLUMN     "story_type" "StoryStoryTypeType" DEFAULT E'story',
+DROP COLUMN "full_screen_ad",
+ADD COLUMN     "full_screen_ad" "StoryFullScreenAdType" DEFAULT E'none';
 
 -- DropTable
 DROP TABLE "_Podcast_tag";
 
 -- CreateIndex
-CREATE INDEX "Podcast_document_idx" ON "Podcast"("document");
+CREATE INDEX "Podcast_story_idx" ON "Podcast"("story");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "ReportReason_reason_key" ON "ReportReason"("reason");
 
 -- CreateIndex
-CREATE INDEX "Story_story_type_idx" ON "Story"("story_type");
-
--- CreateIndex
-CREATE INDEX "Story_podcast_src_idx" ON "Story"("podcast_src");
+CREATE INDEX "Story_podcast_idx" ON "Story"("podcast");
 
 -- AddForeignKey
-ALTER TABLE "Story" ADD CONSTRAINT "Story_podcast_src_fkey" FOREIGN KEY ("podcast_src") REFERENCES "Podcast"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Story" ADD CONSTRAINT "Story_podcast_fkey" FOREIGN KEY ("podcast") REFERENCES "Podcast"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Podcast" ADD CONSTRAINT "Podcast_document_fkey" FOREIGN KEY ("document") REFERENCES "Story"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Podcast" ADD CONSTRAINT "Podcast_story_fkey" FOREIGN KEY ("story") REFERENCES "Story"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/mesh/schema.graphql
+++ b/packages/mesh/schema.graphql
@@ -1309,7 +1309,7 @@ type Story {
   paywall: Boolean
   isMember: Boolean
   origid: String
-  full_screen_ad: String
+  full_screen_ad: StoryFullScreenAdType
   is_active: Boolean
   tag(
     where: TagWhereInput! = {}
@@ -1318,12 +1318,24 @@ type Story {
     skip: Int! = 0
   ): [Tag!]
   tagCount(where: TagWhereInput! = {}): Int
-  story_type: String
-  podcast_src: Podcast
+  story_type: StoryStoryTypeType
+  podcast: Podcast
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User
   updatedBy: User
+}
+
+enum StoryFullScreenAdType {
+  mobile
+  desktop
+  all
+  none
+}
+
+enum StoryStoryTypeType {
+  story
+  podcast
 }
 
 input StoryWhereUniqueInput {
@@ -1356,11 +1368,11 @@ input StoryWhereInput {
   paywall: BooleanFilter
   isMember: BooleanFilter
   origid: StringFilter
-  full_screen_ad: StringNullableFilter
+  full_screen_ad: StoryFullScreenAdTypeNullableFilter
   is_active: BooleanFilter
   tag: TagManyRelationFilter
-  story_type: StringNullableFilter
-  podcast_src: PodcastWhereInput
+  story_type: StoryStoryTypeTypeNullableFilter
+  podcast: PodcastWhereInput
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
@@ -1373,10 +1385,24 @@ input StoryManyRelationFilter {
   none: StoryWhereInput
 }
 
+input StoryFullScreenAdTypeNullableFilter {
+  equals: StoryFullScreenAdType
+  in: [StoryFullScreenAdType!]
+  notIn: [StoryFullScreenAdType!]
+  not: StoryFullScreenAdTypeNullableFilter
+}
+
 input TagManyRelationFilter {
   every: TagWhereInput
   some: TagWhereInput
   none: TagWhereInput
+}
+
+input StoryStoryTypeTypeNullableFilter {
+  equals: StoryStoryTypeType
+  in: [StoryStoryTypeType!]
+  notIn: [StoryStoryTypeType!]
+  not: StoryStoryTypeTypeNullableFilter
 }
 
 input StoryOrderByInput {
@@ -1425,11 +1451,11 @@ input StoryUpdateInput {
   paywall: Boolean
   isMember: Boolean
   origid: String
-  full_screen_ad: String
+  full_screen_ad: StoryFullScreenAdType
   is_active: Boolean
   tag: TagRelateToManyForUpdateInput
-  story_type: String
-  podcast_src: PodcastRelateToOneForUpdateInput
+  story_type: StoryStoryTypeType
+  podcast: PodcastRelateToOneForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
@@ -1484,11 +1510,11 @@ input StoryCreateInput {
   paywall: Boolean
   isMember: Boolean
   origid: String
-  full_screen_ad: String
+  full_screen_ad: StoryFullScreenAdType
   is_active: Boolean
   tag: TagRelateToManyForCreateInput
-  story_type: String
-  podcast_src: PodcastRelateToOneForCreateInput
+  story_type: StoryStoryTypeType
+  podcast: PodcastRelateToOneForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput
@@ -2368,8 +2394,12 @@ input PolicyCreateInput {
 type Podcast {
   id: ID!
   url: String
+  author: String
+  duration: String
   source: Publisher
-  document: Story
+  story: Story
+  file_size: Int
+  mime_type: String
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User
@@ -2387,8 +2417,12 @@ input PodcastWhereInput {
   NOT: [PodcastWhereInput!]
   id: IDFilter
   url: StringFilter
+  author: StringFilter
+  duration: StringFilter
   source: PublisherWhereInput
-  document: StoryWhereInput
+  story: StoryWhereInput
+  file_size: IntNullableFilter
+  mime_type: StringFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
@@ -2398,14 +2432,22 @@ input PodcastWhereInput {
 input PodcastOrderByInput {
   id: OrderDirection
   url: OrderDirection
+  author: OrderDirection
+  duration: OrderDirection
+  file_size: OrderDirection
+  mime_type: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
 
 input PodcastUpdateInput {
   url: String
+  author: String
+  duration: String
   source: PublisherRelateToOneForUpdateInput
-  document: StoryRelateToOneForUpdateInput
+  story: StoryRelateToOneForUpdateInput
+  file_size: Int
+  mime_type: String
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
@@ -2419,8 +2461,12 @@ input PodcastUpdateArgs {
 
 input PodcastCreateInput {
   url: String
+  author: String
+  duration: String
   source: PublisherRelateToOneForCreateInput
-  document: StoryRelateToOneForCreateInput
+  story: StoryRelateToOneForCreateInput
+  file_size: Int
+  mime_type: String
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput

--- a/packages/mesh/schema.graphql
+++ b/packages/mesh/schema.graphql
@@ -290,7 +290,6 @@ type Comment {
   id: ID!
   member: Member
   story: Story
-  podcast: Podcast
   collection: Collection
   content: String
   parent: Comment
@@ -323,7 +322,6 @@ input CommentWhereInput {
   id: IDFilter
   member: MemberWhereInput
   story: StoryWhereInput
-  podcast: PodcastWhereInput
   collection: CollectionWhereInput
   content: StringFilter
   parent: CommentWhereInput
@@ -388,7 +386,6 @@ input CommentOrderByInput {
 input CommentUpdateInput {
   member: MemberRelateToOneForUpdateInput
   story: StoryRelateToOneForUpdateInput
-  podcast: PodcastRelateToOneForUpdateInput
   collection: CollectionRelateToOneForUpdateInput
   content: String
   parent: CommentRelateToOneForUpdateInput
@@ -413,12 +410,6 @@ input MemberRelateToOneForUpdateInput {
 input StoryRelateToOneForUpdateInput {
   create: StoryCreateInput
   connect: StoryWhereUniqueInput
-  disconnect: Boolean
-}
-
-input PodcastRelateToOneForUpdateInput {
-  create: PodcastCreateInput
-  connect: PodcastWhereUniqueInput
   disconnect: Boolean
 }
 
@@ -449,7 +440,6 @@ input CommentUpdateArgs {
 input CommentCreateInput {
   member: MemberRelateToOneForCreateInput
   story: StoryRelateToOneForCreateInput
-  podcast: PodcastRelateToOneForCreateInput
   collection: CollectionRelateToOneForCreateInput
   content: String
   parent: CommentRelateToOneForCreateInput
@@ -475,11 +465,6 @@ input StoryRelateToOneForCreateInput {
   connect: StoryWhereUniqueInput
 }
 
-input PodcastRelateToOneForCreateInput {
-  create: PodcastCreateInput
-  connect: PodcastWhereUniqueInput
-}
-
 input CollectionRelateToOneForCreateInput {
   create: CollectionCreateInput
   connect: CollectionWhereUniqueInput
@@ -500,7 +485,6 @@ type Pick {
   member: Member
   objective: String
   story: Story
-  podcast: Podcast
   collection: Collection
   comment: Comment
   pick_comment(
@@ -533,7 +517,6 @@ input PickWhereInput {
   member: MemberWhereInput
   objective: StringNullableFilter
   story: StoryWhereInput
-  podcast: PodcastWhereInput
   collection: CollectionWhereInput
   comment: CommentWhereInput
   pick_comment: CommentManyRelationFilter
@@ -570,7 +553,6 @@ input PickUpdateInput {
   member: MemberRelateToOneForUpdateInput
   objective: String
   story: StoryRelateToOneForUpdateInput
-  podcast: PodcastRelateToOneForUpdateInput
   collection: CollectionRelateToOneForUpdateInput
   comment: CommentRelateToOneForUpdateInput
   pick_comment: CommentRelateToManyForUpdateInput
@@ -601,7 +583,6 @@ input PickCreateInput {
   member: MemberRelateToOneForCreateInput
   objective: String
   story: StoryRelateToOneForCreateInput
-  podcast: PodcastRelateToOneForCreateInput
   collection: CollectionRelateToOneForCreateInput
   comment: CommentRelateToOneForCreateInput
   pick_comment: CommentRelateToManyForCreateInput
@@ -1337,6 +1318,8 @@ type Story {
     skip: Int! = 0
   ): [Tag!]
   tagCount(where: TagWhereInput! = {}): Int
+  story_type: String
+  podcast_src: Podcast
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User
@@ -1376,6 +1359,8 @@ input StoryWhereInput {
   full_screen_ad: StringNullableFilter
   is_active: BooleanFilter
   tag: TagManyRelationFilter
+  story_type: StringNullableFilter
+  podcast_src: PodcastWhereInput
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
@@ -1412,6 +1397,7 @@ input StoryOrderByInput {
   origid: OrderDirection
   full_screen_ad: OrderDirection
   is_active: OrderDirection
+  story_type: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
@@ -1442,6 +1428,8 @@ input StoryUpdateInput {
   full_screen_ad: String
   is_active: Boolean
   tag: TagRelateToManyForUpdateInput
+  story_type: String
+  podcast_src: PodcastRelateToOneForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
@@ -1460,6 +1448,12 @@ input TagRelateToManyForUpdateInput {
   set: [TagWhereUniqueInput!]
   create: [TagCreateInput!]
   connect: [TagWhereUniqueInput!]
+}
+
+input PodcastRelateToOneForUpdateInput {
+  create: PodcastCreateInput
+  connect: PodcastWhereUniqueInput
+  disconnect: Boolean
 }
 
 input StoryUpdateArgs {
@@ -1493,6 +1487,8 @@ input StoryCreateInput {
   full_screen_ad: String
   is_active: Boolean
   tag: TagRelateToManyForCreateInput
+  story_type: String
+  podcast_src: PodcastRelateToOneForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput
@@ -1507,6 +1503,11 @@ input StoryRelateToManyForCreateInput {
 input TagRelateToManyForCreateInput {
   create: [TagCreateInput!]
   connect: [TagWhereUniqueInput!]
+}
+
+input PodcastRelateToOneForCreateInput {
+  create: PodcastCreateInput
+  connect: PodcastWhereUniqueInput
 }
 
 type Tag {
@@ -2366,41 +2367,9 @@ input PolicyCreateInput {
 
 type Podcast {
   id: ID!
-  title: String
   url: String
-  description: String
-  author: String
   source: Publisher
-  category: Category
-  duration: String
-  pick(
-    where: PickWhereInput! = {}
-    orderBy: [PickOrderByInput!]! = []
-    take: Int
-    skip: Int! = 0
-  ): [Pick!]
-  pickCount(where: PickWhereInput! = {}): Int
-  comment(
-    where: CommentWhereInput! = {}
-    orderBy: [CommentOrderByInput!]! = []
-    take: Int
-    skip: Int! = 0
-  ): [Comment!]
-  commentCount(where: CommentWhereInput! = {}): Int
-  published_date: DateTime
-  og_title: String
-  og_image: String
-  og_description: String
-  isMember: Boolean
-  origid: String
-  is_active: Boolean
-  tag(
-    where: TagWhereInput! = {}
-    orderBy: [TagOrderByInput!]! = []
-    take: Int
-    skip: Int! = 0
-  ): [Tag!]
-  tagCount(where: TagWhereInput! = {}): Int
+  document: Story
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User
@@ -2417,23 +2386,9 @@ input PodcastWhereInput {
   OR: [PodcastWhereInput!]
   NOT: [PodcastWhereInput!]
   id: IDFilter
-  title: StringFilter
   url: StringFilter
-  description: StringFilter
-  author: StringFilter
   source: PublisherWhereInput
-  category: CategoryWhereInput
-  duration: StringFilter
-  pick: PickManyRelationFilter
-  comment: CommentManyRelationFilter
-  published_date: DateTimeNullableFilter
-  og_title: StringFilter
-  og_image: StringFilter
-  og_description: StringFilter
-  isMember: BooleanFilter
-  origid: StringFilter
-  is_active: BooleanFilter
-  tag: TagManyRelationFilter
+  document: StoryWhereInput
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
@@ -2442,40 +2397,15 @@ input PodcastWhereInput {
 
 input PodcastOrderByInput {
   id: OrderDirection
-  title: OrderDirection
   url: OrderDirection
-  description: OrderDirection
-  author: OrderDirection
-  duration: OrderDirection
-  published_date: OrderDirection
-  og_title: OrderDirection
-  og_image: OrderDirection
-  og_description: OrderDirection
-  isMember: OrderDirection
-  origid: OrderDirection
-  is_active: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
 
 input PodcastUpdateInput {
-  title: String
   url: String
-  description: String
-  author: String
   source: PublisherRelateToOneForUpdateInput
-  category: CategoryRelateToOneForUpdateInput
-  duration: String
-  pick: PickRelateToManyForUpdateInput
-  comment: CommentRelateToManyForUpdateInput
-  published_date: DateTime
-  og_title: String
-  og_image: String
-  og_description: String
-  isMember: Boolean
-  origid: String
-  is_active: Boolean
-  tag: TagRelateToManyForUpdateInput
+  document: StoryRelateToOneForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
@@ -2488,23 +2418,9 @@ input PodcastUpdateArgs {
 }
 
 input PodcastCreateInput {
-  title: String
   url: String
-  description: String
-  author: String
   source: PublisherRelateToOneForCreateInput
-  category: CategoryRelateToOneForCreateInput
-  duration: String
-  pick: PickRelateToManyForCreateInput
-  comment: CommentRelateToManyForCreateInput
-  published_date: DateTime
-  og_title: String
-  og_image: String
-  og_description: String
-  isMember: Boolean
-  origid: String
-  is_active: Boolean
-  tag: TagRelateToManyForCreateInput
+  document: StoryRelateToOneForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput
@@ -2821,6 +2737,7 @@ type ReportReason {
 
 input ReportReasonWhereUniqueInput {
   id: ID
+  reason: String
 }
 
 input ReportReasonWhereInput {

--- a/packages/mesh/schema.prisma
+++ b/packages/mesh/schema.prisma
@@ -97,7 +97,6 @@ model Category {
   from_Publisher_category        Publisher[] @relation("Publisher_category")
   from_Story_category            Story[]     @relation("Story_category")
   from_Member_following_category Member[]    @relation("Member_following_category")
-  from_Podcast_category          Podcast[]   @relation("Podcast_category")
 
   @@index([createdById])
   @@index([updatedById])
@@ -109,8 +108,6 @@ model Comment {
   memberId                  Int?           @map("member")
   story                     Story?         @relation("Comment_story", fields: [storyId], references: [id])
   storyId                   Int?           @map("story")
-  podcast                   Podcast?       @relation("Comment_podcast", fields: [podcastId], references: [id])
-  podcastId                 Int?           @map("podcast")
   collection                Collection?    @relation("Comment_collection", fields: [collectionId], references: [id])
   collectionId              Int?           @map("collection")
   content                   String         @default("")
@@ -137,7 +134,6 @@ model Comment {
 
   @@index([memberId])
   @@index([storyId])
-  @@index([podcastId])
   @@index([collectionId])
   @@index([parentId])
   @@index([rootId])
@@ -152,8 +148,6 @@ model Pick {
   objective     String?
   story         Story?      @relation("Pick_story", fields: [storyId], references: [id])
   storyId       Int?        @map("story")
-  podcast       Podcast?    @relation("Pick_podcast", fields: [podcastId], references: [id])
-  podcastId     Int?        @map("podcast")
   collection    Collection? @relation("Pick_collection", fields: [collectionId], references: [id])
   collectionId  Int?        @map("collection")
   comment       Comment?    @relation("Pick_comment", fields: [commentId], references: [id])
@@ -174,7 +168,6 @@ model Pick {
 
   @@index([memberId])
   @@index([storyId])
-  @@index([podcastId])
   @@index([collectionId])
   @@index([commentId])
   @@index([createdById])
@@ -362,6 +355,9 @@ model Story {
   full_screen_ad               String?          @default("none")
   is_active                    Boolean          @default(true)
   tag                          Tag[]            @relation("Story_tag")
+  story_type                   String?          @default("story")
+  podcast_src                  Podcast?         @relation("Story_podcast_src", fields: [podcast_srcId], references: [id])
+  podcast_srcId                Int?             @map("podcast_src")
   createdAt                    DateTime?
   updatedAt                    DateTime?
   createdBy                    User?            @relation("Story_createdBy", fields: [createdById], references: [id])
@@ -370,27 +366,29 @@ model Story {
   updatedById                  Int?             @map("updatedBy")
   from_CollectionPick_story    CollectionPick[] @relation("CollectionPick_story")
   from_Story_related           Story[]          @relation("Story_related")
+  from_Podcast_document        Podcast[]        @relation("Podcast_document")
   from_Transaction_unlockStory Transaction[]    @relation("Transaction_unlockStory")
 
   @@index([sourceId])
   @@index([authorId])
   @@index([categoryId])
+  @@index([story_type])
+  @@index([podcast_srcId])
   @@index([createdById])
   @@index([updatedById])
 }
 
 model Tag {
-  id               Int       @id @default(autoincrement())
-  name             String    @unique @default("")
-  pick             Pick[]    @relation("Tag_pick")
-  story            Story[]   @relation("Story_tag")
-  createdAt        DateTime?
-  updatedAt        DateTime?
-  createdBy        User?     @relation("Tag_createdBy", fields: [createdById], references: [id])
-  createdById      Int?      @map("createdBy")
-  updatedBy        User?     @relation("Tag_updatedBy", fields: [updatedById], references: [id])
-  updatedById      Int?      @map("updatedBy")
-  from_Podcast_tag Podcast[] @relation("Podcast_tag")
+  id          Int       @id @default(autoincrement())
+  name        String    @unique @default("")
+  pick        Pick[]    @relation("Tag_pick")
+  story       Story[]   @relation("Story_tag")
+  createdAt   DateTime?
+  updatedAt   DateTime?
+  createdBy   User?     @relation("Tag_createdBy", fields: [createdById], references: [id])
+  createdById Int?      @map("createdBy")
+  updatedBy   User?     @relation("Tag_updatedBy", fields: [updatedById], references: [id])
+  updatedById Int?      @map("updatedBy")
 
   @@index([createdById])
   @@index([updatedById])
@@ -537,35 +535,22 @@ model Policy {
 }
 
 model Podcast {
-  id             Int        @id @default(autoincrement())
-  title          String     @default("")
-  url            String     @unique @default("")
-  description    String     @default("")
-  author         String     @default("")
-  source         Publisher? @relation("Podcast_source", fields: [sourceId], references: [id])
-  sourceId       Int?       @map("source")
-  category       Category?  @relation("Podcast_category", fields: [categoryId], references: [id])
-  categoryId     Int?       @map("category")
-  duration       String     @default("")
-  pick           Pick[]     @relation("Pick_podcast")
-  comment        Comment[]  @relation("Comment_podcast")
-  published_date DateTime?
-  og_title       String     @default("")
-  og_image       String     @default("")
-  og_description String     @default("")
-  isMember       Boolean    @default(false)
-  origid         String     @default("")
-  is_active      Boolean    @default(true)
-  tag            Tag[]      @relation("Podcast_tag")
-  createdAt      DateTime?
-  updatedAt      DateTime?
-  createdBy      User?      @relation("Podcast_createdBy", fields: [createdById], references: [id])
-  createdById    Int?       @map("createdBy")
-  updatedBy      User?      @relation("Podcast_updatedBy", fields: [updatedById], references: [id])
-  updatedById    Int?       @map("updatedBy")
+  id                     Int        @id @default(autoincrement())
+  url                    String     @unique @default("")
+  source                 Publisher? @relation("Podcast_source", fields: [sourceId], references: [id])
+  sourceId               Int?       @map("source")
+  document               Story?     @relation("Podcast_document", fields: [documentId], references: [id])
+  documentId             Int?       @map("document")
+  createdAt              DateTime?
+  updatedAt              DateTime?
+  createdBy              User?      @relation("Podcast_createdBy", fields: [createdById], references: [id])
+  createdById            Int?       @map("createdBy")
+  updatedBy              User?      @relation("Podcast_updatedBy", fields: [updatedById], references: [id])
+  updatedById            Int?       @map("updatedBy")
+  from_Story_podcast_src Story[]    @relation("Story_podcast_src")
 
   @@index([sourceId])
-  @@index([categoryId])
+  @@index([documentId])
   @@index([createdById])
   @@index([updatedById])
 }
@@ -643,7 +628,7 @@ model Exchange {
 
 model ReportReason {
   id                       Int            @id @default(autoincrement())
-  reason                   String         @default("")
+  reason                   String         @unique @default("")
   createdAt                DateTime?
   updatedAt                DateTime?
   createdBy                User?          @relation("ReportReason_createdBy", fields: [createdById], references: [id])

--- a/packages/mesh/schema.prisma
+++ b/packages/mesh/schema.prisma
@@ -326,54 +326,53 @@ model InvitationCode {
 }
 
 model Story {
-  id                           Int              @id @default(autoincrement())
-  title                        String           @default("")
-  url                          String           @unique @default("")
-  summary                      String           @default("")
-  content                      String           @default("")
-  trimContent                  String           @default("")
-  writer                       String           @default("")
+  id                           Int                    @id @default(autoincrement())
+  title                        String                 @default("")
+  url                          String                 @unique @default("")
+  summary                      String                 @default("")
+  content                      String                 @default("")
+  trimContent                  String                 @default("")
+  writer                       String                 @default("")
   apiData                      Json?
   trimApiData                  Json?
-  source                       Publisher?       @relation("Story_source", fields: [sourceId], references: [id])
-  sourceId                     Int?             @map("source")
-  author                       Member?          @relation("Story_author", fields: [authorId], references: [id])
-  authorId                     Int?             @map("author")
-  category                     Category?        @relation("Story_category", fields: [categoryId], references: [id])
-  categoryId                   Int?             @map("category")
-  pick                         Pick[]           @relation("Pick_story")
-  comment                      Comment[]        @relation("Comment_story")
-  related                      Story[]          @relation("Story_related")
+  source                       Publisher?             @relation("Story_source", fields: [sourceId], references: [id])
+  sourceId                     Int?                   @map("source")
+  author                       Member?                @relation("Story_author", fields: [authorId], references: [id])
+  authorId                     Int?                   @map("author")
+  category                     Category?              @relation("Story_category", fields: [categoryId], references: [id])
+  categoryId                   Int?                   @map("category")
+  pick                         Pick[]                 @relation("Pick_story")
+  comment                      Comment[]              @relation("Comment_story")
+  related                      Story[]                @relation("Story_related")
   published_date               DateTime?
-  og_title                     String           @default("")
-  og_image                     String           @default("")
-  og_description               String           @default("")
-  full_content                 Boolean          @default(false)
-  paywall                      Boolean          @default(false)
-  isMember                     Boolean          @default(false)
-  origid                       String           @default("")
-  full_screen_ad               String?          @default("none")
-  is_active                    Boolean          @default(true)
-  tag                          Tag[]            @relation("Story_tag")
-  story_type                   String?          @default("story")
-  podcast_src                  Podcast?         @relation("Story_podcast_src", fields: [podcast_srcId], references: [id])
-  podcast_srcId                Int?             @map("podcast_src")
+  og_title                     String                 @default("")
+  og_image                     String                 @default("")
+  og_description               String                 @default("")
+  full_content                 Boolean                @default(false)
+  paywall                      Boolean                @default(false)
+  isMember                     Boolean                @default(false)
+  origid                       String                 @default("")
+  full_screen_ad               StoryFullScreenAdType? @default(none)
+  is_active                    Boolean                @default(true)
+  tag                          Tag[]                  @relation("Story_tag")
+  story_type                   StoryStoryTypeType?    @default(story)
+  podcast                      Podcast?               @relation("Story_podcast", fields: [podcastId], references: [id])
+  podcastId                    Int?                   @map("podcast")
   createdAt                    DateTime?
   updatedAt                    DateTime?
-  createdBy                    User?            @relation("Story_createdBy", fields: [createdById], references: [id])
-  createdById                  Int?             @map("createdBy")
-  updatedBy                    User?            @relation("Story_updatedBy", fields: [updatedById], references: [id])
-  updatedById                  Int?             @map("updatedBy")
-  from_CollectionPick_story    CollectionPick[] @relation("CollectionPick_story")
-  from_Story_related           Story[]          @relation("Story_related")
-  from_Podcast_document        Podcast[]        @relation("Podcast_document")
-  from_Transaction_unlockStory Transaction[]    @relation("Transaction_unlockStory")
+  createdBy                    User?                  @relation("Story_createdBy", fields: [createdById], references: [id])
+  createdById                  Int?                   @map("createdBy")
+  updatedBy                    User?                  @relation("Story_updatedBy", fields: [updatedById], references: [id])
+  updatedById                  Int?                   @map("updatedBy")
+  from_CollectionPick_story    CollectionPick[]       @relation("CollectionPick_story")
+  from_Story_related           Story[]                @relation("Story_related")
+  from_Podcast_story           Podcast[]              @relation("Podcast_story")
+  from_Transaction_unlockStory Transaction[]          @relation("Transaction_unlockStory")
 
   @@index([sourceId])
   @@index([authorId])
   @@index([categoryId])
-  @@index([story_type])
-  @@index([podcast_srcId])
+  @@index([podcastId])
   @@index([createdById])
   @@index([updatedById])
 }
@@ -535,22 +534,26 @@ model Policy {
 }
 
 model Podcast {
-  id                     Int        @id @default(autoincrement())
-  url                    String     @unique @default("")
-  source                 Publisher? @relation("Podcast_source", fields: [sourceId], references: [id])
-  sourceId               Int?       @map("source")
-  document               Story?     @relation("Podcast_document", fields: [documentId], references: [id])
-  documentId             Int?       @map("document")
-  createdAt              DateTime?
-  updatedAt              DateTime?
-  createdBy              User?      @relation("Podcast_createdBy", fields: [createdById], references: [id])
-  createdById            Int?       @map("createdBy")
-  updatedBy              User?      @relation("Podcast_updatedBy", fields: [updatedById], references: [id])
-  updatedById            Int?       @map("updatedBy")
-  from_Story_podcast_src Story[]    @relation("Story_podcast_src")
+  id                 Int        @id @default(autoincrement())
+  url                String     @unique @default("")
+  author             String     @default("")
+  duration           String     @default("")
+  source             Publisher? @relation("Podcast_source", fields: [sourceId], references: [id])
+  sourceId           Int?       @map("source")
+  story              Story?     @relation("Podcast_story", fields: [storyId], references: [id])
+  storyId            Int?       @map("story")
+  file_size          Int?
+  mime_type          String     @default("")
+  createdAt          DateTime?
+  updatedAt          DateTime?
+  createdBy          User?      @relation("Podcast_createdBy", fields: [createdById], references: [id])
+  createdById        Int?       @map("createdBy")
+  updatedBy          User?      @relation("Podcast_updatedBy", fields: [updatedById], references: [id])
+  updatedById        Int?       @map("updatedBy")
+  from_Story_podcast Story[]    @relation("Story_podcast")
 
   @@index([sourceId])
-  @@index([documentId])
+  @@index([storyId])
   @@index([createdById])
   @@index([updatedById])
 }
@@ -667,6 +670,18 @@ model ReportRecord {
   @@index([collectionId])
   @@index([createdById])
   @@index([updatedById])
+}
+
+enum StoryFullScreenAdType {
+  mobile
+  desktop
+  all
+  none
+}
+
+enum StoryStoryTypeType {
+  story
+  podcast
 }
 
 enum PolicyTypeType {


### PR DESCRIPTION
此份PR主要是將Podcast 以及 Story list 進行些微修改，將Podcast的來源與偏向document的資料拆開
1. document相關的儲存在story list
2. url 來源以及媒體 source 儲存在 podcast list 並且相關聯story list
3. story list 新增判斷type欄位