### PR TITLE
feat(mesh): add revenue and statement list

### DIFF
--- a/packages/mesh/lists/index.ts
+++ b/packages/mesh/lists/index.ts
@@ -21,6 +21,8 @@ import InvalidName from './invalid_name'
 import Exchange from './exchange'
 import ReportReason from './report_reason'
 import ReportRecord from './report_record'
+import Revenue from './revenue'
+import Statement from './statement'
 
 export const listDefinition = {
   User,
@@ -46,4 +48,6 @@ export const listDefinition = {
   Exchange,
   ReportReason,
   ReportRecord,
+  Revenue,
+  Statement,
 }

--- a/packages/mesh/lists/revenue.ts
+++ b/packages/mesh/lists/revenue.ts
@@ -1,0 +1,61 @@
+import { list } from '@keystone-6/core'
+import { utils } from '@mirrormedia/lilith-core'
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+import { text, relationship, select, float, timestamp} from '@keystone-6/core/fields'
+
+const listConfigurations = list({
+  fields: {
+    title: text({
+        label: '標題',
+        validation: {
+            isRequired: false
+        }
+    }),
+    publisher: relationship({ 
+        label: "媒體",
+        ref: 'Publisher', 
+        many: false 
+    }),
+    type: select({
+        label: "種類",
+        type: "enum",  
+        options: [
+            { label: '文章廣告分潤', value: 'story_ad_revenue' },
+            { label: '基金池分潤', value: 'mutual_fund_revenue' },
+        ],
+    }),
+    value: float({
+        label: "分潤金額",
+        validation: {
+            isRequired: true,
+        }
+    }),
+    start_date: timestamp({
+        label: "資料起始時間",
+        validation: { 
+            isRequired: false 
+        } 
+    }),
+    end_date: timestamp({
+        label: "資料結束時間",
+        validation: { 
+            isRequired: false 
+        } 
+    }),
+  },
+  ui: {
+    listView: {
+      initialColumns: ['title', 'publisher', 'type', 'value'],
+    },
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator, editor),
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  },
+})
+
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/mesh/lists/statement.ts
+++ b/packages/mesh/lists/statement.ts
@@ -1,0 +1,62 @@
+import { list } from '@keystone-6/core'
+import { utils } from '@mirrormedia/lilith-core'
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+import { text, relationship, select, float, timestamp} from '@keystone-6/core/fields'
+
+const listConfigurations = list({
+  fields: {
+    title: text({
+        label: '標題',
+        validation: {
+            isRequired: false
+        }
+    }),
+    publisher: relationship({ 
+        label: "媒體",
+        ref: 'Publisher', 
+        many: false 
+    }),
+    type: select({
+        label: "種類",
+        type: "enum",  
+        options: [
+            { label: '月報', value: 'month' },
+            { label: '季報', value: 'quarter' },
+            { label: '半年報', value: 'semi_annual'}
+        ],
+    }),
+    url: text({
+        label: "檔案連結",
+        validation: {
+            isRequired: true,
+        }
+    }),
+    start_date: timestamp({
+        label: "計算起始時間",
+        validation: { 
+            isRequired: false 
+        } 
+    }),
+    end_date: timestamp({
+        label: "計算結束時間",
+        validation: { 
+            isRequired: false 
+        } 
+    }),
+  },
+  ui: {
+    listView: {
+      initialColumns: ['title', 'type', 'start_date', 'end_date'],
+    },
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator, editor),
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  },
+})
+
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/mesh/migrations/20250212032057_add_revenue_and_statement_list/migration.sql
+++ b/packages/mesh/migrations/20250212032057_add_revenue_and_statement_list/migration.sql
@@ -1,0 +1,78 @@
+-- CreateEnum
+CREATE TYPE "RevenueTypeType" AS ENUM ('story_ad_revenue', 'mutual_fund_revenue');
+
+-- CreateEnum
+CREATE TYPE "StatementTypeType" AS ENUM ('month', 'quarter', 'semi_annual');
+
+-- CreateTable
+CREATE TABLE "Revenue" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL DEFAULT E'',
+    "publisher" INTEGER,
+    "type" "RevenueTypeType",
+    "value" DOUBLE PRECISION NOT NULL,
+    "start_date" TIMESTAMP(3),
+    "end_date" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "Revenue_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Statement" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL DEFAULT E'',
+    "publisher" INTEGER,
+    "type" "StatementTypeType",
+    "url" TEXT NOT NULL DEFAULT E'',
+    "start_date" TIMESTAMP(3),
+    "end_date" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "Statement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Revenue_publisher_idx" ON "Revenue"("publisher");
+
+-- CreateIndex
+CREATE INDEX "Revenue_createdBy_idx" ON "Revenue"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "Revenue_updatedBy_idx" ON "Revenue"("updatedBy");
+
+-- CreateIndex
+CREATE INDEX "Statement_publisher_idx" ON "Statement"("publisher");
+
+-- CreateIndex
+CREATE INDEX "Statement_createdBy_idx" ON "Statement"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "Statement_updatedBy_idx" ON "Statement"("updatedBy");
+
+-- CreateIndex
+CREATE INDEX "Story_story_type_idx" ON "Story"("story_type");
+
+-- AddForeignKey
+ALTER TABLE "Revenue" ADD CONSTRAINT "Revenue_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Revenue" ADD CONSTRAINT "Revenue_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Revenue" ADD CONSTRAINT "Revenue_publisher_fkey" FOREIGN KEY ("publisher") REFERENCES "Publisher"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Statement" ADD CONSTRAINT "Statement_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Statement" ADD CONSTRAINT "Statement_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Statement" ADD CONSTRAINT "Statement_publisher_fkey" FOREIGN KEY ("publisher") REFERENCES "Publisher"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/mesh/schema.graphql
+++ b/packages/mesh/schema.graphql
@@ -2393,13 +2393,13 @@ input PolicyCreateInput {
 
 type Podcast {
   id: ID!
-  url: String
   author: String
+  url: String
+  file_size: Int
+  mime_type: String
   duration: String
   source: Publisher
   story: Story
-  file_size: Int
-  mime_type: String
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User
@@ -2416,13 +2416,13 @@ input PodcastWhereInput {
   OR: [PodcastWhereInput!]
   NOT: [PodcastWhereInput!]
   id: IDFilter
-  url: StringFilter
   author: StringFilter
+  url: StringFilter
+  file_size: IntNullableFilter
+  mime_type: StringFilter
   duration: StringFilter
   source: PublisherWhereInput
   story: StoryWhereInput
-  file_size: IntNullableFilter
-  mime_type: StringFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
@@ -2431,23 +2431,23 @@ input PodcastWhereInput {
 
 input PodcastOrderByInput {
   id: OrderDirection
-  url: OrderDirection
   author: OrderDirection
-  duration: OrderDirection
+  url: OrderDirection
   file_size: OrderDirection
   mime_type: OrderDirection
+  duration: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
 
 input PodcastUpdateInput {
-  url: String
   author: String
+  url: String
+  file_size: Int
+  mime_type: String
   duration: String
   source: PublisherRelateToOneForUpdateInput
   story: StoryRelateToOneForUpdateInput
-  file_size: Int
-  mime_type: String
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
@@ -2460,13 +2460,13 @@ input PodcastUpdateArgs {
 }
 
 input PodcastCreateInput {
-  url: String
   author: String
+  url: String
+  file_size: Int
+  mime_type: String
   duration: String
   source: PublisherRelateToOneForCreateInput
   story: StoryRelateToOneForCreateInput
-  file_size: Int
-  mime_type: String
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput
@@ -2905,6 +2905,185 @@ input ReportReasonRelateToOneForCreateInput {
   connect: ReportReasonWhereUniqueInput
 }
 
+type Revenue {
+  id: ID!
+  title: String
+  publisher: Publisher
+  type: RevenueTypeType
+  value: Float
+  start_date: DateTime
+  end_date: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+enum RevenueTypeType {
+  story_ad_revenue
+  mutual_fund_revenue
+}
+
+input RevenueWhereUniqueInput {
+  id: ID
+}
+
+input RevenueWhereInput {
+  AND: [RevenueWhereInput!]
+  OR: [RevenueWhereInput!]
+  NOT: [RevenueWhereInput!]
+  id: IDFilter
+  title: StringFilter
+  publisher: PublisherWhereInput
+  type: RevenueTypeTypeNullableFilter
+  value: FloatFilter
+  start_date: DateTimeNullableFilter
+  end_date: DateTimeNullableFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input RevenueTypeTypeNullableFilter {
+  equals: RevenueTypeType
+  in: [RevenueTypeType!]
+  notIn: [RevenueTypeType!]
+  not: RevenueTypeTypeNullableFilter
+}
+
+input RevenueOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+  type: OrderDirection
+  value: OrderDirection
+  start_date: OrderDirection
+  end_date: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input RevenueUpdateInput {
+  title: String
+  publisher: PublisherRelateToOneForUpdateInput
+  type: RevenueTypeType
+  value: Float
+  start_date: DateTime
+  end_date: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input RevenueUpdateArgs {
+  where: RevenueWhereUniqueInput!
+  data: RevenueUpdateInput!
+}
+
+input RevenueCreateInput {
+  title: String
+  publisher: PublisherRelateToOneForCreateInput
+  type: RevenueTypeType
+  value: Float
+  start_date: DateTime
+  end_date: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
+type Statement {
+  id: ID!
+  title: String
+  publisher: Publisher
+  type: StatementTypeType
+  url: String
+  start_date: DateTime
+  end_date: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+enum StatementTypeType {
+  month
+  quarter
+  semi_annual
+}
+
+input StatementWhereUniqueInput {
+  id: ID
+}
+
+input StatementWhereInput {
+  AND: [StatementWhereInput!]
+  OR: [StatementWhereInput!]
+  NOT: [StatementWhereInput!]
+  id: IDFilter
+  title: StringFilter
+  publisher: PublisherWhereInput
+  type: StatementTypeTypeNullableFilter
+  url: StringFilter
+  start_date: DateTimeNullableFilter
+  end_date: DateTimeNullableFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input StatementTypeTypeNullableFilter {
+  equals: StatementTypeType
+  in: [StatementTypeType!]
+  notIn: [StatementTypeType!]
+  not: StatementTypeTypeNullableFilter
+}
+
+input StatementOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+  type: OrderDirection
+  url: OrderDirection
+  start_date: OrderDirection
+  end_date: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input StatementUpdateInput {
+  title: String
+  publisher: PublisherRelateToOneForUpdateInput
+  type: StatementTypeType
+  url: String
+  start_date: DateTime
+  end_date: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input StatementUpdateArgs {
+  where: StatementWhereUniqueInput!
+  data: StatementUpdateInput!
+}
+
+input StatementCreateInput {
+  title: String
+  publisher: PublisherRelateToOneForCreateInput
+  type: StatementTypeType
+  url: String
+  start_date: DateTime
+  end_date: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -3109,6 +3288,24 @@ type Mutation {
   updateReportRecords(data: [ReportRecordUpdateArgs!]!): [ReportRecord]
   deleteReportRecord(where: ReportRecordWhereUniqueInput!): ReportRecord
   deleteReportRecords(where: [ReportRecordWhereUniqueInput!]!): [ReportRecord]
+  createRevenue(data: RevenueCreateInput!): Revenue
+  createRevenues(data: [RevenueCreateInput!]!): [Revenue]
+  updateRevenue(
+    where: RevenueWhereUniqueInput!
+    data: RevenueUpdateInput!
+  ): Revenue
+  updateRevenues(data: [RevenueUpdateArgs!]!): [Revenue]
+  deleteRevenue(where: RevenueWhereUniqueInput!): Revenue
+  deleteRevenues(where: [RevenueWhereUniqueInput!]!): [Revenue]
+  createStatement(data: StatementCreateInput!): Statement
+  createStatements(data: [StatementCreateInput!]!): [Statement]
+  updateStatement(
+    where: StatementWhereUniqueInput!
+    data: StatementUpdateInput!
+  ): Statement
+  updateStatements(data: [StatementUpdateArgs!]!): [Statement]
+  deleteStatement(where: StatementWhereUniqueInput!): Statement
+  deleteStatements(where: [StatementWhereUniqueInput!]!): [Statement]
   endSession: Boolean!
   authenticateUserWithPassword(
     email: String!
@@ -3324,6 +3521,22 @@ type Query {
   ): [ReportRecord!]
   reportRecord(where: ReportRecordWhereUniqueInput!): ReportRecord
   reportRecordsCount(where: ReportRecordWhereInput! = {}): Int
+  revenues(
+    where: RevenueWhereInput! = {}
+    orderBy: [RevenueOrderByInput!]! = []
+    take: Int
+    skip: Int! = 0
+  ): [Revenue!]
+  revenue(where: RevenueWhereUniqueInput!): Revenue
+  revenuesCount(where: RevenueWhereInput! = {}): Int
+  statements(
+    where: StatementWhereInput! = {}
+    orderBy: [StatementOrderByInput!]! = []
+    take: Int
+    skip: Int! = 0
+  ): [Statement!]
+  statement(where: StatementWhereUniqueInput!): Statement
+  statementsCount(where: StatementWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
 }

--- a/packages/mesh/schema.prisma
+++ b/packages/mesh/schema.prisma
@@ -64,6 +64,10 @@ model User {
   from_ReportReason_updatedBy     ReportReason[]     @relation("ReportReason_updatedBy")
   from_ReportRecord_createdBy     ReportRecord[]     @relation("ReportRecord_createdBy")
   from_ReportRecord_updatedBy     ReportRecord[]     @relation("ReportRecord_updatedBy")
+  from_Revenue_createdBy          Revenue[]          @relation("Revenue_createdBy")
+  from_Revenue_updatedBy          Revenue[]          @relation("Revenue_updatedBy")
+  from_Statement_createdBy        Statement[]        @relation("Statement_createdBy")
+  from_Statement_updatedBy        Statement[]        @relation("Statement_updatedBy")
 
   @@index([publisherId])
 }
@@ -175,39 +179,41 @@ model Pick {
 }
 
 model Publisher {
-  id                    Int           @id @default(autoincrement())
-  title                 String        @default("")
-  official_site         String        @default("")
-  rss                   String        @default("")
-  summary               String        @default("")
-  logo                  String        @default("")
-  description           String        @default("")
-  is_active             Boolean       @default(true)
-  customId              String        @default("")
-  admin                 Member?       @relation("Publisher_admin", fields: [adminId], references: [id])
-  adminId               Int?          @map("admin")
-  exchange              Exchange[]    @relation("Exchange_publisher")
-  sponsored             Sponsorship[] @relation("Sponsorship_publisher")
-  lang                  String?       @default("zh-TW")
-  category              Category?     @relation("Publisher_category", fields: [categoryId], references: [id])
-  categoryId            Int?          @map("category")
-  full_content          Boolean       @default(false)
-  full_screen_ad        String?       @default("none")
-  source_type           String?       @default("empty")
-  paywall               Boolean       @default(false)
-  follower              Member[]      @relation("Member_follow_publisher")
-  exclude_follower      Member[]      @relation("Member_exclude_publisher")
-  wallet                String        @default("")
-  user                  User[]        @relation("User_publisher")
-  createdAt             DateTime?
-  updatedAt             DateTime?
-  createdBy             User?         @relation("Publisher_createdBy", fields: [createdById], references: [id])
-  createdById           Int?          @map("createdBy")
-  updatedBy             User?         @relation("Publisher_updatedBy", fields: [updatedById], references: [id])
-  updatedById           Int?          @map("updatedBy")
-  from_Story_source     Story[]       @relation("Story_source")
-  from_Policy_publisher Policy[]      @relation("Policy_publisher")
-  from_Podcast_source   Podcast[]     @relation("Podcast_source")
+  id                       Int           @id @default(autoincrement())
+  title                    String        @default("")
+  official_site            String        @default("")
+  rss                      String        @default("")
+  summary                  String        @default("")
+  logo                     String        @default("")
+  description              String        @default("")
+  is_active                Boolean       @default(true)
+  customId                 String        @default("")
+  admin                    Member?       @relation("Publisher_admin", fields: [adminId], references: [id])
+  adminId                  Int?          @map("admin")
+  exchange                 Exchange[]    @relation("Exchange_publisher")
+  sponsored                Sponsorship[] @relation("Sponsorship_publisher")
+  lang                     String?       @default("zh-TW")
+  category                 Category?     @relation("Publisher_category", fields: [categoryId], references: [id])
+  categoryId               Int?          @map("category")
+  full_content             Boolean       @default(false)
+  full_screen_ad           String?       @default("none")
+  source_type              String?       @default("empty")
+  paywall                  Boolean       @default(false)
+  follower                 Member[]      @relation("Member_follow_publisher")
+  exclude_follower         Member[]      @relation("Member_exclude_publisher")
+  wallet                   String        @default("")
+  user                     User[]        @relation("User_publisher")
+  createdAt                DateTime?
+  updatedAt                DateTime?
+  createdBy                User?         @relation("Publisher_createdBy", fields: [createdById], references: [id])
+  createdById              Int?          @map("createdBy")
+  updatedBy                User?         @relation("Publisher_updatedBy", fields: [updatedById], references: [id])
+  updatedById              Int?          @map("updatedBy")
+  from_Story_source        Story[]       @relation("Story_source")
+  from_Policy_publisher    Policy[]      @relation("Policy_publisher")
+  from_Podcast_source      Podcast[]     @relation("Podcast_source")
+  from_Revenue_publisher   Revenue[]     @relation("Revenue_publisher")
+  from_Statement_publisher Statement[]   @relation("Statement_publisher")
 
   @@index([adminId])
   @@index([categoryId])
@@ -372,6 +378,7 @@ model Story {
   @@index([sourceId])
   @@index([authorId])
   @@index([categoryId])
+  @@index([story_type])
   @@index([podcastId])
   @@index([createdById])
   @@index([updatedById])
@@ -535,15 +542,15 @@ model Policy {
 
 model Podcast {
   id                 Int        @id @default(autoincrement())
-  url                String     @unique @default("")
   author             String     @default("")
+  url                String     @unique @default("")
+  file_size          Int?
+  mime_type          String     @default("")
   duration           String     @default("")
   source             Publisher? @relation("Podcast_source", fields: [sourceId], references: [id])
   sourceId           Int?       @map("source")
   story              Story?     @relation("Podcast_story", fields: [storyId], references: [id])
   storyId            Int?       @map("story")
-  file_size          Int?
-  mime_type          String     @default("")
   createdAt          DateTime?
   updatedAt          DateTime?
   createdBy          User?      @relation("Podcast_createdBy", fields: [createdById], references: [id])
@@ -672,6 +679,48 @@ model ReportRecord {
   @@index([updatedById])
 }
 
+model Revenue {
+  id          Int              @id @default(autoincrement())
+  title       String           @default("")
+  publisher   Publisher?       @relation("Revenue_publisher", fields: [publisherId], references: [id])
+  publisherId Int?             @map("publisher")
+  type        RevenueTypeType?
+  value       Float
+  start_date  DateTime?
+  end_date    DateTime?
+  createdAt   DateTime?
+  updatedAt   DateTime?
+  createdBy   User?            @relation("Revenue_createdBy", fields: [createdById], references: [id])
+  createdById Int?             @map("createdBy")
+  updatedBy   User?            @relation("Revenue_updatedBy", fields: [updatedById], references: [id])
+  updatedById Int?             @map("updatedBy")
+
+  @@index([publisherId])
+  @@index([createdById])
+  @@index([updatedById])
+}
+
+model Statement {
+  id          Int                @id @default(autoincrement())
+  title       String             @default("")
+  publisher   Publisher?         @relation("Statement_publisher", fields: [publisherId], references: [id])
+  publisherId Int?               @map("publisher")
+  type        StatementTypeType?
+  url         String             @default("")
+  start_date  DateTime?
+  end_date    DateTime?
+  createdAt   DateTime?
+  updatedAt   DateTime?
+  createdBy   User?              @relation("Statement_createdBy", fields: [createdById], references: [id])
+  createdById Int?               @map("createdBy")
+  updatedBy   User?              @relation("Statement_updatedBy", fields: [updatedById], references: [id])
+  updatedById Int?               @map("updatedBy")
+
+  @@index([publisherId])
+  @@index([createdById])
+  @@index([updatedById])
+}
+
 enum StoryFullScreenAdType {
   mobile
   desktop
@@ -706,4 +755,15 @@ enum ExchangeStatusType {
   Success
   Failed
   Processing
+}
+
+enum RevenueTypeType {
+  story_ad_revenue
+  mutual_fund_revenue
+}
+
+enum StatementTypeType {
+  month
+  quarter
+  semi_annual
 }


### PR DESCRIPTION
新增收益(revenue)與報表(statement)的list，兩者分別用途如下
1. revenue: 在每個月計算廣告分潤(from gam)與基金池分潤(from adsense)時，將資料寫入revenue
2. statement: 在產出月報(month)/季報(qualter)/半年報(semi_annual)時，將檔案來源與相關資料寫入statement

實際運作情形如下：
在每個月計算月報表時，將各媒體廣告分潤與基金池分潤一併寫入revenue list當中供後續查詢；在產製個報表時，會將資訊寫入statement list，需注意季報會需要該媒體前幾個月的廣告收益，此部分會從revenue list取得。
另需注意，在statement中的報表檔案連結，若非具權限的Google帳戶時，會需要Signed cookie才可以進行讀檔，此部分會依照以不同的媒體切割權限。