### PR TITLE
feat(mesh): add language field into member list

### DIFF
--- a/packages/mesh/lists/member.ts
+++ b/packages/mesh/lists/member.ts
@@ -1,6 +1,6 @@
 import { utils } from '@mirrormedia/lilith-core'
 import { list } from '@keystone-6/core'
-import { text, relationship, checkbox, integer } from '@keystone-6/core/fields'
+import { text, relationship, checkbox, integer, select } from '@keystone-6/core/fields'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
 
@@ -127,6 +127,20 @@ const listConfigurations = list({
       ui: {
         createView: {fieldMode: "hidden"},
       }
+    }),
+    language: select({
+      label: '語系',
+      type: 'enum',
+      options: [
+        {label: "中文-台灣", value: "zh_TW"},
+        {label: "中文-中國", value: "zh_CN"},
+        {label: "英文-美國", value: "en_US"},
+        {label: "英文-英國", value: "en_GB"},
+        {label: "日文-日本", value: "ja_JP"},
+        {label: "法文-法國", value: "fr_FR"},
+        {label: "德文-德國", value: "de_DE"},
+      ],
+      defaultValue: "zh_TW",
     }),
   },
   ui: {

--- a/packages/mesh/migrations/20250224024903_add_language_field_to_member/migration.sql
+++ b/packages/mesh/migrations/20250224024903_add_language_field_to_member/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "MemberLanguageType" AS ENUM ('zh_TW', 'zh_CN', 'en_US', 'en_GB', 'ja_JP', 'fr_FR', 'de_DE');
+
+-- AlterTable
+ALTER TABLE "Member" ADD COLUMN     "language" "MemberLanguageType" DEFAULT E'zh_TW';

--- a/packages/mesh/schema.graphql
+++ b/packages/mesh/schema.graphql
@@ -1778,10 +1778,21 @@ type Member {
   ): [CollectionMember!]
   modify_collectionCount(where: CollectionMemberWhereInput! = {}): Int
   balance: Int
+  language: MemberLanguageType
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User
   updatedBy: User
+}
+
+enum MemberLanguageType {
+  zh_TW
+  zh_CN
+  en_US
+  en_GB
+  ja_JP
+  fr_FR
+  de_DE
 }
 
 input MemberWhereUniqueInput {
@@ -1826,6 +1837,7 @@ input MemberWhereInput {
   create_collection: CollectionMemberManyRelationFilter
   modify_collection: CollectionMemberManyRelationFilter
   balance: IntNullableFilter
+  language: MemberLanguageTypeNullableFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
@@ -1868,6 +1880,13 @@ input CollectionMemberManyRelationFilter {
   none: CollectionMemberWhereInput
 }
 
+input MemberLanguageTypeNullableFilter {
+  equals: MemberLanguageType
+  in: [MemberLanguageType!]
+  notIn: [MemberLanguageType!]
+  not: MemberLanguageTypeNullableFilter
+}
+
 input MemberOrderByInput {
   id: OrderDirection
   firebaseId: OrderDirection
@@ -1881,6 +1900,7 @@ input MemberOrderByInput {
   is_active: OrderDirection
   verified: OrderDirection
   balance: OrderDirection
+  language: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
@@ -1916,6 +1936,7 @@ input MemberUpdateInput {
   create_collection: CollectionMemberRelateToManyForUpdateInput
   modify_collection: CollectionMemberRelateToManyForUpdateInput
   balance: Int
+  language: MemberLanguageType
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
@@ -2006,6 +2027,7 @@ input MemberCreateInput {
   create_collection: CollectionMemberRelateToManyForCreateInput
   modify_collection: CollectionMemberRelateToManyForCreateInput
   balance: Int
+  language: MemberLanguageType
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput

--- a/packages/mesh/schema.prisma
+++ b/packages/mesh/schema.prisma
@@ -402,52 +402,53 @@ model Tag {
 }
 
 model Member {
-  id                           Int                @id @default(autoincrement())
-  firebaseId                   String             @unique @default("")
-  customId                     String             @unique @default("")
-  name                         String             @default("")
-  nickname                     String             @default("")
-  avatar                       String             @default("")
-  intro                        String             @default("")
-  avatar_image                 Photo?             @relation("Member_avatar_image", fields: [avatar_imageId], references: [id])
-  avatar_imageId               Int?               @map("avatar_image")
-  wallet                       String             @default("")
-  email                        String             @unique @default("")
-  is_active                    Boolean            @default(true)
-  verified                     Boolean            @default(false)
-  publisher                    Publisher[]        @relation("Publisher_admin")
-  pick                         Pick[]             @relation("Pick_member")
-  sponsor                      Sponsorship[]      @relation("Sponsorship_sponsor")
-  transaction                  Transaction[]      @relation("Transaction_member")
-  comment                      Comment[]          @relation("Comment_member")
-  member_like                  Comment[]          @relation("Comment_like")
-  follower                     Member[]           @relation("Member_follower")
-  following                    Member[]           @relation("Member_follower")
-  block                        Member[]           @relation("Member_block")
-  blocked                      Member[]           @relation("Member_block")
-  following_category           Category[]         @relation("Member_following_category")
-  following_collection         Collection[]       @relation("Member_following_collection")
-  follow_publisher             Publisher[]        @relation("Member_follow_publisher")
-  exclude_publisher            Publisher[]        @relation("Member_exclude_publisher")
-  invited                      InvitationCode[]   @relation("InvitationCode_send")
-  invited_by                   InvitationCode?    @relation("InvitationCode_receive")
-  create_collection            CollectionMember[] @relation("CollectionMember_added_by")
-  modify_collection            CollectionMember[] @relation("CollectionMember_updated_by")
-  balance                      Int?               @default(0)
+  id                           Int                 @id @default(autoincrement())
+  firebaseId                   String              @unique @default("")
+  customId                     String              @unique @default("")
+  name                         String              @default("")
+  nickname                     String              @default("")
+  avatar                       String              @default("")
+  intro                        String              @default("")
+  avatar_image                 Photo?              @relation("Member_avatar_image", fields: [avatar_imageId], references: [id])
+  avatar_imageId               Int?                @map("avatar_image")
+  wallet                       String              @default("")
+  email                        String              @unique @default("")
+  is_active                    Boolean             @default(true)
+  verified                     Boolean             @default(false)
+  publisher                    Publisher[]         @relation("Publisher_admin")
+  pick                         Pick[]              @relation("Pick_member")
+  sponsor                      Sponsorship[]       @relation("Sponsorship_sponsor")
+  transaction                  Transaction[]       @relation("Transaction_member")
+  comment                      Comment[]           @relation("Comment_member")
+  member_like                  Comment[]           @relation("Comment_like")
+  follower                     Member[]            @relation("Member_follower")
+  following                    Member[]            @relation("Member_follower")
+  block                        Member[]            @relation("Member_block")
+  blocked                      Member[]            @relation("Member_block")
+  following_category           Category[]          @relation("Member_following_category")
+  following_collection         Collection[]        @relation("Member_following_collection")
+  follow_publisher             Publisher[]         @relation("Member_follow_publisher")
+  exclude_publisher            Publisher[]         @relation("Member_exclude_publisher")
+  invited                      InvitationCode[]    @relation("InvitationCode_send")
+  invited_by                   InvitationCode?     @relation("InvitationCode_receive")
+  create_collection            CollectionMember[]  @relation("CollectionMember_added_by")
+  modify_collection            CollectionMember[]  @relation("CollectionMember_updated_by")
+  balance                      Int?                @default(0)
+  language                     MemberLanguageType? @default(zh_TW)
   createdAt                    DateTime?
   updatedAt                    DateTime?
-  createdBy                    User?              @relation("Member_createdBy", fields: [createdById], references: [id])
-  createdById                  Int?               @map("createdBy")
-  updatedBy                    User?              @relation("Member_updatedBy", fields: [updatedById], references: [id])
-  updatedById                  Int?               @map("updatedBy")
-  from_Collection_creator      Collection[]       @relation("Collection_creator")
-  from_CollectionMember_member CollectionMember[] @relation("CollectionMember_member")
-  from_CollectionPick_creator  CollectionPick[]   @relation("CollectionPick_creator")
-  from_Story_author            Story[]            @relation("Story_author")
-  from_Notify_member           Notify[]           @relation("Notify_member")
-  from_Notify_sender           Notify[]           @relation("Notify_sender")
-  from_ReportRecord_informant  ReportRecord[]     @relation("ReportRecord_informant")
-  from_ReportRecord_respondent ReportRecord[]     @relation("ReportRecord_respondent")
+  createdBy                    User?               @relation("Member_createdBy", fields: [createdById], references: [id])
+  createdById                  Int?                @map("createdBy")
+  updatedBy                    User?               @relation("Member_updatedBy", fields: [updatedById], references: [id])
+  updatedById                  Int?                @map("updatedBy")
+  from_Collection_creator      Collection[]        @relation("Collection_creator")
+  from_CollectionMember_member CollectionMember[]  @relation("CollectionMember_member")
+  from_CollectionPick_creator  CollectionPick[]    @relation("CollectionPick_creator")
+  from_Story_author            Story[]             @relation("Story_author")
+  from_Notify_member           Notify[]            @relation("Notify_member")
+  from_Notify_sender           Notify[]            @relation("Notify_sender")
+  from_ReportRecord_informant  ReportRecord[]      @relation("ReportRecord_informant")
+  from_ReportRecord_respondent ReportRecord[]      @relation("ReportRecord_respondent")
 
   @@index([avatar_imageId])
   @@index([createdById])
@@ -732,6 +733,16 @@ enum StoryFullScreenAdType {
 enum StoryStoryTypeType {
   story
   podcast
+}
+
+enum MemberLanguageType {
+  zh_TW
+  zh_CN
+  en_US
+  en_GB
+  ja_JP
+  fr_FR
+  de_DE
 }
 
 enum PolicyTypeType {


### PR DESCRIPTION
將語系的欄位新增至member的list，預設使用zh-TW，並提供其他主流語言的對照碼。

現提供以下語系，並因應地區性差異做區別:
{label: "中文-台灣", value: "zh_TW"},
{label: "中文-中國", value: "zh_CN"},
{label: "英文-美國", value: "en_US"},
{label: "英文-英國", value: "en_GB"},
{label: "日文-日本", value: "ja_JP"},
{label: "法文-法國", value: "fr_FR"},
{label: "德文-德國", value: "de_DE"},

語系對照表請參考以下網站
https://hoohoo.top/blog/national-language-code-table-zh-tw-zh-cn-en-us-json-format/