### PR TITLE
refactor(daily): update topic list

### DIFF
--- a/packages/mirrordaily/lists/Topic.ts
+++ b/packages/mirrordaily/lists/Topic.ts
@@ -62,6 +62,15 @@ const listConfigurations = list({
         'youtube',
       ],
     }),
+    leading: select({
+      label: '標頭樣式',
+      options: [
+        { label: 'video', value: 'video' },
+        { label: 'slideshow', value: 'slideshow' },
+        { label: 'image', value: 'image' },
+      ],
+      isIndexed: true,
+    }),
     heroImage: relationship({
       ref: 'Photo',
       label: '首圖',
@@ -76,19 +85,14 @@ const listConfigurations = list({
       label: '首圖影片（Leading Video）',
       ref: 'Video',
     }),
-    leading: select({
-      label: '標頭樣式',
-      options: [
-        { label: 'video', value: 'video' },
-        { label: 'slideshow', value: 'slideshow' },
-        { label: 'image', value: 'image' },
-      ],
-      isIndexed: true,
-    }),
-    sections: relationship({
-      label: '分區',
-      ref: 'Section.topics',
+    slideshow_images: relationship({
+      ref: 'Photo',
+      label: 'slideshow 圖片',
       many: true,
+    }),
+    manualOrderOfSlideshowImages: json({
+      label: 'slideshow 圖片排序結果',
+      defaultValue: null,
     }),
     og_title: text({
       label: 'FB分享標題',
@@ -102,60 +106,126 @@ const listConfigurations = list({
       label: 'FB分享縮圖',
       ref: 'Photo',
     }),
-    isFeatured: checkbox({
-      label: '置頂',
-    }),
-    title_style: select({
-      label: '專題樣式',
-      options: [{ label: 'Feature', value: 'feature' }],
-      isIndexed: true,
-      defaultValue: 'feature',
-    }),
     type: select({
       label: '型態',
       isIndexed: true,
       defaultValue: 'list',
       options: [
         { label: 'List', value: 'list' },
-        { label: 'Timeline', value: 'timeline' },
         { label: 'Group', value: 'group' },
-        { label: 'Portrait Wall', value: 'portraitwall' },
       ],
-    }),
-    style: text({
-      label: 'CSS',
-      ui: { displayMode: 'textarea' },
     }),
     tags: relationship({
       ref: 'Tag.topics',
       label: '標籤',
       many: true,
     }),
-    slideshow_images: relationship({
-      ref: 'Photo',
-      label: 'slideshow 圖片',
-      many: true,
-    }),
-    manualOrderOfSlideshowImages: json({
-      label: 'slideshow 圖片排序結果',
-      defaultValue: null,
-    }),
     posts: relationship({
       ref: 'Post.topics',
       label: '文章',
       many: true,
     }),
+    style: text({
+      label: 'CSS',
+      ui: { displayMode: 'textarea' },
+    }),
+    isFeatured: checkbox({
+      label: '置頂',
+      ui: {
+        // TODO: 未被使用，移除此欄位
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'hidden',
+        },
+        listView: {
+          fieldMode: 'hidden',
+        },
+      },
+    }),
+    title_style: select({
+      label: '專題樣式',
+      options: [{ label: 'Feature', value: 'feature' }],
+      isIndexed: true,
+      defaultValue: 'feature',
+      ui: {
+        // TODO: 未被使用，移除此欄位
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'hidden',
+        },
+        listView: {
+          fieldMode: 'hidden',
+        },
+      },
+    }),
+    sections: relationship({
+      label: '分區',
+      ref: 'Section.topics',
+      many: true,
+      ui: {
+        // TODO: 未被使用，移除此欄位
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'hidden',
+        },
+        listView: {
+          fieldMode: 'hidden',
+        },
+      },
+    }),
     javascript: text({
       label: 'javascript',
-      ui: { displayMode: 'textarea' },
+      ui: {
+        displayMode: 'textarea',
+        // TODO: 未被使用，移除此欄位
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'hidden',
+        },
+        listView: {
+          fieldMode: 'hidden',
+        },
+      },
     }),
     dfp: text({
       validation: { isRequired: false },
       label: 'DFP code',
+      ui: {
+        // TODO: 未被使用，移除此欄位
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'hidden',
+        },
+        listView: {
+          fieldMode: 'hidden',
+        },
+      },
     }),
     mobile_dfp: text({
       validation: { isRequired: false },
       label: 'Mobile DFP code',
+      ui: {
+        // TODO: 未被使用，移除此欄位
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'hidden',
+        },
+        listView: {
+          fieldMode: 'hidden',
+        },
+      },
     }),
   },
   ui: {

--- a/packages/mirrordaily/lists/Topic.ts
+++ b/packages/mirrordaily/lists/Topic.ts
@@ -62,6 +62,14 @@ const listConfigurations = list({
         'youtube',
       ],
     }),
