### PR TITLE
refactor(daily): http2 proxy activation logic

### DIFF
--- a/packages/mirrordaily/run.sh
+++ b/packages/mirrordaily/run.sh
@@ -12,30 +12,22 @@ ls /app/public/
 # Run the web service on container startup on the background.
 yarn run db-migrate
 
-#for http/2 proxy
-if [ "$IS_UI_DISABLED" = "true" ]
-then
-  # Keystone server is GQL mode
-  PORT=$KEYSTONE_SERVER_PORT yarn start &
-else
-  # Keystone server is CMS mode
-  PORT=$KEYSTONE_SERVER_PORT yarn start &
+PORT=$KEYSTONE_SERVER_PORT yarn start &
 
+isServerRunning=`lsof -Pi :$KEYSTONE_SERVER_PORT -sTCP:LISTEN -t`
+while [ -z "$isServerRunning" ]
+do
+  echo "Keystone server is not ready."
+  sleep 5
   isServerRunning=`lsof -Pi :$KEYSTONE_SERVER_PORT -sTCP:LISTEN -t`
-  while [ -z "$isServerRunning" ]
-  do
-    echo "Keystone server is not ready."
-    sleep 5
-    isServerRunning=`lsof -Pi :$KEYSTONE_SERVER_PORT -sTCP:LISTEN -t`
-  done
+done
 
-  echo "Keystone server is ready."
+echo "Keystone server is ready."
 
+if [ -n "${$REVERSE_PROXY_PORT}" ]; then
   # Run the http2 reverse proxy server, which proxies http2 request to web server
   PORT=$REVERSE_PROXY_PORT yarn run start-http2-proxy-server &
 fi
-
-#`yarn start &
 
 # Exit immediately when one of the background processes terminate.
 wait -n


### PR DESCRIPTION
## Notes
* 簡化 http2 proxy 的啟動邏輯，改為參考的是 `REVERSE_PROXY_PORT` 是否設定，而非 `IS_UI_DISABLED`。原本，GQL API 不啟動 Adamin UI，且 GQL API 不使用 http2 proxy，所以使用 `IS_UI_DISABLED` 作為參考，但在 daily 的情境下，因為 GQL API 需要啟動 http2 proxy，與原先 `IS_UI_DISABLED` 的參考邏輯衝突，為了簡化邏輯，改用 `REVERSE_PROXY_PORT` 作為參考