### PR TITLE
feat(daily): add filter to Topic, Section and Category list

### DIFF
--- a/packages/mirrordaily/environment-variables.ts
+++ b/packages/mirrordaily/environment-variables.ts
@@ -1,3 +1,5 @@
+import { ACL } from './type'
+
 const {
   IS_UI_DISABLED,
   ACCESS_CONTROL_STRATEGY,
@@ -32,7 +34,7 @@ const cacheConnectTimeout = Number(CACHE_CONNECT_TIMEOUT)
 
 export default {
   isUIDisabled: IS_UI_DISABLED === 'true',
-  accessControlStrategy: ACCESS_CONTROL_STRATEGY || 'cms', // the value could be one of 'cms', 'gql' or 'preview'
+  accessControlStrategy: ACCESS_CONTROL_STRATEGY || ACL.CMS, // the value could be one of 'cms', 'gql' or 'preview'
   previewServer: {
     origin: PREVIEW_SERVER_ORIGIN || 'http://localhost:3001',
     path: PREVIEW_SERVER_PATH || '/preview-server',

--- a/packages/mirrordaily/keystone.ts
+++ b/packages/mirrordaily/keystone.ts
@@ -11,6 +11,7 @@ import { KeyvAdapter } from '@apollo/utils.keyvadapter'
 import { ApolloServerPluginCacheControl } from '@apollo/server/plugin/cacheControl'
 import responseCachePlugin from '@apollo/server-plugin-response-cache'
 import { GraphQLConfig } from '@keystone-6/core/types'
+import { ACL } from './type'
 
 const { withAuth } = createAuth({
   listKey: 'User',
@@ -28,7 +29,7 @@ const session = statelessSessions(envVar.session)
 
 const graphqlConfig: GraphQLConfig = {
   apolloConfig:
-    envVar.accessControlStrategy === 'gql' && envVar.cache.isEnabled
+    envVar.accessControlStrategy === ACL.GraphQL && envVar.cache.isEnabled
       ? {
           plugins: [
             responseCachePlugin(),
@@ -108,7 +109,7 @@ export default withAuth(
         const jsonBodyParser = express.json({ limit: '500mb' })
         app.use(jsonBodyParser)
 
-        if (envVar.accessControlStrategy === 'cms') {
+        if (envVar.accessControlStrategy === ACL.CMS) {
           app.use(
             createPreviewMiniApp({
               previewServer: envVar.previewServer,

--- a/packages/mirrordaily/lists/Category.ts
+++ b/packages/mirrordaily/lists/Category.ts
@@ -7,8 +7,13 @@ import {
   text,
   integer,
 } from '@keystone-6/core/fields'
+import { State } from '../type'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
+enum CategoryState {
+  Active = State.Active,
+  Inactive = State.Inactive,
+}
 
 const listConfigurations = list({
   fields: {
@@ -31,13 +36,13 @@ const listConfigurations = list({
     }),
     state: select({
       options: [
-        { label: 'active', value: 'active' },
-        { label: 'inactive', value: 'inactive' },
+        { label: 'active', value: CategoryState.Active },
+        { label: 'inactive', value: CategoryState.Inactive },
       ],
       isIndexed: true,
       validation: { isRequired: true },
       ui: { displayMode: 'segmented-control' },
-      defaultValue: 'active',
+      defaultValue: CategoryState.Active,
     }),
     heroImage: relationship({
       label: 'Banner圖片',

--- a/packages/mirrordaily/lists/EditorChoice.ts
+++ b/packages/mirrordaily/lists/EditorChoice.ts
@@ -1,8 +1,16 @@
 import { utils } from '@mirrormedia/lilith-core'
 import { list } from '@keystone-6/core'
 import { relationship, select, integer, text } from '@keystone-6/core/fields'
+import { State } from '../type'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+enum EditorChoiceState {
+  Draft = State.Draft,
+  Published = State.Published,
+  Scheduled = State.Scheduled,
+  Archived = State.Archived,
+}
 
 const listConfigurations = list({
   fields: {
@@ -28,12 +36,12 @@ const listConfigurations = list({
     state: select({
       label: '狀態',
       options: [
-        { label: '草稿', value: 'draft' },
-        { label: '已發布', value: 'published' },
-        { label: '預約發佈', value: 'scheduled' },
-        { label: '下線', value: 'archived' },
+        { label: '草稿', value: EditorChoiceState.Draft },
+        { label: '已發布', value: EditorChoiceState.Published },
+        { label: '預約發佈', value: EditorChoiceState.Scheduled },
+        { label: '下線', value: EditorChoiceState.Archived },
       ],
-      defaultValue: 'draft',
+      defaultValue: EditorChoiceState.Draft,
       isIndexed: true,
     }),
     heroImage: relationship({

--- a/packages/mirrordaily/lists/Event.ts
+++ b/packages/mirrordaily/lists/Event.ts
@@ -7,8 +7,14 @@ import {
   checkbox,
   relationship,
 } from '@keystone-6/core/fields'
+import { State } from '../type'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+enum EventState {
+  Draft = State.Draft,
+  Published = State.Published,
+}
 
 const listConfigurations = list({
   fields: {
@@ -23,11 +29,11 @@ const listConfigurations = list({
     }),
     state: select({
       options: [
-        { label: '過往活動', value: 'draft' },
-        { label: '即將舉辦（舉辦中）', value: 'published' },
+        { label: '過往活動', value: EventState.Draft },
+        { label: '即將舉辦（舉辦中）', value: EventState.Published },
       ],
       label: '狀態',
-      defaultValue: 'draft',
+      defaultValue: EventState.Draft,
       isIndexed: true,
     }),
     publishedDate: timestamp({

--- a/packages/mirrordaily/lists/External.ts
+++ b/packages/mirrordaily/lists/External.ts
@@ -2,15 +2,9 @@ import { utils } from '@mirrormedia/lilith-core'
 import { list } from '@keystone-6/core'
 import { select, text, timestamp, relationship } from '@keystone-6/core/fields'
 import envVar from '../environment-variables'
+import { ACL, UserRole } from '../type'
 
 const { allowRoles, admin, moderator } = utils.accessControl
-
-enum UserRole {
-  Admin = 'admin',
-  Moderator = 'moderator',
-  Editor = 'editor',
-  Contributor = 'contributor',
-}
 
 enum ExternalStatus {
   Published = 'published',
@@ -30,19 +24,19 @@ type Session = {
 function filterExternals(roles: string[]) {
   return ({ session }: { session: Session }) => {
     switch (envVar.accessControlStrategy) {
-      case 'gql': {
+      case ACL.GraphQL: {
         // Expose `published` and `invisible` externals
         return {
           state: { in: [ExternalStatus.Published, ExternalStatus.Invisible] },
         }
       }
-      case 'preview': {
-        // Expose all externals, including `published`, `draft` and `archived` externals
+      case ACL.Preview: {
+        // Expose all externals
         return true
       }
-      case 'cms':
+      case ACL.CMS:
       default: {
-        // Expose all externals, including `published`, `draft` and `archived` externals if user logged in
+        // Expose all externals if user logged in
         return roles.indexOf(session?.data?.role) > -1
       }
     }
@@ -69,13 +63,13 @@ const listConfigurations = list({
     state: select({
       label: '狀態',
       options: [
-        { label: '草稿', value: 'draft' },
-        { label: '已發布', value: 'published' },
-        { label: '預約發佈', value: 'scheduled' },
-        { label: '下線', value: 'archived' },
-        { label: '前台不可見', value: 'invisible' },
+        { label: '草稿', value: ExternalStatus.Draft },
+        { label: '已發布', value: ExternalStatus.Published },
+        { label: '預約發佈', value: ExternalStatus.Scheduled },
+        { label: '下線', value: ExternalStatus.Archived },
+        { label: '前台不可見', value: ExternalStatus.Invisible },
       ],
-      defaultValue: 'draft',
+      defaultValue: ExternalStatus.Draft,
       isIndexed: true,
     }),
     publishedDate: timestamp({
@@ -131,7 +125,7 @@ const listConfigurations = list({
       },
     }),
     groups: relationship({
-      label: "群組",
+      label: '群組',
       ref: 'Group.externals',
       many: true,
       ui: {
@@ -149,6 +143,7 @@ const listConfigurations = list({
   },
   access: {
     operation: {
+      query: () => true,
       update: allowRoles(admin, moderator),
       create: allowRoles(admin, moderator),
       delete: allowRoles(admin),
@@ -177,7 +172,7 @@ const listConfigurations = list({
           return
         }
       }
-      return 0
+      return
     },
   },
 })

--- a/packages/mirrordaily/lists/External.ts
+++ b/packages/mirrordaily/lists/External.ts
@@ -2,23 +2,16 @@ import { utils } from '@mirrormedia/lilith-core'
 import { list } from '@keystone-6/core'
 import { select, text, timestamp, relationship } from '@keystone-6/core/fields'
 import envVar from '../environment-variables'
-import { ACL, UserRole } from '../type'
+import { ACL, UserRole, State, type Session } from '../type'
 
 const { allowRoles, admin, moderator } = utils.accessControl
 
 enum ExternalStatus {
-  Published = 'published',
-  Draft = 'draft',
-  Scheduled = 'scheduled',
-  Archived = 'archived',
-  Invisible = 'invisible',
-}
-
-type Session = {
-  data: {
-    id: string
-    role: UserRole
-  }
+  Published = State.Published,
+  Draft = State.Draft,
+  Scheduled = State.Scheduled,
+  Archived = State.Archived,
+  Invisible = State.Invisible,
 }
 
 function filterExternals(roles: string[]) {

--- a/packages/mirrordaily/lists/Game.ts
+++ b/packages/mirrordaily/lists/Game.ts
@@ -8,8 +8,14 @@ import {
   integer,
   relationship,
 } from '@keystone-6/core/fields'
+import { State } from '../type'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+enum GameState {
+  Draft = State.Draft,
+  Published = State.Published,
+}
 
 const listConfigurations = list({
   fields: {
@@ -19,11 +25,11 @@ const listConfigurations = list({
     }),
     state: select({
       options: [
-        { label: '草稿', value: 'draft' },
-        { label: '發布', value: 'published' },
+        { label: '草稿', value: GameState.Draft },
+        { label: '發布', value: GameState.Published },
       ],
       label: '狀態',
-      defaultValue: 'draft',
+      defaultValue: GameState.Draft,
       isIndexed: true,
     }),
     publishedDate: timestamp({

--- a/packages/mirrordaily/lists/Group.ts
+++ b/packages/mirrordaily/lists/Group.ts
@@ -7,24 +7,24 @@ const { allowRoles, admin, moderator } = utils.accessControl
 const listConfigurations = list({
   fields: {
     keyword: text({
-        label: '關鍵詞',
-        validation: {
-            isRequired: true,
-        },
+      label: '關鍵詞',
+      validation: {
+        isRequired: true,
+      },
     }),
     posts: relationship({
-        ref: 'Post.groups',
-        many: true,
-        ui: {
+      ref: 'Post.groups',
+      many: true,
+      ui: {
         views: './lists/views/sorted-relationship/index',
-        },
+      },
     }),
     externals: relationship({
-        ref: 'External.groups',
-        many: true,
-        ui: {
-            views: './lists/views/sorted-relationship/index',
-        },
+      ref: 'External.groups',
+      many: true,
+      ui: {
+        views: './lists/views/sorted-relationship/index',
+      },
     }),
   },
   ui: {
@@ -37,6 +37,7 @@ const listConfigurations = list({
   },
   access: {
     operation: {
+      query: () => true,
       update: allowRoles(admin, moderator),
       create: allowRoles(admin, moderator),
       delete: allowRoles(admin),

--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -13,23 +13,16 @@ import {
 import envVar from '../environment-variables'
 // @ts-ignore draft-js does not have typescript definition
 import { RawContentState } from 'draft-js'
-import { ACL, UserRole } from '../type'
+import { ACL, UserRole, State, type Session } from '../type'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
 
 enum PostStatus {
-  Published = 'published',
-  Draft = 'draft',
-  Scheduled = 'scheduled',
-  Archived = 'archived',
-  Invisible = 'invisible',
-}
-
-type Session = {
-  data: {
-    id: string
-    role: UserRole
-  }
+  Published = State.Published,
+  Draft = State.Draft,
+  Scheduled = State.Scheduled,
+  Archived = State.Archived,
+  Invisible = State.Invisible,
 }
 
 function filterPosts(roles: string[]) {

--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -13,15 +13,9 @@ import {
 import envVar from '../environment-variables'
 // @ts-ignore draft-js does not have typescript definition
 import { RawContentState } from 'draft-js'
+import { ACL, UserRole } from '../type'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
-
-enum UserRole {
-  Admin = 'admin',
-  Moderator = 'moderator',
-  Editor = 'editor',
-  Contributor = 'contributor',
-}
 
 enum PostStatus {
   Published = 'published',
@@ -41,17 +35,17 @@ type Session = {
 function filterPosts(roles: string[]) {
   return ({ session }: { session?: Session }) => {
     switch (envVar.accessControlStrategy) {
-      case 'gql': {
+      case ACL.GraphQL: {
         // Expose `published` and `invisible` posts
         return { state: { in: [PostStatus.Published, PostStatus.Invisible] } }
       }
-      case 'preview': {
-        // Expose all posts, including `published`, `draft` and `archived` posts
+      case ACL.Preview: {
+        // Expose all posts
         return true
       }
-      case 'cms':
+      case ACL.CMS:
       default: {
-        // Expose all posts, including `published`, `draft` and `archived` posts if user logged in
+        // Expose all posts if user logged in
         return (
           session?.data?.role !== undefined &&
           roles.indexOf(session.data.role) > -1
@@ -59,6 +53,53 @@ function filterPosts(roles: string[]) {
       }
     }
   }
+}
+
+function checkReadPermission({
+  context,
+  item,
+}: {
+  context: KeystoneContext
+  item: Record<string, unknown>
+}) {
+  if (envVar.accessControlStrategy === ACL.GraphQL) {
+    // Post is not member only,
+    // every request could access content field
+    if (item?.isMember === false) {
+      return true
+    }
+
+    // Post is member only.
+    // Check request permission.
+    const scope = context.req?.headers?.['x-access-token-scope']
+
+    // get acl from scope
+    const acl =
+      typeof scope === 'string'
+        ? scope.match(/read:member-posts:([^\s]*)/i)?.[1]
+        : ''
+
+    if (typeof acl !== 'string') {
+      return false
+    } else if (acl === 'all') {
+      // scope contains 'read:memeber-posts:all'
+      // the request has the permission to read this field
+      return true
+    } else {
+      // scope contains 'read:member-posts:${postId1},${postId2},...,${postIdN}'
+      const postIdArr = acl.split(',')
+
+      // check the request has the permission to read this field
+      if (postIdArr.indexOf(`${item.id}`) > -1) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  // the request has permission to read this field
+  return true
 }
 
 type FieldMode = 'edit' | 'read' | 'hidden'
@@ -148,13 +189,13 @@ const listConfigurations = list({
     state: select({
       label: '狀態',
       options: [
-        { label: '草稿', value: 'draft' },
-        { label: '已發布', value: 'published' },
-        { label: '預約發佈', value: 'scheduled' },
-        { label: '下線', value: 'archived' },
-        { label: '前台不可見', value: 'invisible' },
+        { label: '草稿', value: PostStatus.Draft },
+        { label: '已發布', value: PostStatus.Published },
+        { label: '預約發佈', value: PostStatus.Scheduled },
+        { label: '下線', value: PostStatus.Archived },
+        { label: '前台不可見', value: PostStatus.Invisible },
       ],
-      defaultValue: 'draft',
+      defaultValue: PostStatus.Draft,
       isIndexed: true,
     }),
     publishedDate: timestamp({
@@ -364,52 +405,7 @@ const listConfigurations = list({
       ],
       website: 'mirrormedia',
       access: {
-        read: ({
-          context,
-          item,
-        }: {
-          context: KeystoneContext
-          item: Record<string, unknown>
-        }) => {
-          if (envVar.accessControlStrategy === 'gql') {
-            // Post is not member only,
-            // every request could access content field
-            if (item?.isMember === false) {
-              return true
-            }
-
-            // Post is member only.
-            // Check request permission.
-            const scope = context.req?.headers?.['x-access-token-scope']
-
-            // get acl from scope
-            const acl =
-              typeof scope === 'string'
-                ? scope.match(/read:member-posts:([^\s]*)/i)?.[1]
-                : ''
-
-            if (typeof acl !== 'string') {
-              return false
-            } else if (acl === 'all') {
-              // scope contains 'read:memeber-posts:all'
-              // the request has the permission to read this field
-              return true
-            } else {
-              // scope contains 'read:member-posts:${postId1},${postId2},...,${postIdN}'
-              const postIdArr = acl.split(',')
-
-              // check the request has the permission to read this field
-              if (postIdArr.indexOf(`${item.id}`) > -1) {
-                return true
-              }
-            }
-
-            return false
-          }
-
-          // the request has permission to read this field
-          return true
-        },
+        read: checkReadPermission,
       },
     }),
     isMember: checkbox({
@@ -438,21 +434,21 @@ const listConfigurations = list({
       many: true,
       ui: {
         views: './lists/views/sorted-relationship/index',
-        createView: { fieldMode: 'hidden', },
-        itemView: { fieldMode: 'hidden', },
-        listView: { fieldMode: 'hidden', },
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'hidden' },
+        listView: { fieldMode: 'hidden' },
       },
     }),
     groups: relationship({
-      label: "群組(發佈後由演算法自動計算)",
+      label: '群組(發佈後由演算法自動計算)',
       isFilterable: false,
       ref: 'Group.posts',
       many: true,
       ui: {
         views: './lists/views/sorted-relationship/index',
-        createView: { fieldMode: 'hidden', },
-        itemView: { fieldMode: 'hidden', },
-        listView: { fieldMode: 'hidden', },
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'hidden' },
+        listView: { fieldMode: 'hidden' },
       },
     }),
     manualOrderOfRelateds: json({
@@ -474,9 +470,9 @@ const listConfigurations = list({
       many: true,
       ui: {
         views: './lists/views/sorted-relationship/index',
-        createView: { fieldMode: 'hidden', },
-        itemView: { fieldMode: 'hidden', },
-        listView: { fieldMode: 'hidden', },
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'hidden' },
+        listView: { fieldMode: 'hidden' },
       },
     }),
     og_title: text({
@@ -578,52 +574,7 @@ const listConfigurations = list({
         itemView: { fieldMode: 'hidden' },
       },
       access: {
-        read: ({
-          context,
-          item,
-        }: {
-          context: KeystoneContext
-          item: Record<string, unknown>
-        }) => {
-          if (envVar.accessControlStrategy === 'gql') {
-            // Post is not member only,
-            // every request could access content field
-            if (item?.isMember === false) {
-              return true
-            }
-
-            // Post is member only.
-            // Check request permission.
-            const scope = context.req?.headers?.['x-access-token-scope']
-
-            // get acl from scope
-            const acl =
-              typeof scope === 'string'
-                ? scope.match(/read:member-posts:([^\s]*)/i)?.[1]
-                : ''
-
-            if (typeof acl !== 'string') {
-              return false
-            } else if (acl === 'all') {
-              // scope contains 'read:memeber-posts:all'
-              // the request has the permission to read this field
-              return true
-            } else {
-              // scope contains 'read:member-posts:${postId1},${postId2},...,${postIdN}'
-              const postIdArr = acl.split(',')
-
-              // check the request has the permission to read this field
-              if (postIdArr.indexOf(`${item.id}`) > -1) {
-                return true
-              }
-            }
-
-            return false
-          }
-
-          // the request has permission to read this field
-          return true
-        },
+        read: checkReadPermission,
       },
     }),
     trimmedApiData: virtual({
@@ -660,7 +611,7 @@ const listConfigurations = list({
     },
   },
   graphql: {
-	cacheHint: { maxAge: 0, scope: 'PRIVATE' },
+    cacheHint: { maxAge: 0, scope: 'PRIVATE' },
   },
   access: {
     operation: {
@@ -717,12 +668,12 @@ const listConfigurations = list({
       if (operation === 'create' || operation === 'update') {
         if (resolvedData.slug) {
           resolvedData.slug = resolvedData.slug.trim()
-          resolvedData.slug = resolvedData.slug.replace(" ", "_")
+          resolvedData.slug = resolvedData.slug.replace(' ', '_')
         }
         if (resolvedData.publishedDate) {
           /* check the publishedDate */
           if (resolvedData.publishedDate > Date.now()) {
-            resolvedData.state = 'scheduled'
+            resolvedData.state = PostStatus.Scheduled
           }
           /* end publishedDate check */
           resolvedData.publishedDateString = new Date(
@@ -736,7 +687,7 @@ const listConfigurations = list({
           return
         }
       }
-      return 0
+      return
     },
     afterOperation: async ({ operation, inputData, item, context }) => {
       if (operation === 'update') {

--- a/packages/mirrordaily/lists/Section.ts
+++ b/packages/mirrordaily/lists/Section.ts
@@ -7,8 +7,13 @@ import {
   relationship,
   integer,
 } from '@keystone-6/core/fields'
+import { State } from '../type'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
+enum SectionState {
+  Active = State.Active,
+  Inactive = State.Inactive,
+}
 
 type Option = {
   label: string
@@ -74,13 +79,13 @@ const listConfigurations = list({
     }),
     state: select({
       options: [
-        { label: 'active', value: 'active' },
-        { label: 'inactive', value: 'inactive' },
+        { label: 'active', value: SectionState.Active },
+        { label: 'inactive', value: SectionState.Inactive },
       ],
       validation: { isRequired: true },
       isIndexed: true,
       ui: { displayMode: 'segmented-control' },
-      defaultValue: 'active',
+      defaultValue: SectionState.Active,
     }),
     isFeatured: checkbox({
       label: '置頂',

--- a/packages/mirrordaily/lists/Topic.ts
+++ b/packages/mirrordaily/lists/Topic.ts
@@ -8,8 +8,14 @@ import {
   integer,
   json,
 } from '@keystone-6/core/fields'
+import { State } from '../type'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+enum TopicState {
+  Draft = State.Draft,
+  Published = State.Published,
+}
 
 const listConfigurations = list({
   fields: {
@@ -26,10 +32,10 @@ const listConfigurations = list({
     state: select({
       label: '狀態',
       options: [
-        { label: '草稿', value: 'draft' },
-        { label: '已發布', value: 'published' },
+        { label: '草稿', value: TopicState.Draft },
+        { label: '已發布', value: TopicState.Published },
       ],
-      defaultValue: 'draft',
+      defaultValue: TopicState.Draft,
       isIndexed: true,
     }),
     brief: customFields.richTextEditor({

--- a/packages/mirrordaily/lists/Topic.ts
+++ b/packages/mirrordaily/lists/Topic.ts
@@ -8,13 +8,37 @@ import {
   integer,
   json,
 } from '@keystone-6/core/fields'
-import { State } from '../type'
+import envVar from '../environment-variables'
+import { State, ACL, UserRole, type Session } from '../type'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
 
 enum TopicState {
   Draft = State.Draft,
   Published = State.Published,
+}
+
+function filterTopics(roles: string[]) {
+  return ({ session }: { session?: Session }) => {
+    switch (envVar.accessControlStrategy) {
+      case ACL.GraphQL: {
+        // Expose `published` topics
+        return { state: { equals: TopicState.Published } }
+      }
+      case ACL.Preview: {
+        // Expose all topics
+        return true
+      }
+      case ACL.CMS:
+      default: {
+        // Expose all topics if user logged in
+        return (
+          session?.data?.role !== undefined &&
+          roles.indexOf(session.data.role) > -1
+        )
+      }
+    }
+  }
 }
 
 const listConfigurations = list({
@@ -256,6 +280,13 @@ const listConfigurations = list({
       update: allowRoles(admin, moderator, editor),
       create: allowRoles(admin, moderator, editor),
       delete: allowRoles(admin),
+    },
+    filter: {
+      query: filterTopics([
+        UserRole.Admin,
+        UserRole.Moderator,
+        UserRole.Editor,
+      ]),
     },
   },
   hooks: {

--- a/packages/mirrordaily/lists/Video.ts
+++ b/packages/mirrordaily/lists/Video.ts
@@ -13,8 +13,15 @@ import {
   virtual,
 } from '@keystone-6/core/fields'
 import { getFileURL } from '../utils/common'
+import { State } from '../type'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+enum VideoState {
+  Draft = State.Draft,
+  Published = State.Published,
+  Scheduled = State.Scheduled,
+}
 
 const listConfigurations = list({
   fields: {
@@ -84,11 +91,11 @@ const listConfigurations = list({
     state: select({
       label: '狀態',
       options: [
-        { label: '草稿', value: 'draft' },
-        { label: '已發布', value: 'published' },
-        { label: '預約發佈', value: 'scheduled' },
+        { label: '草稿', value: VideoState.Draft },
+        { label: '已發布', value: VideoState.Published },
+        { label: '預約發佈', value: VideoState.Scheduled },
       ],
-      defaultValue: 'draft',
+      defaultValue: VideoState.Draft,
       isIndexed: true,
     }),
     publishedDate: timestamp({

--- a/packages/mirrordaily/type.ts
+++ b/packages/mirrordaily/type.ts
@@ -1,0 +1,29 @@
+export enum UserRole {
+  Admin = 'admin',
+  Moderator = 'moderator',
+  Editor = 'editor',
+  Contributor = 'contributor',
+}
+
+export enum State {
+  Active = 'active',
+  Inactive = 'inactive',
+  Published = 'published',
+  Draft = 'draft',
+  Scheduled = 'scheduled',
+  Archived = 'archived',
+  Invisible = 'invisible', // hidden from listing, but can be accessed by single item
+}
+
+export enum ACL {
+  GraphQL = 'gql',
+  Preview = 'preview',
+  CMS = 'cms',
+}
+
+export type Session = {
+  data: {
+    id: string
+    role: UserRole
+  }
+}


### PR DESCRIPTION
## Notable Changes
* Topic List 增加 filter 處理
* Section List 增加 filter 處理
* Category List 增加 filter 處理
* 增加 ACL, State, UserRole 三個共用的 enum
* 增加 Session 共用的 type

## Notes
* 請 @nickchen111  確認 Topic, Section 和 Category 加上 filter 後，後端相關服務 (如：cronjobs) ，在呼叫 GQL API 的輸出結果是否異常
  * Topic 在 GQL API 僅輸出 state 為 `published` 的紀錄
  * Section 在 GQL API 僅輸出 state 為 `active` 的紀錄
  * Category 在 GQL API 僅輸出 state 為 `active`  的紀錄