### PR TITLE
feat(mesh): add revenue and statement list

### DIFF
--- a/packages/mesh/lists/index.ts
+++ b/packages/mesh/lists/index.ts
@@ -19,6 +19,7 @@ import Transaction from './transaction'
 import Sponsorship from './sponsorship'
 import InvalidName from './invalid_name'
 import Exchange from './exchange'
+import Revenue from './revenue'
 
 export const listDefinition = {
   User,
@@ -42,4 +43,5 @@ export const listDefinition = {
   Transaction,
   Sponsorship,
   Exchange,
+  Revenue,
 }

--- a/packages/mesh/lists/index.ts
+++ b/packages/mesh/lists/index.ts
@@ -20,6 +20,7 @@ import Sponsorship from './sponsorship'
 import InvalidName from './invalid_name'
 import Exchange from './exchange'
 import Revenue from './revenue'
+import Statement from './statement'
 
 export const listDefinition = {
   User,
@@ -44,4 +45,5 @@ export const listDefinition = {
   Sponsorship,
   Exchange,
   Revenue,
+  Statement,
 }

--- a/packages/mesh/lists/revenue.ts
+++ b/packages/mesh/lists/revenue.ts
@@ -1,0 +1,61 @@
+import { list } from '@keystone-6/core'
+import { utils } from '@mirrormedia/lilith-core'
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+import { text, relationship, select, float, timestamp} from '@keystone-6/core/fields'
+
+const listConfigurations = list({
+  fields: {
+    title: text({
+        label: '標題',
+        validation: {
+            isRequired: false
+        }
+    }),
+    publisher: relationship({ 
+        label: "媒體",
+        ref: 'Publisher', 
+        many: false 
+    }),
+    type: select({
+        label: "種類",
+        type: "enum",  
+        options: [
+            { label: '文章廣告分潤', value: 'story_ad_revenue' },
+            { label: '基金池分潤', value: 'mutual_fund_revenue' },
+        ],
+    }),
+    value: float({
+        label: "分潤金額",
+        validation: {
+            isRequired: true,
+        }
+    }),
+    start_date: timestamp({
+        label: "資料起始時間",
+        validation: { 
+            isRequired: false 
+        } 
+    }),
+    end_date: timestamp({
+        label: "資料結束時間",
+        validation: { 
+            isRequired: false 
+        } 
+    }),
+  },
+  ui: {
+    listView: {
+      initialColumns: ['title', 'publisher', 'type', 'value'],
+    },
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator, editor),
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  },
+})
+
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/mesh/lists/statement.ts
+++ b/packages/mesh/lists/statement.ts
@@ -1,0 +1,62 @@
+import { list } from '@keystone-6/core'
+import { utils } from '@mirrormedia/lilith-core'
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+import { text, relationship, select, float, timestamp} from '@keystone-6/core/fields'
+
+const listConfigurations = list({
+  fields: {
+    title: text({
+        label: '標題',
+        validation: {
+            isRequired: false
+        }
+    }),
+    publisher: relationship({ 
+        label: "媒體",
+        ref: 'Publisher', 
+        many: false 
+    }),
+    type: select({
+        label: "種類",
+        type: "enum",  
+        options: [
+            { label: '月報', value: 'month' },
+            { label: '季報', value: 'quarter' },
+            { label: '半年報', value: 'semi_annual'}
+        ],
+    }),
+    url: text({
+        label: "檔案連結",
+        validation: {
+            isRequired: true,
+        }
+    }),
+    start_date: timestamp({
+        label: "計算起始時間",
+        validation: { 
+            isRequired: false 
+        } 
+    }),
+    end_date: timestamp({
+        label: "計算結束時間",
+        validation: { 
+            isRequired: false 
+        } 
+    }),
+  },
+  ui: {
+    listView: {
+      initialColumns: ['title', 'type', 'start_date', 'end_date'],
+    },
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator, editor),
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  },
+})
+
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/mesh/migrations/20250212022954_add_revenue_list/migration.sql
+++ b/packages/mesh/migrations/20250212022954_add_revenue_list/migration.sql
@@ -1,0 +1,37 @@
+-- CreateEnum
+CREATE TYPE "RevenueTypeType" AS ENUM ('story_ad_revenue', 'mutual_fund_revenue');
+
+-- CreateTable
+CREATE TABLE "Revenue" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL DEFAULT E'',
+    "publisher" INTEGER,
+    "type" "RevenueTypeType",
+    "value" DOUBLE PRECISION NOT NULL,
+    "start_date" TIMESTAMP(3),
+    "end_date" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "Revenue_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Revenue_publisher_idx" ON "Revenue"("publisher");
+
+-- CreateIndex
+CREATE INDEX "Revenue_createdBy_idx" ON "Revenue"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "Revenue_updatedBy_idx" ON "Revenue"("updatedBy");
+
+-- AddForeignKey
+ALTER TABLE "Revenue" ADD CONSTRAINT "Revenue_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Revenue" ADD CONSTRAINT "Revenue_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Revenue" ADD CONSTRAINT "Revenue_publisher_fkey" FOREIGN KEY ("publisher") REFERENCES "Publisher"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/mesh/migrations/20250212024403_add_statement_list/migration.sql
+++ b/packages/mesh/migrations/20250212024403_add_statement_list/migration.sql
@@ -1,0 +1,37 @@
+-- CreateEnum
+CREATE TYPE "StatementTypeType" AS ENUM ('month', 'quarter', 'semi_annual');
+
+-- CreateTable
+CREATE TABLE "Statement" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL DEFAULT E'',
+    "publisher" INTEGER,
+    "type" "StatementTypeType",
+    "url" TEXT NOT NULL DEFAULT E'',
+    "start_date" TIMESTAMP(3),
+    "end_date" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "Statement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Statement_publisher_idx" ON "Statement"("publisher");
+
+-- CreateIndex
+CREATE INDEX "Statement_createdBy_idx" ON "Statement"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "Statement_updatedBy_idx" ON "Statement"("updatedBy");
+
+-- AddForeignKey
+ALTER TABLE "Statement" ADD CONSTRAINT "Statement_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Statement" ADD CONSTRAINT "Statement_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Statement" ADD CONSTRAINT "Statement_publisher_fkey" FOREIGN KEY ("publisher") REFERENCES "Publisher"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/mesh/schema.graphql
+++ b/packages/mesh/schema.graphql
@@ -2810,6 +2810,95 @@ input ExchangeCreateInput {
   updatedBy: UserRelateToOneForCreateInput
 }
 