+    apiDataBrief: json({
+      label: 'Brief資料庫使用',
+      isFilterable: false,
+      ui: {
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'hidden' },
+      },
+    }),
     leading: select({
       label: '標頭樣式',
       options: [
@@ -242,6 +250,17 @@ const listConfigurations = list({
       update: allowRoles(admin, moderator, editor),
       create: allowRoles(admin, moderator, editor),
       delete: allowRoles(admin),
+    },
+  },
+  hooks: {
+    resolveInput: async ({ resolvedData }) => {
+      const { brief } = resolvedData
+      if (brief) {
+        resolvedData.apiDataBrief = customFields.draftConverter
+          .convertToApiData(brief)
+          .toJS()
+      }
+      return resolvedData
     },
   },
 })

--- a/packages/mirrordaily/migrations/20250212060230_add_api_data_brief_field_to_topic/migration.sql
+++ b/packages/mirrordaily/migrations/20250212060230_add_api_data_brief_field_to_topic/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Topic" ADD COLUMN     "apiDataBrief" JSONB;

--- a/packages/mirrordaily/schema.graphql
+++ b/packages/mirrordaily/schema.graphql
@@ -1631,6 +1631,7 @@ type Topic {
   sortOrder: Int
   state: String
   brief: JSON
+  apiDataBrief: JSON
   leading: String
   heroImage: Photo
   heroUrl: String
@@ -1733,6 +1734,7 @@ input TopicUpdateInput {
   sortOrder: Int
   state: String
   brief: JSON
+  apiDataBrief: JSON
   leading: String
   heroImage: PhotoRelateToOneForUpdateInput
   heroUrl: String
@@ -1776,6 +1778,7 @@ input TopicCreateInput {
   sortOrder: Int
   state: String
   brief: JSON
+  apiDataBrief: JSON
   leading: String
   heroImage: PhotoRelateToOneForCreateInput
   heroUrl: String

--- a/packages/mirrordaily/schema.graphql
+++ b/packages/mirrordaily/schema.graphql
@@ -1631,26 +1631,26 @@ type Topic {
   sortOrder: Int
   state: String
   brief: JSON
+  leading: String
   heroImage: Photo
   heroUrl: String
   heroVideo: Video
-  leading: String
-  sections(where: SectionWhereInput! = {}, orderBy: [SectionOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: SectionWhereUniqueInput): [Section!]
-  sectionsCount(where: SectionWhereInput! = {}): Int
-  og_title: String
-  og_description: String
-  og_image: Photo
-  isFeatured: Boolean
-  title_style: String
-  type: String
-  style: String
-  tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
-  tagsCount(where: TagWhereInput! = {}): Int
   slideshow_images(where: PhotoWhereInput! = {}, orderBy: [PhotoOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PhotoWhereUniqueInput): [Photo!]
   slideshow_imagesCount(where: PhotoWhereInput! = {}): Int
   manualOrderOfSlideshowImages: JSON
+  og_title: String
+  og_description: String
+  og_image: Photo
+  type: String
+  tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
+  tagsCount(where: TagWhereInput! = {}): Int
   posts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
   postsCount(where: PostWhereInput! = {}): Int
+  style: String
+  isFeatured: Boolean
+  title_style: String
+  sections(where: SectionWhereInput! = {}, orderBy: [SectionOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: SectionWhereUniqueInput): [Section!]
+  sectionsCount(where: SectionWhereInput! = {}): Int
   javascript: String
   dfp: String
   mobile_dfp: String
@@ -1676,21 +1676,21 @@ input TopicWhereInput {
   slug: StringFilter
   sortOrder: IntNullableFilter
   state: StringNullableFilter
+  leading: StringNullableFilter
   heroImage: PhotoWhereInput
   heroUrl: StringNullableFilter
   heroVideo: VideoWhereInput
-  leading: StringNullableFilter
-  sections: SectionManyRelationFilter
+  slideshow_images: PhotoManyRelationFilter
   og_title: StringFilter
   og_description: StringFilter
   og_image: PhotoWhereInput
+  type: StringNullableFilter
+  tags: TagManyRelationFilter
+  posts: PostManyRelationFilter
+  style: StringFilter
   isFeatured: BooleanFilter
   title_style: StringNullableFilter
-  type: StringNullableFilter
-  style: StringFilter
-  tags: TagManyRelationFilter
-  slideshow_images: PhotoManyRelationFilter
-  posts: PostManyRelationFilter
+  sections: SectionManyRelationFilter
   javascript: StringFilter
   dfp: StringFilter
   mobile_dfp: StringFilter
@@ -1712,14 +1712,14 @@ input TopicOrderByInput {
   slug: OrderDirection
   sortOrder: OrderDirection
   state: OrderDirection
-  heroUrl: OrderDirection
   leading: OrderDirection
+  heroUrl: OrderDirection
   og_title: OrderDirection
   og_description: OrderDirection
-  isFeatured: OrderDirection
-  title_style: OrderDirection
   type: OrderDirection
   style: OrderDirection
+  isFeatured: OrderDirection
+  title_style: OrderDirection
   javascript: OrderDirection
   dfp: OrderDirection
   mobile_dfp: OrderDirection
@@ -1733,22 +1733,22 @@ input TopicUpdateInput {
   sortOrder: Int
   state: String
   brief: JSON
+  leading: String
   heroImage: PhotoRelateToOneForUpdateInput
   heroUrl: String
   heroVideo: VideoRelateToOneForUpdateInput
-  leading: String
-  sections: SectionRelateToManyForUpdateInput
+  slideshow_images: PhotoRelateToManyForUpdateInput
+  manualOrderOfSlideshowImages: JSON
   og_title: String
   og_description: String
   og_image: PhotoRelateToOneForUpdateInput
+  type: String
+  tags: TagRelateToManyForUpdateInput
+  posts: PostRelateToManyForUpdateInput
+  style: String
   isFeatured: Boolean
   title_style: String
-  type: String
-  style: String
-  tags: TagRelateToManyForUpdateInput
-  slideshow_images: PhotoRelateToManyForUpdateInput
-  manualOrderOfSlideshowImages: JSON
-  posts: PostRelateToManyForUpdateInput
+  sections: SectionRelateToManyForUpdateInput
   javascript: String
   dfp: String
   mobile_dfp: String
@@ -1776,22 +1776,22 @@ input TopicCreateInput {
   sortOrder: Int
   state: String
   brief: JSON
+  leading: String
   heroImage: PhotoRelateToOneForCreateInput
   heroUrl: String
   heroVideo: VideoRelateToOneForCreateInput
-  leading: String
-  sections: SectionRelateToManyForCreateInput
+  slideshow_images: PhotoRelateToManyForCreateInput
+  manualOrderOfSlideshowImages: JSON
   og_title: String
   og_description: String
   og_image: PhotoRelateToOneForCreateInput
+  type: String
+  tags: TagRelateToManyForCreateInput
+  posts: PostRelateToManyForCreateInput
+  style: String
   isFeatured: Boolean
   title_style: String
-  type: String
-  style: String
-  tags: TagRelateToManyForCreateInput
-  slideshow_images: PhotoRelateToManyForCreateInput
-  manualOrderOfSlideshowImages: JSON
-  posts: PostRelateToManyForCreateInput
+  sections: SectionRelateToManyForCreateInput
   javascript: String
   dfp: String
   mobile_dfp: String

--- a/packages/mirrordaily/schema.prisma
+++ b/packages/mirrordaily/schema.prisma
@@ -376,6 +376,7 @@ model Topic {
   sortOrder                    Int?
   state                        String?   @default("draft")
   brief                        Json?
+  apiDataBrief                 Json?
   leading                      String?
   heroImage                    Photo?    @relation("Topic_heroImage", fields: [heroImageId], references: [id])
   heroImageId                  Int?      @map("heroImage")

--- a/packages/mirrordaily/schema.prisma
+++ b/packages/mirrordaily/schema.prisma
@@ -231,8 +231,8 @@ model Photo {
   from_Post_og_image          Post[]         @relation("Post_og_image")
   from_Section_heroImage      Section[]      @relation("Section_heroImage")
   from_Topic_heroImage        Topic[]        @relation("Topic_heroImage")
-  from_Topic_og_image         Topic[]        @relation("Topic_og_image")
   from_Topic_slideshow_images Topic[]        @relation("Topic_slideshow_images")
+  from_Topic_og_image         Topic[]        @relation("Topic_og_image")
   from_Video_heroImage        Video[]        @relation("Video_heroImage")
   from_Game_heroImage         Game[]         @relation("Game_heroImage")
 
@@ -376,25 +376,25 @@ model Topic {
   sortOrder                    Int?
   state                        String?   @default("draft")
   brief                        Json?
+  leading                      String?
   heroImage                    Photo?    @relation("Topic_heroImage", fields: [heroImageId], references: [id])
   heroImageId                  Int?      @map("heroImage")
   heroUrl                      String?
   heroVideo                    Video?    @relation("Topic_heroVideo", fields: [heroVideoId], references: [id])
   heroVideoId                  Int?      @map("heroVideo")
-  leading                      String?
-  sections                     Section[] @relation("Section_topics")
+  slideshow_images             Photo[]   @relation("Topic_slideshow_images")
+  manualOrderOfSlideshowImages Json?
   og_title                     String    @default("")
   og_description               String    @default("")
   og_image                     Photo?    @relation("Topic_og_image", fields: [og_imageId], references: [id])
   og_imageId                   Int?      @map("og_image")
+  type                         String?   @default("list")
+  tags                         Tag[]     @relation("Tag_topics")
+  posts                        Post[]    @relation("Post_topics")
+  style                        String    @default("")
   isFeatured                   Boolean   @default(false)
   title_style                  String?   @default("feature")
-  type                         String?   @default("list")
-  style                        String    @default("")
-  tags                         Tag[]     @relation("Tag_topics")
-  slideshow_images             Photo[]   @relation("Topic_slideshow_images")
-  manualOrderOfSlideshowImages Json?
-  posts                        Post[]    @relation("Post_topics")
+  sections                     Section[] @relation("Section_topics")
   javascript                   String    @default("")
   dfp                          String    @default("")
   mobile_dfp                   String    @default("")
@@ -406,12 +406,12 @@ model Topic {
   updatedById                  Int?      @map("updatedBy")
 
   @@index([state])
+  @@index([leading])
   @@index([heroImageId])
   @@index([heroVideoId])
-  @@index([leading])
   @@index([og_imageId])
-  @@index([title_style])
   @@index([type])
+  @@index([title_style])
   @@index([createdById])
   @@index([updatedById])
 }


### PR DESCRIPTION
## Notable Changes
* 隱藏以下未被使用的欄位：
  * 分區
  * 置頂
  * 專題樣式
  * javascript
  * DFP code
  * mobile DFP code
* 刪除型態欄位中，Timeline 與 Portrait Wall 選項
* 調整欄位順序，使用者在設定「標頭樣式」後，就近可以設定對應的「首圖」、「首圖影片」或「slideshow 圖片」資訊