+type Revenue {
+  id: ID!
+  title: String
+  publisher: Publisher
+  type: RevenueTypeType
+  value: Float
+  start_date: DateTime
+  end_date: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+enum RevenueTypeType {
+  story_ad_revenue
+  mutual_fund_revenue
+}
+
+input RevenueWhereUniqueInput {
+  id: ID
+}
+
+input RevenueWhereInput {
+  AND: [RevenueWhereInput!]
+  OR: [RevenueWhereInput!]
+  NOT: [RevenueWhereInput!]
+  id: IDFilter
+  title: StringFilter
+  publisher: PublisherWhereInput
+  type: RevenueTypeTypeNullableFilter
+  value: FloatFilter
+  start_date: DateTimeNullableFilter
+  end_date: DateTimeNullableFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input RevenueTypeTypeNullableFilter {
+  equals: RevenueTypeType
+  in: [RevenueTypeType!]
+  notIn: [RevenueTypeType!]
+  not: RevenueTypeTypeNullableFilter
+}
+
+input RevenueOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+  type: OrderDirection
+  value: OrderDirection
+  start_date: OrderDirection
+  end_date: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input RevenueUpdateInput {
+  title: String
+  publisher: PublisherRelateToOneForUpdateInput
+  type: RevenueTypeType
+  value: Float
+  start_date: DateTime
+  end_date: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input RevenueUpdateArgs {
+  where: RevenueWhereUniqueInput!
+  data: RevenueUpdateInput!
+}
+
+input RevenueCreateInput {
+  title: String
+  publisher: PublisherRelateToOneForCreateInput
+  type: RevenueTypeType
+  value: Float
+  start_date: DateTime
+  end_date: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -2996,6 +3085,15 @@ type Mutation {
   updateExchanges(data: [ExchangeUpdateArgs!]!): [Exchange]
   deleteExchange(where: ExchangeWhereUniqueInput!): Exchange
   deleteExchanges(where: [ExchangeWhereUniqueInput!]!): [Exchange]
+  createRevenue(data: RevenueCreateInput!): Revenue
+  createRevenues(data: [RevenueCreateInput!]!): [Revenue]
+  updateRevenue(
+    where: RevenueWhereUniqueInput!
+    data: RevenueUpdateInput!
+  ): Revenue
+  updateRevenues(data: [RevenueUpdateArgs!]!): [Revenue]
+  deleteRevenue(where: RevenueWhereUniqueInput!): Revenue
+  deleteRevenues(where: [RevenueWhereUniqueInput!]!): [Revenue]
   endSession: Boolean!
   authenticateUserWithPassword(
     email: String!
@@ -3195,6 +3293,14 @@ type Query {
   ): [Exchange!]
   exchange(where: ExchangeWhereUniqueInput!): Exchange
   exchangesCount(where: ExchangeWhereInput! = {}): Int
+  revenues(
+    where: RevenueWhereInput! = {}
+    orderBy: [RevenueOrderByInput!]! = []
+    take: Int
+    skip: Int! = 0
+  ): [Revenue!]
+  revenue(where: RevenueWhereUniqueInput!): Revenue
+  revenuesCount(where: RevenueWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
 }

--- a/packages/mesh/schema.graphql
+++ b/packages/mesh/schema.graphql
@@ -2899,6 +2899,96 @@ input RevenueCreateInput {
   updatedBy: UserRelateToOneForCreateInput
 }
 
+type Statement {
+  id: ID!
+  title: String
+  publisher: Publisher
+  type: StatementTypeType
+  url: String
+  start_date: DateTime
+  end_date: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+enum StatementTypeType {
+  month
+  quarter
+  semi_annual
+}
+
+input StatementWhereUniqueInput {
+  id: ID
+}
+
+input StatementWhereInput {
+  AND: [StatementWhereInput!]
+  OR: [StatementWhereInput!]
+  NOT: [StatementWhereInput!]
+  id: IDFilter
+  title: StringFilter
+  publisher: PublisherWhereInput
+  type: StatementTypeTypeNullableFilter
+  url: StringFilter
+  start_date: DateTimeNullableFilter
+  end_date: DateTimeNullableFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input StatementTypeTypeNullableFilter {
+  equals: StatementTypeType
+  in: [StatementTypeType!]
+  notIn: [StatementTypeType!]
+  not: StatementTypeTypeNullableFilter
+}
+
+input StatementOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+  type: OrderDirection
+  url: OrderDirection
+  start_date: OrderDirection
+  end_date: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input StatementUpdateInput {
+  title: String
+  publisher: PublisherRelateToOneForUpdateInput
+  type: StatementTypeType
+  url: String
+  start_date: DateTime
+  end_date: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input StatementUpdateArgs {
+  where: StatementWhereUniqueInput!
+  data: StatementUpdateInput!
+}
+
+input StatementCreateInput {
+  title: String
+  publisher: PublisherRelateToOneForCreateInput
+  type: StatementTypeType
+  url: String
+  start_date: DateTime
+  end_date: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -3094,6 +3184,15 @@ type Mutation {
   updateRevenues(data: [RevenueUpdateArgs!]!): [Revenue]
   deleteRevenue(where: RevenueWhereUniqueInput!): Revenue
   deleteRevenues(where: [RevenueWhereUniqueInput!]!): [Revenue]
+  createStatement(data: StatementCreateInput!): Statement
+  createStatements(data: [StatementCreateInput!]!): [Statement]
+  updateStatement(
+    where: StatementWhereUniqueInput!
+    data: StatementUpdateInput!
+  ): Statement
+  updateStatements(data: [StatementUpdateArgs!]!): [Statement]
+  deleteStatement(where: StatementWhereUniqueInput!): Statement
+  deleteStatements(where: [StatementWhereUniqueInput!]!): [Statement]
   endSession: Boolean!
   authenticateUserWithPassword(
     email: String!
@@ -3301,6 +3400,14 @@ type Query {
   ): [Revenue!]
   revenue(where: RevenueWhereUniqueInput!): Revenue
   revenuesCount(where: RevenueWhereInput! = {}): Int
+  statements(
+    where: StatementWhereInput! = {}
+    orderBy: [StatementOrderByInput!]! = []
+    take: Int
+    skip: Int! = 0
+  ): [Statement!]
+  statement(where: StatementWhereUniqueInput!): Statement
+  statementsCount(where: StatementWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
 }

--- a/packages/mesh/schema.prisma
+++ b/packages/mesh/schema.prisma
@@ -62,6 +62,8 @@ model User {
   from_Exchange_updatedBy         Exchange[]         @relation("Exchange_updatedBy")
   from_Revenue_createdBy          Revenue[]          @relation("Revenue_createdBy")
   from_Revenue_updatedBy          Revenue[]          @relation("Revenue_updatedBy")
+  from_Statement_createdBy        Statement[]        @relation("Statement_createdBy")
+  from_Statement_updatedBy        Statement[]        @relation("Statement_updatedBy")
 
   @@index([publisherId])
 }
@@ -179,40 +181,41 @@ model Pick {
 }
 
 model Publisher {
-  id                     Int           @id @default(autoincrement())
-  title                  String        @default("")
-  official_site          String        @default("")
-  rss                    String        @default("")
-  summary                String        @default("")
-  logo                   String        @default("")
-  description            String        @default("")
-  is_active              Boolean       @default(true)
-  customId               String        @default("")
-  admin                  Member?       @relation("Publisher_admin", fields: [adminId], references: [id])
-  adminId                Int?          @map("admin")
-  exchange               Exchange[]    @relation("Exchange_publisher")
-  sponsored              Sponsorship[] @relation("Sponsorship_publisher")
-  lang                   String?       @default("zh-TW")
-  category               Category?     @relation("Publisher_category", fields: [categoryId], references: [id])
-  categoryId             Int?          @map("category")
-  full_content           Boolean       @default(false)
-  full_screen_ad         String?       @default("none")
-  source_type            String?       @default("empty")
-  paywall                Boolean       @default(false)
-  follower               Member[]      @relation("Member_follow_publisher")
-  exclude_follower       Member[]      @relation("Member_exclude_publisher")
-  wallet                 String        @default("")
-  user                   User[]        @relation("User_publisher")
-  createdAt              DateTime?
-  updatedAt              DateTime?
-  createdBy              User?         @relation("Publisher_createdBy", fields: [createdById], references: [id])
-  createdById            Int?          @map("createdBy")
-  updatedBy              User?         @relation("Publisher_updatedBy", fields: [updatedById], references: [id])
-  updatedById            Int?          @map("updatedBy")
-  from_Story_source      Story[]       @relation("Story_source")
-  from_Policy_publisher  Policy[]      @relation("Policy_publisher")
-  from_Podcast_source    Podcast[]     @relation("Podcast_source")
-  from_Revenue_publisher Revenue[]     @relation("Revenue_publisher")
+  id                       Int           @id @default(autoincrement())
+  title                    String        @default("")
+  official_site            String        @default("")
+  rss                      String        @default("")
+  summary                  String        @default("")
+  logo                     String        @default("")
+  description              String        @default("")
+  is_active                Boolean       @default(true)
+  customId                 String        @default("")
+  admin                    Member?       @relation("Publisher_admin", fields: [adminId], references: [id])
+  adminId                  Int?          @map("admin")
+  exchange                 Exchange[]    @relation("Exchange_publisher")
+  sponsored                Sponsorship[] @relation("Sponsorship_publisher")
+  lang                     String?       @default("zh-TW")
+  category                 Category?     @relation("Publisher_category", fields: [categoryId], references: [id])
+  categoryId               Int?          @map("category")
+  full_content             Boolean       @default(false)
+  full_screen_ad           String?       @default("none")
+  source_type              String?       @default("empty")
+  paywall                  Boolean       @default(false)
+  follower                 Member[]      @relation("Member_follow_publisher")
+  exclude_follower         Member[]      @relation("Member_exclude_publisher")
+  wallet                   String        @default("")
+  user                     User[]        @relation("User_publisher")
+  createdAt                DateTime?
+  updatedAt                DateTime?
+  createdBy                User?         @relation("Publisher_createdBy", fields: [createdById], references: [id])
+  createdById              Int?          @map("createdBy")
+  updatedBy                User?         @relation("Publisher_updatedBy", fields: [updatedById], references: [id])
+  updatedById              Int?          @map("updatedBy")
+  from_Story_source        Story[]       @relation("Story_source")
+  from_Policy_publisher    Policy[]      @relation("Policy_publisher")
+  from_Podcast_source      Podcast[]     @relation("Podcast_source")
+  from_Revenue_publisher   Revenue[]     @relation("Revenue_publisher")
+  from_Statement_publisher Statement[]   @relation("Statement_publisher")
 
   @@index([adminId])
   @@index([categoryId])
@@ -657,6 +660,27 @@ model Revenue {
   @@index([updatedById])
 }
 
+model Statement {
+  id          Int                @id @default(autoincrement())
+  title       String             @default("")
+  publisher   Publisher?         @relation("Statement_publisher", fields: [publisherId], references: [id])
+  publisherId Int?               @map("publisher")
+  type        StatementTypeType?
+  url         String             @default("")
+  start_date  DateTime?
+  end_date    DateTime?
+  createdAt   DateTime?
+  updatedAt   DateTime?
+  createdBy   User?              @relation("Statement_createdBy", fields: [createdById], references: [id])
+  createdById Int?               @map("createdBy")
+  updatedBy   User?              @relation("Statement_updatedBy", fields: [updatedById], references: [id])
+  updatedById Int?               @map("updatedBy")
+
+  @@index([publisherId])
+  @@index([createdById])
+  @@index([updatedById])
+}
+
 enum PolicyTypeType {
   deposit
   unlock_all_publishers
@@ -684,4 +708,10 @@ enum ExchangeStatusType {
 enum RevenueTypeType {
   story_ad_revenue
   mutual_fund_revenue
+}
+
+enum StatementTypeType {
+  month
+  quarter
+  semi_annual
 }

--- a/packages/mesh/schema.prisma
+++ b/packages/mesh/schema.prisma
@@ -60,6 +60,8 @@ model User {
   from_Sponsorship_updatedBy      Sponsorship[]      @relation("Sponsorship_updatedBy")
   from_Exchange_createdBy         Exchange[]         @relation("Exchange_createdBy")
   from_Exchange_updatedBy         Exchange[]         @relation("Exchange_updatedBy")
+  from_Revenue_createdBy          Revenue[]          @relation("Revenue_createdBy")
+  from_Revenue_updatedBy          Revenue[]          @relation("Revenue_updatedBy")
 
   @@index([publisherId])
 }
@@ -177,39 +179,40 @@ model Pick {
 }
 
 model Publisher {
-  id                    Int           @id @default(autoincrement())
-  title                 String        @default("")
-  official_site         String        @default("")
-  rss                   String        @default("")
-  summary               String        @default("")
-  logo                  String        @default("")
-  description           String        @default("")
-  is_active             Boolean       @default(true)
-  customId              String        @default("")
-  admin                 Member?       @relation("Publisher_admin", fields: [adminId], references: [id])
-  adminId               Int?          @map("admin")
-  exchange              Exchange[]    @relation("Exchange_publisher")
-  sponsored             Sponsorship[] @relation("Sponsorship_publisher")
-  lang                  String?       @default("zh-TW")
-  category              Category?     @relation("Publisher_category", fields: [categoryId], references: [id])
-  categoryId            Int?          @map("category")
-  full_content          Boolean       @default(false)
-  full_screen_ad        String?       @default("none")
-  source_type           String?       @default("empty")
-  paywall               Boolean       @default(false)
-  follower              Member[]      @relation("Member_follow_publisher")
-  exclude_follower      Member[]      @relation("Member_exclude_publisher")
-  wallet                String        @default("")
-  user                  User[]        @relation("User_publisher")
-  createdAt             DateTime?
-  updatedAt             DateTime?
-  createdBy             User?         @relation("Publisher_createdBy", fields: [createdById], references: [id])
-  createdById           Int?          @map("createdBy")
-  updatedBy             User?         @relation("Publisher_updatedBy", fields: [updatedById], references: [id])
-  updatedById           Int?          @map("updatedBy")
-  from_Story_source     Story[]       @relation("Story_source")
-  from_Policy_publisher Policy[]      @relation("Policy_publisher")
-  from_Podcast_source   Podcast[]     @relation("Podcast_source")
+  id                     Int           @id @default(autoincrement())
+  title                  String        @default("")
+  official_site          String        @default("")
+  rss                    String        @default("")
+  summary                String        @default("")
+  logo                   String        @default("")
+  description            String        @default("")
+  is_active              Boolean       @default(true)
+  customId               String        @default("")
+  admin                  Member?       @relation("Publisher_admin", fields: [adminId], references: [id])
+  adminId                Int?          @map("admin")
+  exchange               Exchange[]    @relation("Exchange_publisher")
+  sponsored              Sponsorship[] @relation("Sponsorship_publisher")
+  lang                   String?       @default("zh-TW")
+  category               Category?     @relation("Publisher_category", fields: [categoryId], references: [id])
+  categoryId             Int?          @map("category")
+  full_content           Boolean       @default(false)
+  full_screen_ad         String?       @default("none")
+  source_type            String?       @default("empty")
+  paywall                Boolean       @default(false)
+  follower               Member[]      @relation("Member_follow_publisher")
+  exclude_follower       Member[]      @relation("Member_exclude_publisher")
+  wallet                 String        @default("")
+  user                   User[]        @relation("User_publisher")
+  createdAt              DateTime?
+  updatedAt              DateTime?
+  createdBy              User?         @relation("Publisher_createdBy", fields: [createdById], references: [id])
+  createdById            Int?          @map("createdBy")
+  updatedBy              User?         @relation("Publisher_updatedBy", fields: [updatedById], references: [id])
+  updatedById            Int?          @map("updatedBy")
+  from_Story_source      Story[]       @relation("Story_source")
+  from_Policy_publisher  Policy[]      @relation("Policy_publisher")
+  from_Podcast_source    Podcast[]     @relation("Podcast_source")
+  from_Revenue_publisher Revenue[]     @relation("Revenue_publisher")
 
   @@index([adminId])
   @@index([categoryId])
@@ -633,6 +636,27 @@ model Exchange {
   @@index([updatedById])
 }
 
+model Revenue {
+  id          Int              @id @default(autoincrement())
+  title       String           @default("")
+  publisher   Publisher?       @relation("Revenue_publisher", fields: [publisherId], references: [id])
+  publisherId Int?             @map("publisher")
+  type        RevenueTypeType?
+  value       Float
+  start_date  DateTime?
+  end_date    DateTime?
+  createdAt   DateTime?
+  updatedAt   DateTime?
+  createdBy   User?            @relation("Revenue_createdBy", fields: [createdById], references: [id])
+  createdById Int?             @map("createdBy")
+  updatedBy   User?            @relation("Revenue_updatedBy", fields: [updatedById], references: [id])
+  updatedById Int?             @map("updatedBy")
+
+  @@index([publisherId])
+  @@index([createdById])
+  @@index([updatedById])
+}
+
 enum PolicyTypeType {
   deposit
   unlock_all_publishers
@@ -655,4 +679,9 @@ enum ExchangeStatusType {
   Success
   Failed
   Processing
+}
+
+enum RevenueTypeType {
+  story_ad_revenue
+  mutual_fund_revenue
 }


### PR DESCRIPTION
新增兩個list分別是revenue與statement為報表相關列表
1. revenue: 記錄每個月計算出來的文章廣告分潤與基金池的分潤
2. statement: 記錄報表

說明: Cronjob每個月會定時計算文章廣告分潤及基金池分潤，並將結果記錄到revenue當中。另外在Cronjob產出月報/季報/半年報時也會一併將報表資訊寫入statement。在statement裡面的連結僅允許使用兩種方式讀取，分別是: (1)登入在專案內的週刊帳戶 (2)向Proxy-server取得SignedCookie後讀取。