### PR TITLE
refactor(daily): add CustomRelationship views and update CustomPostCreation UI

### DIFF
--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -212,6 +212,7 @@ const listConfigurations = list({
       many: true,
       ui: {
         labelField: 'name',
+        views: './lists/views/default-section-relationship/index',
       },
     }),
     manualOrderOfSections: json({
@@ -899,8 +900,8 @@ const listConfigurations = list({
         const result = fetch(envVar.dataServiceApi + '?id=' + item.id, {
           method: 'GET',
         })
-		console.log(envVar.dataServiceApi + '?id=' + item.id)
-		console.log("tagging result :" + result)
+        console.log(envVar.dataServiceApi + '?id=' + item.id)
+        console.log('tagging result :' + result)
       }
       if (operation === 'update') {
         await context.prisma.post.update({

--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -243,6 +243,9 @@ const listConfigurations = list({
       label: '作者',
       ref: 'Contact',
       many: true,
+      ui: {
+        views: './lists/views/default-author-relationship/index',
+      },
     }),
     manualOrderOfWriters: json({
       label: '作者手動排序結果',

--- a/packages/mirrordaily/lists/views/default-author-relationship/RelationshipSelect.tsx
+++ b/packages/mirrordaily/lists/views/default-author-relationship/RelationshipSelect.tsx
@@ -1,0 +1,440 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import 'intersection-observer'
+import {
+  RefObject,
+  useEffect,
+  useMemo,
+  useState,
+  createContext,
+  useContext,
+  useRef,
+} from 'react'
+
+// eslint-disable-next-line
+import { jsx } from '@keystone-ui/core';
+import { MultiSelect, Select, selectComponents } from '@keystone-ui/fields'
+import { validate as validateUUID } from 'uuid'
+import { IdFieldConfig, ListMeta } from '@keystone-6/core/types'
+import {
+  ApolloClient,
+  gql,
+  InMemoryCache,
+  TypedDocumentNode,
+  useApolloClient,
+  useQuery,
+} from '@keystone-6/core/admin-ui/apollo'
+
+function useIntersectionObserver(
+  cb: IntersectionObserverCallback,
+  ref: RefObject<any>
+) {
+  const cbRef = useRef(cb)
+  useEffect(() => {
+    cbRef.current = cb
+  })
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (...args) => cbRef.current(...args),
+      {}
+    )
+    const node = ref.current
+    if (node !== null) {
+      observer.observe(node)
+      return () => observer.unobserve(node)
+    }
+  }, [ref])
+}
+
+const idValidators = {
+  uuid: validateUUID,
+  cuid(value: string) {
+    return value.startsWith('c')
+  },
+  autoincrement(value: string) {
+    return /^\d+$/.test(value)
+  },
+}
+
+function useDebouncedValue<T>(value: T, limitMs: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(() => value)
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setDebouncedValue(() => value)
+    }, limitMs)
+    return () => {
+      clearTimeout(id)
+    }
+  }, [value, limitMs])
+  return debouncedValue
+}
+
+export function useFilter(
+  search: string,
+  list: ListMeta,
+  searchFields: string[]
+) {
+  return useMemo(() => {
+    if (!search.length) return { OR: [] }
+
+    const idFieldKind: IdFieldConfig['kind'] = (
+      list.fields.id.controller as any
+    ).idFieldKind
+    const trimmedSearch = search.trim()
+    const isValidId = idValidators[idFieldKind](trimmedSearch)
+
+    const conditions: Record<string, any>[] = []
+    if (isValidId) {
+      conditions.push({ id: { equals: trimmedSearch } })
+    }
+
+    for (const fieldKey of searchFields) {
+      const field = list.fields[fieldKey]
+      conditions.push({
+        [field.path]: {
+          contains: trimmedSearch,
+          mode: field.search === 'insensitive' ? 'insensitive' : undefined,
+        },
+      })
+    }
+
+    return { OR: conditions }
+  }, [search, list, searchFields])
+}
+
+const idFieldAlias = '____id____'
+
+const labelFieldAlias = '____label____'
+
+const LoadingIndicatorContext = createContext<{
+  count: number
+  ref: (element: HTMLElement | null) => void
+}>({
+  count: 0,
+  // To avoid @typescript-eslint/no-empty-function,
+  // add a console log.
+  ref: () => {
+    console.log('ref function called')
+  },
+})
+
+export const RelationshipSelect = ({
+  autoFocus,
+  controlShouldRenderValue,
+  isDisabled,
+  isLoading,
+  labelField,
+  searchFields,
+  list,
+  placeholder,
+  portalMenu,
+  state,
+  extraSelection = '',
+  orderBy,
+}: {
+  autoFocus?: boolean
+  controlShouldRenderValue: boolean
+  isDisabled: boolean
+  isLoading?: boolean
+  labelField: string
+  searchFields: string[]
+  list: ListMeta
+  placeholder?: string
+  portalMenu?: true | undefined
+  state:
+    | {
+        kind: 'many'
+        value: { label: string; id: string; data?: Record<string, any> }[]
+        onChange(
+          value: { label: string; id: string; data: Record<string, any> }[]
+        ): void
+      }
+    | {
+        kind: 'one'
+        value: { label: string; id: string; data?: Record<string, any> } | null
+        onChange(
+          value: { label: string; id: string; data: Record<string, any> } | null
+        ): void
+      }
+  extraSelection?: string
+  orderBy: Record<string, any>[]
+}) => {
+  const [search, setSearch] = useState('')
+  // note it's important that this is in state rather than a ref
+  // because we want a re-render if the element changes
+  // so that we can register the intersection observer
+  // on the right element
+  const [loadingIndicatorElement, setLoadingIndicatorElement] =
+    useState<null | HTMLElement>(null)
+
+  const QUERY: TypedDocumentNode<
+    {
+      items: { [idFieldAlias]: string; [labelFieldAlias]: string | null }[]
+      count: number
+    },
+    {
+      where: Record<string, any>
+      take: number
+      skip: number
+      orderBy: Record<string, any>[]
+    }
+  > = gql`
+    query RelationshipSelect($where: ${list.gqlNames.whereInputName}!, $take: Int!, $skip: Int!, $orderBy: [${list.gqlNames.listOrderName}!]!) {
+      items: ${list.gqlNames.listQueryName}(where: $where, take: $take, skip: $skip, orderBy: $orderBy) {
+        ${idFieldAlias}: id
+        ${labelFieldAlias}: ${labelField}
+        ${extraSelection}
+      }
+      count: ${list.gqlNames.listQueryCountName}(where: $where)
+    }
+  `
+
+  const debouncedSearch = useDebouncedValue(search, 200)
+  const where = useFilter(debouncedSearch, list, searchFields)
+
+  const link = useApolloClient().link
+  // we're using a local apollo client here because writing a global implementation of the typePolicies
+  // would require making assumptions about how pagination should work which won't always be right
+  const apolloClient = useMemo(
+    () =>
+      new ApolloClient({
+        link,
+        cache: new InMemoryCache({
+          typePolicies: {
+            Query: {
+              fields: {
+                [list.gqlNames.listQueryName]: {
+                  keyArgs: ['where'],
+                  merge: (
+                    existing: readonly unknown[],
+                    incoming: readonly unknown[],
+                    { args }
+                  ) => {
+                    const merged = existing ? existing.slice() : []
+                    const { skip } = args!
+                    for (let i = 0; i < incoming.length; ++i) {
+                      merged[skip + i] = incoming[i]
+                    }
+                    return merged
+                  },
+                },
+              },
+            },
+          },
+        }),
+      }),
+    [link, list.gqlNames.listQueryName]
+  )
+
+  const initialItemsToLoad = Math.min(list.pageSize, 10)
+  const subsequentItemsToLoad = Math.min(list.pageSize, 50)
+  const { data, error, loading, fetchMore } = useQuery(QUERY, {
+    fetchPolicy: 'network-only',
+    variables: { where, take: initialItemsToLoad, skip: 0, orderBy },
+    client: apolloClient,
+  })
+
+  const count = data?.count || 0
+
+  const options =
+    data?.items?.map(
+      ({ [idFieldAlias]: value, [labelFieldAlias]: label, ...data }) => ({
+        value,
+        label: label || value,
+        data,
+      })
+    ) || []
+
+  const loadingIndicatorContextVal = useMemo(
+    () => ({
+      count,
+      ref: setLoadingIndicatorElement,
+    }),
+    [count]
+  )
+
+  // we want to avoid fetching more again and `loading` from Apollo
+  // doesn't seem to become true when fetching more
+  const [lastFetchMore, setLastFetchMore] = useState<{
+    where: Record<string, any>
+    extraSelection: string
+    list: ListMeta
+    skip: number
+  } | null>(null)
+
+  useIntersectionObserver(
+    ([{ isIntersecting }]) => {
+      const skip = data?.items.length
+      if (
+        !loading &&
+        skip &&
+        isIntersecting &&
+        options.length < count &&
+        (lastFetchMore?.extraSelection !== extraSelection ||
+          lastFetchMore?.where !== where ||
+          lastFetchMore?.list !== list ||
+          lastFetchMore?.skip !== skip)
+      ) {
+        const QUERY: TypedDocumentNode<
+          {
+            items: {
+              [idFieldAlias]: string
+              [labelFieldAlias]: string | null
+            }[]
+          },
+          {
+            where: Record<string, any>
+            take: number
+            skip: number
+            orderBy: Record<string, any>[]
+          }
+        > = gql`
+              query RelationshipSelectMore($where: ${list.gqlNames.whereInputName}!, $take: Int!, $skip: Int!, $orderBy: [${list.gqlNames.listOrderName}!]!) {
+                items: ${list.gqlNames.listQueryName}(where: $where, take: $take, skip: $skip, orderBy: $orderBy) {
+                  ${labelFieldAlias}: ${labelField}
+                  ${idFieldAlias}: id
+                  ${extraSelection}
+                }
+              }
+            `
+        setLastFetchMore({ extraSelection, list, skip, where })
+        fetchMore({
+          query: QUERY,
+          variables: {
+            where,
+            take: subsequentItemsToLoad,
+            skip,
+            orderBy,
+          },
+        })
+          .then(() => {
+            setLastFetchMore(null)
+          })
+          .catch(() => {
+            setLastFetchMore(null)
+          })
+      }
+    },
+    { current: loadingIndicatorElement }
+  )
+
+  // TODO: better error UI
+  // TODO: Handle permission errors
+  // (ie; user has permission to read this relationship field, but
+  // not the related list, or some items on the list)
+  if (error) {
+    return <span>Error</span>
+  }
+
+  if (state.kind === 'one') {
+    return (
+      <LoadingIndicatorContext.Provider value={loadingIndicatorContextVal}>
+        <Select
+          // this is necessary because react-select passes a second argument to onInputChange
+          // and useState setters log a warning if a second argument is passed
+          onInputChange={(val) => setSearch(val)}
+          isLoading={loading || isLoading}
+          autoFocus={autoFocus}
+          components={relationshipSelectComponents}
+          portalMenu={portalMenu}
+          value={
+            state.value
+              ? {
+                  value: state.value.id,
+                  label: state.value.label,
+                  // eslint-disable-next-line
+                  // @ts-ignore
+                  data: state.value.data,
+                }
+              : null
+          }
+          options={options}
+          onChange={(value) => {
+            state.onChange(
+              value
+                ? {
+                    id: value.value,
+                    label: value.label,
+                    data: (value as any).data,
+                  }
+                : null
+            )
+          }}
+          placeholder={placeholder}
+          controlShouldRenderValue={controlShouldRenderValue}
+          isClearable={controlShouldRenderValue}
+          isDisabled={isDisabled}
+        />
+      </LoadingIndicatorContext.Provider>
+    )
+  }
+
+  return (
+    <LoadingIndicatorContext.Provider value={loadingIndicatorContextVal}>
+      <MultiSelect // this is necessary because react-select passes a second argument to onInputChange
+        // and useState setters log a warning if a second argument is passed
+        onInputChange={(val) => setSearch(val)}
+        isLoading={loading || isLoading}
+        autoFocus={autoFocus}
+        components={relationshipSelectComponents}
+        portalMenu={portalMenu}
+        value={state.value.map((value) => ({
+          value: value.id,
+          label: value.label,
+          data: value.data,
+        }))}
+        options={options}
+        onChange={(value) => {
+          state.onChange(
+            value.map((x) => ({
+              id: x.value,
+              label: x.label,
+              data: (x as any).data,
+            }))
+          )
+        }}
+        placeholder={placeholder}
+        controlShouldRenderValue={controlShouldRenderValue}
+        isClearable={controlShouldRenderValue}
+        isDisabled={isDisabled}
+        // The parameter `formatOptionLabel` is added specifically for this project
+        // and is not copied from the codebase of keystone-6/core.
+        // This parameter controls the appearance of element in drop-down list component, make it display image if needed.
+        // See [Pull Request](https://github.com/mirror-media/Lilith/pull/698) to get more details.
+        formatOptionLabel={(option) => {
+          return (
+            <div style={{ display: 'flex', flexDirection: 'row' }}>
+              <span>{option.label}</span>
+              {list.label === 'Photos' && (
+                <img
+                  src={option?.data?.imageFile?.url}
+                  width={50}
+                  height={50}
+                  style={{ objectFit: 'cover', marginLeft: 'auto' }}
+                ></img>
+              )}
+            </div>
+          )
+        }}
+      />
+    </LoadingIndicatorContext.Provider>
+  )
+}
+
+const relationshipSelectComponents: Partial<typeof selectComponents> = {
+  MenuList: ({ children, ...props }) => {
+    const { count, ref } = useContext(LoadingIndicatorContext)
+    return (
+      <selectComponents.MenuList {...props}>
+        {children}
+        <div css={{ textAlign: 'center' }} ref={ref}>
+          {props.options.length < count && (
+            <span css={{ padding: 8 }}>Loading...</span>
+          )}
+        </div>
+      </selectComponents.MenuList>
+    )
+  },
+}

--- a/packages/mirrordaily/lists/views/default-author-relationship/cards/InlineCreate.tsx
+++ b/packages/mirrordaily/lists/views/default-author-relationship/cards/InlineCreate.tsx
@@ -1,0 +1,147 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { FormEvent, useState } from 'react'
+// eslint-disable-next-line
+import { jsx, Stack } from '@keystone-ui/core';
+import isDeepEqual from 'fast-deep-equal'
+import { useToasts } from '@keystone-ui/toast'
+import { Button } from '@keystone-ui/button'
+import { ListMeta } from '@keystone-6/core/types'
+import {
+  ItemData,
+  makeDataGetter,
+  DataGetter,
+  Value,
+  useInvalidFields,
+  serializeValueToObjByFieldKey,
+  Fields,
+} from '@keystone-6/core/admin-ui/utils'
+import { gql, useMutation } from '@keystone-6/core/admin-ui/apollo'
+import { GraphQLErrorNotice } from '@keystone-6/core/admin-ui/components'
+import { useFieldsObj } from './useItemState'
+
+export function InlineCreate({
+  list,
+  onCancel,
+  onCreate,
+  fields: fieldPaths,
+  selectedFields,
+}: {
+  list: ListMeta
+  selectedFields: string
+  fields: readonly string[]
+  onCancel: () => void
+  onCreate: (itemGetter: DataGetter<ItemData>) => void
+}) {
+  const toasts = useToasts()
+  const fields = useFieldsObj(list, fieldPaths)
+
+  const [createItem, { loading, error }] = useMutation(
+    gql`mutation($data: ${list.gqlNames.createInputName}!) {
+      item: ${list.gqlNames.createMutationName}(data: $data) {
+        ${selectedFields}
+    }
+  }`
+  )
+
+  const [value, setValue] = useState(() => {
+    const value: Value = {}
+    Object.keys(fields).forEach((fieldPath) => {
+      value[fieldPath] = {
+        kind: 'value',
+        value: fields[fieldPath].controller.defaultValue,
+      }
+    })
+    return value
+  })
+
+  const invalidFields = useInvalidFields(fields, value)
+
+  const [forceValidation, setForceValidation] = useState(false)
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const newForceValidation = invalidFields.size !== 0
+    setForceValidation(newForceValidation)
+
+    if (newForceValidation) return
+    const data: Record<string, any> = {}
+    const allSerializedValues = serializeValueToObjByFieldKey(fields, value)
+    Object.keys(allSerializedValues).forEach((fieldPath) => {
+      const { controller } = fields[fieldPath]
+      const serialized = allSerializedValues[fieldPath]
+      if (
+        !isDeepEqual(serialized, controller.serialize(controller.defaultValue))
+      ) {
+        Object.assign(data, serialized)
+      }
+    })
+
+    createItem({
+      variables: {
+        data,
+      },
+    })
+      .then(({ data, errors }) => {
+        // we're checking for path.length === 1 because errors with a path larger than 1 will be field level errors
+        // which are handled seperately and do not indicate a failure to update the item
+        const error = errors?.find((x) => x.path?.length === 1)
+        if (error) {
+          toasts.addToast({
+            title: 'Failed to create item',
+            tone: 'negative',
+            message: error.message,
+          })
+        } else {
+          toasts.addToast({
+            title: data.item[list.labelField] || data.item.id,
+            tone: 'positive',
+            message: 'Saved successfully',
+          })
+          onCreate(makeDataGetter(data, errors).get('item'))
+        }
+      })
+      .catch((err) => {
+        toasts.addToast({
+          title: 'Failed to update item',
+          tone: 'negative',
+          message: err.message,
+        })
+      })
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <Stack gap="xlarge">
+        {error && (
+          <GraphQLErrorNotice
+            networkError={error?.networkError}
+            errors={error?.graphQLErrors}
+          />
+        )}
+        <Fields
+          fields={fields}
+          forceValidation={forceValidation}
+          invalidFields={invalidFields}
+          onChange={setValue}
+          value={value}
+        />
+        <Stack gap="small" across>
+          <Button
+            isLoading={loading}
+            size="small"
+            tone="positive"
+            weight="bold"
+            type="submit"
+          >
+            Create {list.singular}
+          </Button>
+          <Button size="small" weight="none" onClick={onCancel}>
+            Cancel
+          </Button>
+        </Stack>
+      </Stack>
+    </form>
+  )
+}

--- a/packages/mirrordaily/lists/views/default-author-relationship/cards/InlineEdit.tsx
+++ b/packages/mirrordaily/lists/views/default-author-relationship/cards/InlineEdit.tsx
@@ -1,0 +1,160 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { Button } from '@keystone-ui/button'
+// eslint-disable-next-line
+import { jsx, Stack } from '@keystone-ui/core';
+import { useToasts } from '@keystone-ui/toast'
+import { useCallback, useState } from 'react'
+import { ListMeta } from '@keystone-6/core/types'
+import {
+  deserializeValue,
+  ItemData,
+  useInvalidFields,
+  Fields,
+  useChangedFieldsAndDataForUpdate,
+  makeDataGetter,
+  DataGetter,
+} from '@keystone-6/core/admin-ui/utils'
+import { gql, useMutation } from '@keystone-6/core/admin-ui/apollo'
+import { GraphQLErrorNotice } from '@keystone-6/core/admin-ui/components'
+import { useFieldsObj } from './useItemState'
+
+export function InlineEdit({
+  fields,
+  list,
+  selectedFields,
+  itemGetter,
+  onCancel,
+  onSave,
+}: {
+  fields: readonly string[]
+  list: ListMeta
+  selectedFields: string
+  itemGetter: DataGetter<ItemData>
+  onCancel: () => void
+  onSave: (newItemGetter: DataGetter<ItemData>) => void
+}) {
+  const fieldsObj = useFieldsObj(list, fields)
+
+  const [update, { loading, error }] = useMutation(
+    gql`mutation ($data: ${list.gqlNames.updateInputName}!, $id: ID!) {
+          item: ${list.gqlNames.updateMutationName}(where: { id: $id }, data: $data) {
+            ${selectedFields}
+          }
+        }`,
+    { errorPolicy: 'all' }
+  )
+
+  const [state, setValue] = useState(() => {
+    const value = deserializeValue(fieldsObj, itemGetter)
+    return { value, item: itemGetter.data }
+  })
+
+  if (
+    state.item !== itemGetter.data &&
+    itemGetter.errors?.every((x) => x.path?.length !== 1)
+  ) {
+    const value = deserializeValue(fieldsObj, itemGetter)
+    setValue({ value, item: itemGetter.data })
+  }
+
+  const { changedFields, dataForUpdate } = useChangedFieldsAndDataForUpdate(
+    fieldsObj,
+    itemGetter,
+    state.value
+  )
+
+  const invalidFields = useInvalidFields(fieldsObj, state.value)
+
+  const [forceValidation, setForceValidation] = useState(false)
+  const toasts = useToasts()
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        if (changedFields.size === 0) {
+          onCancel()
+          return
+        }
+        const newForceValidation = invalidFields.size !== 0
+        setForceValidation(newForceValidation)
+        if (newForceValidation) return
+
+        update({
+          variables: {
+            data: dataForUpdate,
+            id: itemGetter.get('id').data,
+          },
+        })
+          .then(({ data, errors }) => {
+            // we're checking for path.length === 1 because errors with a path larger than 1 will be field level errors
+            // which are handled seperately and do not indicate a failure to update the item
+            const error = errors?.find((x) => x.path?.length === 1)
+            if (error) {
+              toasts.addToast({
+                title: 'Failed to update item',
+                tone: 'negative',
+                message: error.message,
+              })
+            } else {
+              toasts.addToast({
+                title: data.item[list.labelField] || data.item.id,
+                tone: 'positive',
+                message: 'Saved successfully',
+              })
+              onSave(makeDataGetter(data, errors).get('item'))
+            }
+          })
+          .catch((err) => {
+            toasts.addToast({
+              title: 'Failed to update item',
+              tone: 'negative',
+              message: err.message,
+            })
+          })
+      }}
+    >
+      <Stack gap="xlarge">
+        {error && (
+          <GraphQLErrorNotice
+            networkError={error?.networkError}
+            // we're checking for path.length === 1 because errors with a path larger than 1 will be field level errors
+            // which are handled seperately and do not indicate a failure to update the item
+            errors={error?.graphQLErrors.filter((x) => x.path?.length === 1)}
+          />
+        )}
+        <Fields
+          fields={fieldsObj}
+          forceValidation={forceValidation}
+          invalidFields={invalidFields}
+          onChange={useCallback(
+            (value) => {
+              setValue((state) => ({
+                item: state.item,
+                value: value(state.value),
+              }))
+            },
+            [setValue]
+          )}
+          value={state.value}
+        />
+        <Stack across gap="small">
+          <Button
+            isLoading={loading}
+            weight="bold"
+            size="small"
+            tone="active"
+            type="submit"
+          >
+            Save
+          </Button>
+          <Button size="small" weight="none" onClick={onCancel}>
+            Cancel
+          </Button>
+        </Stack>
+      </Stack>
+    </form>
+  )
+}

--- a/packages/mirrordaily/lists/views/default-author-relationship/cards/index.tsx
+++ b/packages/mirrordaily/lists/views/default-author-relationship/cards/index.tsx
@@ -1,0 +1,465 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { ReactNode } from 'react'
+// eslint-disable-next-line
+import { jsx } from '@keystone-ui/core';
+import {
+  Box,
+  BoxProps,
+  Stack,
+  Text,
+  useTheme,
+  forwardRefWithAs,
+  VisuallyHidden,
+} from '@keystone-ui/core'
+
+import { FieldContainer, FieldLabel } from '@keystone-ui/fields'
+import { Button } from '@keystone-ui/button'
+import { Tooltip } from '@keystone-ui/tooltip'
+import { LoadingDots } from '@keystone-ui/loading'
+import { useEffect, useRef, useState } from 'react'
+import { FieldProps, ListMeta } from '@keystone-6/core/types'
+import {
+  getRootGraphQLFieldsFromFieldController,
+  makeDataGetter,
+} from '@keystone-6/core/admin-ui/utils'
+import { Link } from '@keystone-6/core/admin-ui/router'
+import { gql, useApolloClient } from '@keystone-6/core/admin-ui/apollo'
+import { controller } from '../index'
+import { RelationshipSelect } from '../RelationshipSelect'
+import { useItemState } from './useItemState'
+import { InlineEdit } from './InlineEdit'
+import { InlineCreate } from './InlineCreate'
+
+type CardContainerProps = {
+  children: ReactNode
+  mode: 'view' | 'create' | 'edit'
+} & BoxProps
+const CardContainer = forwardRefWithAs(
+  ({ mode = 'view', ...props }: CardContainerProps, ref) => {
+    const { tones } = useTheme()
+
+    const tone =
+      tones[
+        mode === 'edit' ? 'active' : mode === 'create' ? 'positive' : 'passive'
+      ]
+
+    return (
+      <Box
+        ref={ref}
+        paddingLeft="xlarge"
+        css={{
+          position: 'relative',
+
+          ':before': {
+            content: '" "',
+            backgroundColor: tone.border,
+            borderRadius: 4,
+            width: 4,
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            zIndex: 1,
+          },
+        }}
+        {...props}
+      />
+    )
+  }
+)
+
+export function Cards({
+  localList,
+  field,
+  foreignList,
+  id,
+  value,
+  onChange,
+  forceValidation,
+}: {
+  foreignList: ListMeta
+  localList: ListMeta
+  id: string | null
+  value: { kind: 'cards-view' }
+} & FieldProps<typeof controller>) {
+  const { displayOptions } = value
+  let selectedFields = [
+    ...new Set([
+      ...displayOptions.cardFields,
+      ...(displayOptions.inlineEdit?.fields || []),
+    ]),
+  ]
+    .map((fieldPath) => {
+      return foreignList.fields[fieldPath].controller.graphqlSelection
+    })
+    .join('\n')
+  if (!displayOptions.cardFields.includes('id')) {
+    selectedFields += '\nid'
+  }
+  if (
+    !displayOptions.cardFields.includes(foreignList.labelField) &&
+    foreignList.labelField !== 'id'
+  ) {
+    selectedFields += `\n${foreignList.labelField}`
+  }
+
+  const {
+    items,
+    setItems,
+    state: itemsState,
+  } = useItemState({
+    selectedFields,
+    localList,
+    id,
+    field,
+  })
+
+  const client = useApolloClient()
+
+  const [isLoadingLazyItems, setIsLoadingLazyItems] = useState(false)
+  const [showConnectItems, setShowConnectItems] = useState(false)
+  const [hideConnectItemsLabel, setHideConnectItemsLabel] = useState<
+    'Cancel' | 'Done'
+  >('Cancel')
+  const editRef = useRef<HTMLDivElement | null>(null)
+
+  const isMountedRef = useRef(false)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  })
+
+  useEffect(() => {
+    if (value.itemsBeingEdited) {
+      editRef?.current?.focus()
+    }
+  }, [value])
+
+  if (itemsState.kind === 'loading') {
+    return (
+      <div>
+        <LoadingDots label={`Loading items for ${field.label} field`} />
+      </div>
+    )
+  }
+  if (itemsState.kind === 'error') {
+    return <span css={{ color: 'red' }}>{itemsState.message}</span>
+  }
+
+  const currentIdsArrayWithFetchedItems = [...value.currentIds]
+    .map((id) => ({ itemGetter: items[id], id }))
+    .filter((x) => x.itemGetter)
+
+  return (
+    <Stack gap="medium">
+      {currentIdsArrayWithFetchedItems.length !== 0 && (
+        <Stack
+          as="ul"
+          gap="medium"
+          css={{
+            padding: 0,
+            margin: 0,
+            li: {
+              listStyle: 'none',
+            },
+          }}
+        >
+          {currentIdsArrayWithFetchedItems.map(({ id, itemGetter }, index) => {
+            const isEditMode =
+              !!(onChange !== undefined) && value.itemsBeingEdited.has(id)
+            return (
+              <CardContainer
+                role="status"
+                mode={isEditMode ? 'edit' : 'view'}
+                key={id}
+              >
+                <VisuallyHidden as="h2">{`${field.label} ${index + 1} ${
+                  isEditMode ? 'edit' : 'view'
+                } mode`}</VisuallyHidden>
+                {isEditMode ? (
+                  <InlineEdit
+                    list={foreignList}
+                    fields={displayOptions.inlineEdit!.fields}
+                    onSave={(newItemGetter) => {
+                      setItems({
+                        ...items,
+                        [id]: newItemGetter,
+                      })
+                      const itemsBeingEdited = new Set(value.itemsBeingEdited)
+                      itemsBeingEdited.delete(id)
+                      onChange!({
+                        ...value,
+                        itemsBeingEdited,
+                      })
+                    }}
+                    selectedFields={selectedFields}
+                    itemGetter={itemGetter}
+                    onCancel={() => {
+                      const itemsBeingEdited = new Set(value.itemsBeingEdited)
+                      itemsBeingEdited.delete(id)
+                      onChange!({
+                        ...value,
+                        itemsBeingEdited,
+                      })
+                    }}
+                  />
+                ) : (
+                  <Stack gap="xlarge">
+                    {displayOptions.cardFields.map((fieldPath) => {
+                      const field = foreignList.fields[fieldPath]
+                      const itemForField: Record<string, any> = {}
+                      for (const graphqlField of getRootGraphQLFieldsFromFieldController(
+                        field.controller
+                      )) {
+                        const fieldGetter = itemGetter.get(graphqlField)
+                        if (fieldGetter.errors) {
+                          const errorMessage = fieldGetter.errors[0].message
+                          return (
+                            <FieldContainer>
+                              <FieldLabel>{field.label}</FieldLabel>
+                              {errorMessage}
+                            </FieldContainer>
+                          )
+                        }
+                        itemForField[graphqlField] = fieldGetter.data
+                      }
+                      return (
+                        <field.views.CardValue
+                          key={fieldPath}
+                          field={field.controller}
+                          item={itemForField}
+                        />
+                      )
+                    })}
+                    <Stack across gap="small">
+                      {displayOptions.inlineEdit && onChange !== undefined && (
+                        <Button
+                          size="small"
+                          disabled={onChange === undefined}
+                          onClick={() => {
+                            onChange({
+                              ...value,
+                              itemsBeingEdited: new Set([
+                                ...value.itemsBeingEdited,
+                                id,
+                              ]),
+                            })
+                          }}
+                          tone="active"
+                        >
+                          Edit
+                        </Button>
+                      )}
+                      {displayOptions.removeMode === 'disconnect' &&
+                        onChange !== undefined && (
+                          <Tooltip content="This item will not be deleted. It will only be removed from this field.">
+                            {(props) => (
+                              <Button
+                                size="small"
+                                disabled={onChange === undefined}
+                                onClick={() => {
+                                  const currentIds = new Set(value.currentIds)
+                                  currentIds.delete(id)
+                                  onChange({
+                                    ...value,
+                                    currentIds,
+                                  })
+                                }}
+                                {...props}
+                                tone="negative"
+                              >
+                                Remove
+                              </Button>
+                            )}
+                          </Tooltip>
+                        )}
+                      {displayOptions.linkToItem && (
+                        <Button
+                          size="small"
+                          weight="link"
+                          tone="active"
+                          css={{ textDecoration: 'none' }}
+                          as={Link}
+                          href={`/${foreignList.path}/${id}`}
+                        >
+                          View {foreignList.singular} details
+                        </Button>
+                      )}
+                    </Stack>
+                  </Stack>
+                )}
+              </CardContainer>
+            )
+          })}
+        </Stack>
+      )}
+      {onChange === undefined ? null : displayOptions.inlineConnect &&
+        showConnectItems ? (
+        <CardContainer mode="edit">
+          <Stack
+            gap="small"
+            across
+            css={{
+              width: '100%',
+              justifyContent: 'space-between',
+              'div:first-of-type': {
+                flex: '2',
+              },
+            }}
+          >
+            <RelationshipSelect
+              autoFocus
+              controlShouldRenderValue={isLoadingLazyItems}
+              isDisabled={onChange === undefined}
+              list={foreignList}
+              labelField={field.refLabelField}
+              searchFields={field.refSearchFields}
+              isLoading={isLoadingLazyItems}
+              placeholder={`Select a ${foreignList.singular}`}
+              portalMenu
+              // The parameter `extraSelection` is added specifically for this project
+              // and is not copied from the codebase of keystone-6/core.
+              // This parameter controls the extra GraphQL query we need to fetch.
+              // See [Pull Request](https://github.com/mirror-media/Lilith/pull/698) to get more details.
+              extraSelection={
+                foreignList.label === 'Photos' ? 'imageFile {url}' : ''
+              }
+              state={{
+                kind: 'many',
+                async onChange(options) {
+                  // TODO: maybe use the extraSelection prop on RelationshipSelect here
+                  const itemsToFetchAndConnect: string[] = []
+                  options.forEach((item) => {
+                    if (!value.currentIds.has(item.id)) {
+                      itemsToFetchAndConnect.push(item.id)
+                    }
+                  })
+                  if (itemsToFetchAndConnect.length) {
+                    try {
+                      const { data, errors } = await client.query({
+                        query: gql`query ($ids: [ID!]!) {
+                      items: ${foreignList.gqlNames.listQueryName}(where: { id: { in: $ids }}) {
+                        ${selectedFields}
+                      }
+                    }`,
+                        variables: { ids: itemsToFetchAndConnect },
+                      })
+                      if (isMountedRef.current) {
+                        const dataGetters = makeDataGetter(data, errors)
+                        const itemsDataGetter = dataGetters.get('items')
+                        const newItems = { ...items }
+                        const newCurrentIds = field.many
+                          ? new Set(value.currentIds)
+                          : new Set<string>()
+                        if (Array.isArray(itemsDataGetter.data)) {
+                          itemsDataGetter.data.forEach((item, i) => {
+                            if (item?.id != null) {
+                              newCurrentIds.add(item.id)
+                              newItems[item.id] = itemsDataGetter.get(i)
+                            }
+                          })
+                        }
+                        if (newCurrentIds.size) {
+                          setItems(newItems)
+                          onChange({
+                            ...value,
+                            currentIds: newCurrentIds,
+                          })
+                          setHideConnectItemsLabel('Done')
+                        }
+                      }
+                    } finally {
+                      if (isMountedRef.current) {
+                        setIsLoadingLazyItems(false)
+                      }
+                    }
+                  }
+                },
+                value: (() => {
+                  const options: { label: string; id: string }[] = []
+                  Object.keys(items).forEach((id) => {
+                    if (value.currentIds.has(id)) {
+                      options.push({ id, label: id })
+                    }
+                  })
+                  return options
+                })(),
+              }}
+              orderBy={[{ id: 'desc' }]}
+            />
+            <Button onClick={() => setShowConnectItems(false)}>
+              {hideConnectItemsLabel}
+            </Button>
+          </Stack>
+        </CardContainer>
+      ) : value.itemBeingCreated ? (
+        <CardContainer mode="create">
+          <InlineCreate
+            selectedFields={selectedFields}
+            fields={displayOptions.inlineCreate!.fields}
+            list={foreignList}
+            onCancel={() => {
+              onChange({ ...value, itemBeingCreated: false })
+            }}
+            onCreate={(itemGetter) => {
+              const id = itemGetter.data.id
+              setItems({ ...items, [id]: itemGetter })
+              onChange({
+                ...value,
+                itemBeingCreated: false,
+                currentIds: field.many
+                  ? new Set([...value.currentIds, id])
+                  : new Set([id]),
+              })
+            }}
+          />
+        </CardContainer>
+      ) : displayOptions.inlineCreate || displayOptions.inlineConnect ? (
+        <CardContainer mode="create">
+          <Stack gap="small" across>
+            {displayOptions.inlineCreate && (
+              <Button
+                size="small"
+                disabled={onChange === undefined}
+                tone="positive"
+                onClick={() => {
+                  onChange({
+                    ...value,
+                    itemBeingCreated: true,
+                  })
+                }}
+              >
+                Create {foreignList.singular}
+              </Button>
+            )}
+            {displayOptions.inlineConnect && (
+              <Button
+                size="small"
+                weight="none"
+                tone="passive"
+                onClick={() => {
+                  setShowConnectItems(true)
+                  setHideConnectItemsLabel('Cancel')
+                }}
+              >
+                Link existing {foreignList.singular}
+              </Button>
+            )}
+          </Stack>
+        </CardContainer>
+      ) : null}
+      {/* TODO: this may not be visible to the user when they invoke the save action. Maybe scroll to it? */}
+      {forceValidation && (
+        <Text color="red600" size="small">
+          You must finish creating and editing any related{' '}
+          {foreignList.label.toLowerCase()} before saving the{' '}
+          {localList.singular.toLowerCase()}
+        </Text>
+      )}
+    </Stack>
+  )
+}

--- a/packages/mirrordaily/lists/views/default-author-relationship/cards/useItemState.tsx
+++ b/packages/mirrordaily/lists/views/default-author-relationship/cards/useItemState.tsx
@@ -1,0 +1,164 @@
+import { useCallback, useMemo, useState } from 'react'
+import { FieldMeta, ListMeta } from '@keystone-6/core/types'
+import { DataGetter, makeDataGetter } from '@keystone-6/core/admin-ui/utils'
+import { gql, useQuery } from '@keystone-6/core/admin-ui/apollo'
+import { controller } from '..'
+
+type ItemsState =
+  | {
+      kind: 'loading'
+    }
+  | { kind: 'error'; message: string }
+  | { kind: 'loaded' }
+
+type Items = Record<string, DataGetter<{ id: string; [key: string]: any }>>
+
+export function useItemState({
+  selectedFields,
+  localList,
+  id,
+  field,
+}: {
+  selectedFields: string
+  localList: ListMeta
+  field: ReturnType<typeof controller>
+  id: string | null
+}) {
+  const { data, error, loading } = useQuery(
+    gql`query($id: ID!) {
+  item: ${localList.gqlNames.itemQueryName}(where: {id: $id}) {
+    id
+    relationship: ${field.path} {
+      ${selectedFields}
+    }
+  }
+}`,
+    { variables: { id }, errorPolicy: 'all', skip: id === null }
+  )
+  const { itemsArrFromData, relationshipGetter } = useMemo(() => {
+    const dataGetter = makeDataGetter(data, error?.graphQLErrors)
+    const relationshipGetter = dataGetter.get('item').get('relationship')
+    const isMany = Array.isArray(relationshipGetter.data)
+    const itemsArrFromData: DataGetter<{
+      id: string
+      [key: string]: any
+    }>[] = (
+      isMany
+        ? relationshipGetter.data.map((_: any, i: number) =>
+            relationshipGetter.get(i)
+          )
+        : [relationshipGetter]
+    ).filter((x: DataGetter<any>) => x.data?.id != null)
+    return { relationshipGetter, itemsArrFromData }
+  }, [data, error])
+  // eslint-disable-next-line
+  let [{ items, itemsArrFromData: itemsArrFromDataState }, setItemsState] = useState<{ 
+      itemsArrFromData: DataGetter<any>[]
+      items: Record<
+        string,
+        {
+          current: DataGetter<{ id: string; [key: string]: any }>
+          fromInitialQuery:
+            | DataGetter<{ id: string; [key: string]: any }>
+            | undefined
+        }
+      >
+    }>({ itemsArrFromData: [], items: {} })
+
+  if (itemsArrFromDataState !== itemsArrFromData) {
+    const newItems: Record<
+      string,
+      {
+        current: DataGetter<{ id: string; [key: string]: any }>
+        fromInitialQuery:
+          | DataGetter<{ id: string; [key: string]: any }>
+          | undefined
+      }
+    > = {}
+
+    itemsArrFromData.forEach((item) => {
+      const initialItemInState = items[item.data.id]?.fromInitialQuery
+      if (
+        ((items[item.data.id] && initialItemInState) || !items[item.data.id]) &&
+        (!initialItemInState ||
+          item.data !== initialItemInState.data ||
+          item.errors?.length !== initialItemInState.errors?.length ||
+          (item.errors || []).some(
+            (err, i) => err !== initialItemInState.errors?.[i]
+          ))
+      ) {
+        newItems[item.data.id] = { current: item, fromInitialQuery: item }
+      } else {
+        newItems[item.data.id] = items[item.data.id]
+      }
+    })
+    items = newItems
+    setItemsState({
+      items: newItems,
+      itemsArrFromData,
+    })
+  }
+
+  return {
+    items: useMemo(() => {
+      const itemsToReturn: Items = {}
+      Object.keys(items).forEach((id) => {
+        itemsToReturn[id] = items[id].current
+      })
+      return itemsToReturn
+    }, [items]),
+    setItems: useCallback(
+      (items: Items) => {
+        setItemsState((state) => {
+          const itemsForState: (typeof state)['items'] = {}
+          Object.keys(items).forEach((id) => {
+            if (items[id] === state.items[id]?.current) {
+              itemsForState[id] = state.items[id]
+            } else {
+              itemsForState[id] = {
+                current: items[id],
+                fromInitialQuery: state.items[id]?.fromInitialQuery,
+              }
+            }
+          })
+          return {
+            itemsArrFromData: state.itemsArrFromData,
+            items: itemsForState,
+          }
+        })
+      },
+      [setItemsState]
+    ),
+    state: ((): ItemsState => {
+      if (id === null) {
+        return { kind: 'loaded' }
+      }
+      if (loading) {
+        return { kind: 'loading' }
+      }
+      if (error?.networkError) {
+        return { kind: 'error', message: error.networkError.message }
+      }
+      if (field.many && !relationshipGetter.data) {
+        return {
+          kind: 'error',
+          message: relationshipGetter.errors?.[0].message || '',
+        }
+      }
+      return { kind: 'loaded' }
+    })(),
+  }
+}
+
+export function useFieldsObj(
+  list: ListMeta,
+  fields: readonly string[] | undefined
+) {
+  return useMemo(() => {
+    const editFields: Record<string, FieldMeta> = {}
+    fields?.forEach((fieldPath) => {
+      editFields[fieldPath] = list.fields[fieldPath]
+    })
+    return editFields
+  }, [fields, list.fields])
+}

--- a/packages/mirrordaily/lists/views/default-author-relationship/index.tsx
+++ b/packages/mirrordaily/lists/views/default-author-relationship/index.tsx
@@ -1,0 +1,771 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { Fragment, useRef, useState } from 'react'
+
+import { Button } from '@keystone-ui/button'
+// eslint-disable-next-line
+import { jsx, Stack, useTheme } from '@keystone-ui/core';
+import {
+  FieldContainer,
+  FieldDescription,
+  FieldLabel,
+  FieldLegend,
+} from '@keystone-ui/fields'
+import { DrawerController } from '@keystone-ui/modals'
+import {
+  CardValueComponent,
+  CellComponent,
+  FieldController,
+  FieldControllerConfig,
+  FieldProps,
+  ListMeta,
+} from '@keystone-6/core/types'
+import { Link } from '@keystone-6/core/admin-ui/router'
+import { useKeystone, useList } from '@keystone-6/core/admin-ui/context'
+import { gql, useQuery } from '@keystone-6/core/admin-ui/apollo'
+import {
+  CellContainer,
+  CreateItemDrawer,
+} from '@keystone-6/core/admin-ui/components'
+
+import { Cards } from './cards'
+import { RelationshipSelect } from './RelationshipSelect'
+
+function LinkToRelatedItems({
+  itemId,
+  value,
+  list,
+  refFieldKey,
+}: {
+  itemId: string | null
+  value: FieldProps<typeof controller>['value'] & { kind: 'many' | 'one' }
+  list: ListMeta
+  refFieldKey?: string
+}) {
+  function constructQuery({
+    refFieldKey,
+    itemId,
+    value,
+  }: {
+    refFieldKey?: string
+    itemId: string | null
+    value: FieldProps<typeof controller>['value'] & { kind: 'many' | 'one' }
+  }) {
+    if (!!refFieldKey && itemId) {
+      return `!${refFieldKey}_matches="${itemId}"`
+    }
+    return `!id_in="${(value?.value as { id: string; label: string }[])
+      .slice(0, 100)
+      .map(({ id }: { id: string }) => id)
+      .join(',')}"`
+  }
+  const commonProps = {
+    size: 'small',
+    tone: 'active',
+    weight: 'link',
+  } as const
+
+  if (value.kind === 'many') {
+    const query = constructQuery({ refFieldKey, value, itemId })
+    return (
+      <Button {...commonProps} as={Link} href={`/${list.path}?${query}`}>
+        View related {list.plural}
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      {...commonProps}
+      as={Link}
+      href={`/${list.path}/${value.value?.id}`}
+    >
+      View {list.singular} details
+    </Button>
+  )
+}
+
+export const Field = ({
+  field,
+  autoFocus,
+  value,
+  onChange,
+  forceValidation,
+}: FieldProps<typeof controller>) => {
+  const keystone = useKeystone()
+  const foreignList = useList(field.refListKey)
+  const localList = useList(field.listKey)
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+
+  /**
+   * use Ref to prevent infinite re-render
+   * autofill only trigger during item creation
+   */
+  const isAssignedRef = useRef(value.id !== null)
+  const { data } = useQuery(
+    gql`
+      query GetAuthor($userId: ID!) {
+        user(where: { id: $userId }) {
+          author {
+            id
+            name
+          }
+        }
+      }
+    `,
+    {
+      variables: {
+        // @ts-ignore: authenticatedItem.id exists
+        userId: keystone.authenticatedItem.id,
+      },
+    }
+  )
+
+  if (isAssignedRef.current === false && data) {
+    const update = Object.assign({}, value)
+
+    if (data.user?.author && typeof onChange === 'function') {
+      const item = data.user.author
+
+      Object.assign(update, {
+        ...update,
+        value: [
+          {
+            id: item.id,
+            label: item.name,
+          },
+        ],
+      })
+
+      onChange(update)
+      isAssignedRef.current = true
+    }
+  }
+
+  if (value.kind === 'cards-view') {
+    return (
+      <FieldContainer as="fieldset">
+        <FieldLegend>{field.label}</FieldLegend>
+        <FieldDescription id={`${field.path}-description`}>
+          {field.description}
+        </FieldDescription>
+        <Cards
+          forceValidation={forceValidation}
+          field={field}
+          id={value.id}
+          value={value}
+          onChange={onChange}
+          foreignList={foreignList}
+          localList={localList}
+        />
+      </FieldContainer>
+    )
+  }
+
+  if (value.kind === 'count') {
+    return (
+      <Stack as="fieldset" gap="medium">
+        <FieldLegend>{field.label}</FieldLegend>
+        <FieldDescription id={`${field.path}-description`}>
+          {field.description}
+        </FieldDescription>
+        <div>
+          {value.count === 1
+            ? `There is 1 ${foreignList.singular} `
+            : `There are ${value.count} ${foreignList.plural} `}
+          linked to this {localList.singular}
+        </div>
+      </Stack>
+    )
+  }
+
+  const authenticatedItem = keystone.authenticatedItem
+
+  return (
+    <FieldContainer as="fieldset">
+      <FieldLabel as="legend">{field.label}</FieldLabel>
+      <FieldDescription id={`${field.path}-description`}>
+        {field.description}
+      </FieldDescription>
+      <Fragment>
+        <Stack gap="medium">
+          <RelationshipSelect
+            controlShouldRenderValue
+            aria-describedby={
+              field.description === null
+                ? undefined
+                : `${field.path}-description`
+            }
+            autoFocus={autoFocus}
+            isDisabled={onChange === undefined}
+            labelField={field.refLabelField}
+            searchFields={field.refSearchFields}
+            list={foreignList}
+            portalMenu
+            state={
+              value.kind === 'many'
+                ? {
+                    kind: 'many',
+                    value: value.value,
+                    onChange(newItems) {
+                      onChange?.({
+                        ...value,
+                        value: newItems,
+                      })
+                    },
+                  }
+                : {
+                    kind: 'one',
+                    value: value.value,
+                    onChange(newVal) {
+                      if (value.kind === 'one') {
+                        onChange?.({
+                          ...value,
+                          value: newVal,
+                        })
+                      }
+                    },
+                  }
+            }
+            orderBy={[{ id: 'desc' }]}
+          />
+          <Stack across gap="small">
+            {onChange !== undefined && !field.hideCreate && (
+              <Button
+                size="small"
+                disabled={isDrawerOpen}
+                onClick={() => {
+                  setIsDrawerOpen(true)
+                }}
+              >
+                Create related {foreignList.singular}
+              </Button>
+            )}
+            {onChange !== undefined &&
+              authenticatedItem.state === 'authenticated' &&
+              authenticatedItem.listKey === field.refListKey &&
+              (value.kind === 'many'
+                ? value.value.find((x) => x.id === authenticatedItem.id) ===
+                  undefined
+                : value.value?.id !== authenticatedItem.id) && (
+                <Button
+                  size="small"
+                  onClick={() => {
+                    const val = {
+                      label: authenticatedItem.label,
+                      id: authenticatedItem.id,
+                    }
+                    if (value.kind === 'many') {
+                      onChange({
+                        ...value,
+                        value: [...value.value, val],
+                      })
+                    } else {
+                      onChange({
+                        ...value,
+                        value: val,
+                      })
+                    }
+                  }}
+                >
+                  {value.kind === 'many' ? 'Add ' : 'Set as '}
+                  {authenticatedItem.label}
+                </Button>
+              )}
+            {!!(value.kind === 'many'
+              ? value.value.length
+              : value.kind === 'one' && value.value) && (
+              <LinkToRelatedItems
+                itemId={value.id}
+                refFieldKey={field.refFieldKey}
+                list={foreignList}
+                value={value}
+              />
+            )}
+          </Stack>
+        </Stack>
+        {onChange !== undefined && (
+          <DrawerController isOpen={isDrawerOpen}>
+            <CreateItemDrawer
+              listKey={foreignList.key}
+              onClose={() => {
+                setIsDrawerOpen(false)
+              }}
+              onCreate={(val) => {
+                setIsDrawerOpen(false)
+                if (value.kind === 'many') {
+                  onChange({
+                    ...value,
+                    value: [...value.value, val],
+                  })
+                } else if (value.kind === 'one') {
+                  onChange({
+                    ...value,
+                    value: val,
+                  })
+                }
+              }}
+            />
+          </DrawerController>
+        )}
+      </Fragment>
+    </FieldContainer>
+  )
+}
+
+export const Cell: CellComponent<typeof controller> = ({ field, item }) => {
+  const list = useList(field.refListKey)
+  const { colors } = useTheme()
+
+  if (field.display === 'count') {
+    const count = item[`${field.path}Count`] ?? 0
+    return (
+      <CellContainer>
+        {count} {count === 1 ? list.singular : list.plural}
+      </CellContainer>
+    )
+  }
+
+  const data = item[field.path]
+  const items = (Array.isArray(data) ? data : [data]).filter((item) => item)
+  const displayItems = items.length < 5 ? items : items.slice(0, 3)
+  const overflow = items.length < 5 ? 0 : items.length - 3
+  const styles = {
+    color: colors.foreground,
+    textDecoration: 'none',
+
+    ':hover': {
+      textDecoration: 'underline',
+    },
+  } as const
+
+  return (
+    <CellContainer>
+      {displayItems.map((item, index) => (
+        <Fragment key={item.id}>
+          {index ? ', ' : ''}
+          <Link
+            href={`/${list.path}/[id]`}
+            as={`/${list.path}/${item.id}`}
+            css={styles}
+          >
+            {item.label || item.id}
+          </Link>
+        </Fragment>
+      ))}
+      {overflow ? `, and ${overflow} more` : null}
+    </CellContainer>
+  )
+}
+
+export const CardValue: CardValueComponent<typeof controller> = ({
+  field,
+  item,
+}) => {
+  const list = useList(field.refListKey)
+  const data = item[field.path]
+  return (
+    <FieldContainer>
+      <FieldLabel>{field.label}</FieldLabel>
+      {(Array.isArray(data) ? data : [data])
+        .filter((item) => item)
+        .map((item, index) => (
+          <Fragment key={item.id}>
+            {index ? ', ' : ''}
+            <Link href={`/${list.path}/[id]`} as={`/${list.path}/${item.id}`}>
+              {item.label || item.id}
+            </Link>
+          </Fragment>
+        ))}
+    </FieldContainer>
+  )
+}
+
+type Value = { label: string; id: string }
+
+type SingleRelationshipValue = {
+  kind: 'one'
+  id: null | string
+  initialValue: Value | null
+  value: Value | null
+}
+type ManyRelationshipValue = {
+  kind: 'many'
+  id: null | string
+  initialValue: Value[]
+  value: Value[]
+}
+type CardsRelationshipValue = {
+  kind: 'cards-view'
+  id: null | string
+  itemsBeingEdited: ReadonlySet<string>
+  itemBeingCreated: boolean
+  initialIds: ReadonlySet<string>
+  currentIds: ReadonlySet<string>
+  displayOptions: CardsDisplayModeOptions
+}
+type CountRelationshipValue = {
+  kind: 'count'
+  id: null | string
+  count: number
+}
+type CardsDisplayModeOptions = {
+  cardFields: readonly string[]
+  linkToItem: boolean
+  removeMode: 'disconnect' | 'none'
+  inlineCreate: { fields: readonly string[] } | null
+  inlineEdit: { fields: readonly string[] } | null
+  inlineConnect: boolean
+}
+
+type RelationshipController = FieldController<
+  | ManyRelationshipValue
+  | SingleRelationshipValue
+  | CardsRelationshipValue
+  | CountRelationshipValue,
+  string
+> & {
+  display: 'count' | 'cards-or-select'
+  listKey: string
+  refListKey: string
+  refFieldKey?: string
+  refLabelField: string
+  refSearchFields: string[]
+  hideCreate: boolean
+  many: boolean
+}
+
+export const controller = (
+  config: FieldControllerConfig<
+    {
+      refFieldKey?: string
+      refListKey: string
+      many: boolean
+      hideCreate: boolean
+      refLabelField: string
+      refSearchFields: string[]
+    } & (
+      | {
+          displayMode: 'select'
+        }
+      | {
+          displayMode: 'cards'
+          cardFields: readonly string[]
+          linkToItem: boolean
+          removeMode: 'disconnect' | 'none'
+          inlineCreate: { fields: readonly string[] } | null
+          inlineEdit: { fields: readonly string[] } | null
+          inlineConnect: boolean
+        }
+      | {
+          displayMode: 'count'
+        }
+    )
+  >
+): RelationshipController => {
+  const cardsDisplayOptions =
+    config.fieldMeta.displayMode === 'cards'
+      ? {
+          cardFields: config.fieldMeta.cardFields,
+          inlineCreate: config.fieldMeta.inlineCreate,
+          inlineEdit: config.fieldMeta.inlineEdit,
+          linkToItem: config.fieldMeta.linkToItem,
+          removeMode: config.fieldMeta.removeMode,
+          inlineConnect: config.fieldMeta.inlineConnect,
+        }
+      : undefined
+
+  const refLabelField = config.fieldMeta.refLabelField
+  const refSearchFields = config.fieldMeta.refSearchFields
+
+  return {
+    refFieldKey: config.fieldMeta.refFieldKey,
+    many: config.fieldMeta.many,
+    listKey: config.listKey,
+    path: config.path,
+    label: config.label,
+    description: config.description,
+    display:
+      config.fieldMeta.displayMode === 'count' ? 'count' : 'cards-or-select',
+    refLabelField,
+    refSearchFields,
+    refListKey: config.fieldMeta.refListKey,
+    graphqlSelection:
+      config.fieldMeta.displayMode === 'count'
+        ? `${config.path}Count`
+        : `${config.path} {
+              id
+              label: ${refLabelField}
+            }`,
+    hideCreate: config.fieldMeta.hideCreate,
+    // note we're not making the state kind: 'count' when ui.displayMode is set to 'count'.
+    // that ui.displayMode: 'count' is really just a way to have reasonable performance
+    // because our other UIs don't handle relationships with a large number of items well
+    // but that's not a problem here since we're creating a new item so we might as well them a better UI
+    defaultValue:
+      cardsDisplayOptions !== undefined
+        ? {
+            kind: 'cards-view',
+            currentIds: new Set(),
+            id: null,
+            initialIds: new Set(),
+            itemBeingCreated: false,
+            itemsBeingEdited: new Set(),
+            displayOptions: cardsDisplayOptions,
+          }
+        : config.fieldMeta.many
+        ? {
+            id: null,
+            kind: 'many',
+            initialValue: [],
+            value: [],
+          }
+        : { id: null, kind: 'one', value: null, initialValue: null },
+    deserialize: (data) => {
+      if (config.fieldMeta.displayMode === 'count') {
+        return {
+          id: data.id,
+          kind: 'count',
+          count: data[`${config.path}Count`] ?? 0,
+        }
+      }
+      if (cardsDisplayOptions !== undefined) {
+        const initialIds = new Set<string>(
+          (Array.isArray(data[config.path])
+            ? data[config.path]
+            : data[config.path]
+            ? [data[config.path]]
+            : []
+          ).map((x: any) => x.id)
+        )
+        return {
+          kind: 'cards-view',
+          id: data.id,
+          itemsBeingEdited: new Set(),
+          itemBeingCreated: false,
+          initialIds,
+          currentIds: initialIds,
+          displayOptions: cardsDisplayOptions,
+        }
+      }
+      if (config.fieldMeta.many) {
+        const value = (data[config.path] || []).map((x: any) => ({
+          id: x.id,
+          label: x.label || x.id,
+        }))
+        return {
+          kind: 'many',
+          id: data.id,
+          initialValue: value,
+          value,
+        }
+      }
+      let value = data[config.path]
+      if (value) {
+        value = {
+          id: value.id,
+          label: value.label || value.id,
+        }
+      }
+      return {
+        kind: 'one',
+        id: data.id,
+        value,
+        initialValue: value,
+      }
+    },
+    filter: {
+      Filter: ({ onChange, value }) => {
+        const foreignList = useList(config.fieldMeta.refListKey)
+        const { filterValues, loading } = useRelationshipFilterValues({
+          value,
+          list: foreignList,
+        })
+        const state: {
+          kind: 'many'
+          value: Value[]
+          onChange: (newItems: Value[]) => void
+        } = {
+          kind: 'many',
+          value: filterValues,
+          onChange(newItems) {
+            onChange(newItems.map((item) => item.id).join(','))
+          },
+        }
+        return (
+          <RelationshipSelect
+            controlShouldRenderValue
+            list={foreignList}
+            labelField={refLabelField}
+            searchFields={refSearchFields}
+            isLoading={loading}
+            isDisabled={onChange === undefined}
+            state={state}
+            orderBy={[{ id: 'desc' }]}
+          />
+        )
+      },
+      graphql: ({ value }) => {
+        const foreignIds = getForeignIds(value)
+        if (config.fieldMeta.many) {
+          return {
+            [config.path]: {
+              some: {
+                id: {
+                  in: foreignIds,
+                },
+              },
+            },
+          }
+        }
+        return {
+          [config.path]: {
+            id: {
+              in: foreignIds,
+            },
+          },
+        }
+      },
+      Label({ value }) {
+        const foreignList = useList(config.fieldMeta.refListKey)
+        const { filterValues } = useRelationshipFilterValues({
+          value,
+          list: foreignList,
+        })
+
+        if (!filterValues.length) {
+          return `has no value`
+        }
+        if (filterValues.length > 1) {
+          const values = filterValues.map((i: any) => i.label).join(', ')
+          return `is in [${values}]`
+        }
+        const optionLabel = filterValues[0].label
+        return `is ${optionLabel}`
+      },
+      types: {
+        matches: {
+          label: 'Matches',
+          initialValue: '',
+        },
+      },
+    },
+    validate(value) {
+      return (
+        value.kind !== 'cards-view' ||
+        (value.itemsBeingEdited.size === 0 && !value.itemBeingCreated)
+      )
+    },
+    serialize: (state) => {
+      if (state.kind === 'many') {
+        const newAllIds = new Set(state.value.map((x) => x.id))
+        const initialIds = new Set(state.initialValue.map((x) => x.id))
+        const disconnect = state.initialValue
+          .filter((x) => !newAllIds.has(x.id))
+          .map((x) => ({ id: x.id }))
+        const connect = state.value
+          .filter((x) => !initialIds.has(x.id))
+          .map((x) => ({ id: x.id }))
+        if (disconnect.length || connect.length) {
+          const output: any = {}
+
+          if (disconnect.length) {
+            output.disconnect = disconnect
+          }
+
+          if (connect.length) {
+            output.connect = connect
+          }
+
+          return {
+            [config.path]: output,
+          }
+        }
+      } else if (state.kind === 'one') {
+        if (state.initialValue && !state.value) {
+          return { [config.path]: { disconnect: true } }
+        } else if (state.value && state.value.id !== state.initialValue?.id) {
+          return {
+            [config.path]: {
+              connect: {
+                id: state.value.id,
+              },
+            },
+          }
+        }
+      } else if (state.kind === 'cards-view') {
+        const disconnect = [...state.initialIds]
+          .filter((id) => !state.currentIds.has(id))
+          .map((id) => ({ id }))
+        const connect = [...state.currentIds]
+          .filter((id) => !state.initialIds.has(id))
+          .map((id) => ({ id }))
+
+        if (config.fieldMeta.many) {
+          if (disconnect.length || connect.length) {
+            return {
+              [config.path]: {
+                connect: connect.length ? connect : undefined,
+                disconnect: disconnect.length ? disconnect : undefined,
+              },
+            }
+          }
+        } else if (connect.length) {
+          return {
+            [config.path]: {
+              connect: connect[0],
+            },
+          }
+        } else if (disconnect.length) {
+          return { [config.path]: { disconnect: true } }
+        }
+      }
+      return {}
+    },
+  }
+}
+
+function useRelationshipFilterValues({
+  value,
+  list,
+}: {
+  value: string
+  list: ListMeta
+}) {
+  const foreignIds = getForeignIds(value)
+  const where = { id: { in: foreignIds } }
+
+  const query = gql`
+    query FOREIGNLIST_QUERY($where: ${list.gqlNames.whereInputName}!) {
+      items: ${list.gqlNames.listQueryName}(where: $where) {
+        id
+        ${list.labelField}
+      }
+    }
+  `
+
+  const { data, loading } = useQuery(query, {
+    variables: {
+      where,
+    },
+  })
+
+  return {
+    filterValues:
+      data?.items?.map((item: any) => {
+        return {
+          id: item.id,
+          label: item[list.labelField] || item.id,
+        }
+      }) || foreignIds.map((f) => ({ label: f, id: f })),
+    loading: loading,
+  }
+}
+
+function getForeignIds(value: string) {
+  if (typeof value === 'string' && value.length > 0) {
+    return value.split(',')
+  }
+  return []
+}

--- a/packages/mirrordaily/lists/views/default-section-relationship/RelationshipSelect.tsx
+++ b/packages/mirrordaily/lists/views/default-section-relationship/RelationshipSelect.tsx
@@ -1,0 +1,440 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import 'intersection-observer'
+import {
+  RefObject,
+  useEffect,
+  useMemo,
+  useState,
+  createContext,
+  useContext,
+  useRef,
+} from 'react'
+
+// eslint-disable-next-line
+import { jsx } from '@keystone-ui/core';
+import { MultiSelect, Select, selectComponents } from '@keystone-ui/fields'
+import { validate as validateUUID } from 'uuid'
+import { IdFieldConfig, ListMeta } from '@keystone-6/core/types'
+import {
+  ApolloClient,
+  gql,
+  InMemoryCache,
+  TypedDocumentNode,
+  useApolloClient,
+  useQuery,
+} from '@keystone-6/core/admin-ui/apollo'
+
+function useIntersectionObserver(
+  cb: IntersectionObserverCallback,
+  ref: RefObject<any>
+) {
+  const cbRef = useRef(cb)
+  useEffect(() => {
+    cbRef.current = cb
+  })
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (...args) => cbRef.current(...args),
+      {}
+    )
+    const node = ref.current
+    if (node !== null) {
+      observer.observe(node)
+      return () => observer.unobserve(node)
+    }
+  }, [ref])
+}
+
+const idValidators = {
+  uuid: validateUUID,
+  cuid(value: string) {
+    return value.startsWith('c')
+  },
+  autoincrement(value: string) {
+    return /^\d+$/.test(value)
+  },
+}
+
+function useDebouncedValue<T>(value: T, limitMs: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(() => value)
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setDebouncedValue(() => value)
+    }, limitMs)
+    return () => {
+      clearTimeout(id)
+    }
+  }, [value, limitMs])
+  return debouncedValue
+}
+
+export function useFilter(
+  search: string,
+  list: ListMeta,
+  searchFields: string[]
+) {
+  return useMemo(() => {
+    if (!search.length) return { OR: [] }
+
+    const idFieldKind: IdFieldConfig['kind'] = (
+      list.fields.id.controller as any
+    ).idFieldKind
+    const trimmedSearch = search.trim()
+    const isValidId = idValidators[idFieldKind](trimmedSearch)
+
+    const conditions: Record<string, any>[] = []
+    if (isValidId) {
+      conditions.push({ id: { equals: trimmedSearch } })
+    }
+
+    for (const fieldKey of searchFields) {
+      const field = list.fields[fieldKey]
+      conditions.push({
+        [field.path]: {
+          contains: trimmedSearch,
+          mode: field.search === 'insensitive' ? 'insensitive' : undefined,
+        },
+      })
+    }
+
+    return { OR: conditions }
+  }, [search, list, searchFields])
+}
+
+const idFieldAlias = '____id____'
+
+const labelFieldAlias = '____label____'
+
+const LoadingIndicatorContext = createContext<{
+  count: number
+  ref: (element: HTMLElement | null) => void
+}>({
+  count: 0,
+  // To avoid @typescript-eslint/no-empty-function,
+  // add a console log.
+  ref: () => {
+    console.log('ref function called')
+  },
+})
+
+export const RelationshipSelect = ({
+  autoFocus,
+  controlShouldRenderValue,
+  isDisabled,
+  isLoading,
+  labelField,
+  searchFields,
+  list,
+  placeholder,
+  portalMenu,
+  state,
+  extraSelection = '',
+  orderBy,
+}: {
+  autoFocus?: boolean
+  controlShouldRenderValue: boolean
+  isDisabled: boolean
+  isLoading?: boolean
+  labelField: string
+  searchFields: string[]
+  list: ListMeta
+  placeholder?: string
+  portalMenu?: true | undefined
+  state:
+    | {
+        kind: 'many'
+        value: { label: string; id: string; data?: Record<string, any> }[]
+        onChange(
+          value: { label: string; id: string; data: Record<string, any> }[]
+        ): void
+      }
+    | {
+        kind: 'one'
+        value: { label: string; id: string; data?: Record<string, any> } | null
+        onChange(
+          value: { label: string; id: string; data: Record<string, any> } | null
+        ): void
+      }
+  extraSelection?: string
+  orderBy: Record<string, any>[]
+}) => {
+  const [search, setSearch] = useState('')
+  // note it's important that this is in state rather than a ref
+  // because we want a re-render if the element changes
+  // so that we can register the intersection observer
+  // on the right element
+  const [loadingIndicatorElement, setLoadingIndicatorElement] =
+    useState<null | HTMLElement>(null)
+
+  const QUERY: TypedDocumentNode<
+    {
+      items: { [idFieldAlias]: string; [labelFieldAlias]: string | null }[]
+      count: number
+    },
+    {
+      where: Record<string, any>
+      take: number
+      skip: number
+      orderBy: Record<string, any>[]
+    }
+  > = gql`
+    query RelationshipSelect($where: ${list.gqlNames.whereInputName}!, $take: Int!, $skip: Int!, $orderBy: [${list.gqlNames.listOrderName}!]!) {
+      items: ${list.gqlNames.listQueryName}(where: $where, take: $take, skip: $skip, orderBy: $orderBy) {
+        ${idFieldAlias}: id
+        ${labelFieldAlias}: ${labelField}
+        ${extraSelection}
+      }
+      count: ${list.gqlNames.listQueryCountName}(where: $where)
+    }
+  `
+
+  const debouncedSearch = useDebouncedValue(search, 200)
+  const where = useFilter(debouncedSearch, list, searchFields)
+
+  const link = useApolloClient().link
+  // we're using a local apollo client here because writing a global implementation of the typePolicies
+  // would require making assumptions about how pagination should work which won't always be right
+  const apolloClient = useMemo(
+    () =>
+      new ApolloClient({
+        link,
+        cache: new InMemoryCache({
+          typePolicies: {
+            Query: {
+              fields: {
+                [list.gqlNames.listQueryName]: {
+                  keyArgs: ['where'],
+                  merge: (
+                    existing: readonly unknown[],
+                    incoming: readonly unknown[],
+                    { args }
+                  ) => {
+                    const merged = existing ? existing.slice() : []
+                    const { skip } = args!
+                    for (let i = 0; i < incoming.length; ++i) {
+                      merged[skip + i] = incoming[i]
+                    }
+                    return merged
+                  },
+                },
+              },
+            },
+          },
+        }),
+      }),
+    [link, list.gqlNames.listQueryName]
+  )
+
+  const initialItemsToLoad = Math.min(list.pageSize, 10)
+  const subsequentItemsToLoad = Math.min(list.pageSize, 50)
+  const { data, error, loading, fetchMore } = useQuery(QUERY, {
+    fetchPolicy: 'network-only',
+    variables: { where, take: initialItemsToLoad, skip: 0, orderBy },
+    client: apolloClient,
+  })
+
+  const count = data?.count || 0
+
+  const options =
+    data?.items?.map(
+      ({ [idFieldAlias]: value, [labelFieldAlias]: label, ...data }) => ({
+        value,
+        label: label || value,
+        data,
+      })
+    ) || []
+
+  const loadingIndicatorContextVal = useMemo(
+    () => ({
+      count,
+      ref: setLoadingIndicatorElement,
+    }),
+    [count]
+  )
+
+  // we want to avoid fetching more again and `loading` from Apollo
+  // doesn't seem to become true when fetching more
+  const [lastFetchMore, setLastFetchMore] = useState<{
+    where: Record<string, any>
+    extraSelection: string
+    list: ListMeta
+    skip: number
+  } | null>(null)
+
+  useIntersectionObserver(
+    ([{ isIntersecting }]) => {
+      const skip = data?.items.length
+      if (
+        !loading &&
+        skip &&
+        isIntersecting &&
+        options.length < count &&
+        (lastFetchMore?.extraSelection !== extraSelection ||
+          lastFetchMore?.where !== where ||
+          lastFetchMore?.list !== list ||
+          lastFetchMore?.skip !== skip)
+      ) {
+        const QUERY: TypedDocumentNode<
+          {
+            items: {
+              [idFieldAlias]: string
+              [labelFieldAlias]: string | null
+            }[]
+          },
+          {
+            where: Record<string, any>
+            take: number
+            skip: number
+            orderBy: Record<string, any>[]
+          }
+        > = gql`
+              query RelationshipSelectMore($where: ${list.gqlNames.whereInputName}!, $take: Int!, $skip: Int!, $orderBy: [${list.gqlNames.listOrderName}!]!) {
+                items: ${list.gqlNames.listQueryName}(where: $where, take: $take, skip: $skip, orderBy: $orderBy) {
+                  ${labelFieldAlias}: ${labelField}
+                  ${idFieldAlias}: id
+                  ${extraSelection}
+                }
+              }
+            `
+        setLastFetchMore({ extraSelection, list, skip, where })
+        fetchMore({
+          query: QUERY,
+          variables: {
+            where,
+            take: subsequentItemsToLoad,
+            skip,
+            orderBy,
+          },
+        })
+          .then(() => {
+            setLastFetchMore(null)
+          })
+          .catch(() => {
+            setLastFetchMore(null)
+          })
+      }
+    },
+    { current: loadingIndicatorElement }
+  )
+
+  // TODO: better error UI
+  // TODO: Handle permission errors
+  // (ie; user has permission to read this relationship field, but
+  // not the related list, or some items on the list)
+  if (error) {
+    return <span>Error</span>
+  }
+
+  if (state.kind === 'one') {
+    return (
+      <LoadingIndicatorContext.Provider value={loadingIndicatorContextVal}>
+        <Select
+          // this is necessary because react-select passes a second argument to onInputChange
+          // and useState setters log a warning if a second argument is passed
+          onInputChange={(val) => setSearch(val)}
+          isLoading={loading || isLoading}
+          autoFocus={autoFocus}
+          components={relationshipSelectComponents}
+          portalMenu={portalMenu}
+          value={
+            state.value
+              ? {
+                  value: state.value.id,
+                  label: state.value.label,
+                  // eslint-disable-next-line
+                  // @ts-ignore
+                  data: state.value.data,
+                }
+              : null
+          }
+          options={options}
+          onChange={(value) => {
+            state.onChange(
+              value
+                ? {
+                    id: value.value,
+                    label: value.label,
+                    data: (value as any).data,
+                  }
+                : null
+            )
+          }}
+          placeholder={placeholder}
+          controlShouldRenderValue={controlShouldRenderValue}
+          isClearable={controlShouldRenderValue}
+          isDisabled={isDisabled}
+        />
+      </LoadingIndicatorContext.Provider>
+    )
+  }
+
+  return (
+    <LoadingIndicatorContext.Provider value={loadingIndicatorContextVal}>
+      <MultiSelect // this is necessary because react-select passes a second argument to onInputChange
+        // and useState setters log a warning if a second argument is passed
+        onInputChange={(val) => setSearch(val)}
+        isLoading={loading || isLoading}
+        autoFocus={autoFocus}
+        components={relationshipSelectComponents}
+        portalMenu={portalMenu}
+        value={state.value.map((value) => ({
+          value: value.id,
+          label: value.label,
+          data: value.data,
+        }))}
+        options={options}
+        onChange={(value) => {
+          state.onChange(
+            value.map((x) => ({
+              id: x.value,
+              label: x.label,
+              data: (x as any).data,
+            }))
+          )
+        }}
+        placeholder={placeholder}
+        controlShouldRenderValue={controlShouldRenderValue}
+        isClearable={controlShouldRenderValue}
+        isDisabled={isDisabled}
+        // The parameter `formatOptionLabel` is added specifically for this project
+        // and is not copied from the codebase of keystone-6/core.
+        // This parameter controls the appearance of element in drop-down list component, make it display image if needed.
+        // See [Pull Request](https://github.com/mirror-media/Lilith/pull/698) to get more details.
+        formatOptionLabel={(option) => {
+          return (
+            <div style={{ display: 'flex', flexDirection: 'row' }}>
+              <span>{option.label}</span>
+              {list.label === 'Photos' && (
+                <img
+                  src={option?.data?.imageFile?.url}
+                  width={50}
+                  height={50}
+                  style={{ objectFit: 'cover', marginLeft: 'auto' }}
+                ></img>
+              )}
+            </div>
+          )
+        }}
+      />
+    </LoadingIndicatorContext.Provider>
+  )
+}
+
+const relationshipSelectComponents: Partial<typeof selectComponents> = {
+  MenuList: ({ children, ...props }) => {
+    const { count, ref } = useContext(LoadingIndicatorContext)
+    return (
+      <selectComponents.MenuList {...props}>
+        {children}
+        <div css={{ textAlign: 'center' }} ref={ref}>
+          {props.options.length < count && (
+            <span css={{ padding: 8 }}>Loading...</span>
+          )}
+        </div>
+      </selectComponents.MenuList>
+    )
+  },
+}

--- a/packages/mirrordaily/lists/views/default-section-relationship/cards/InlineCreate.tsx
+++ b/packages/mirrordaily/lists/views/default-section-relationship/cards/InlineCreate.tsx
@@ -1,0 +1,147 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { FormEvent, useState } from 'react'
+// eslint-disable-next-line
+import { jsx, Stack } from '@keystone-ui/core';
+import isDeepEqual from 'fast-deep-equal'
+import { useToasts } from '@keystone-ui/toast'
+import { Button } from '@keystone-ui/button'
+import { ListMeta } from '@keystone-6/core/types'
+import {
+  ItemData,
+  makeDataGetter,
+  DataGetter,
+  Value,
+  useInvalidFields,
+  serializeValueToObjByFieldKey,
+  Fields,
+} from '@keystone-6/core/admin-ui/utils'
+import { gql, useMutation } from '@keystone-6/core/admin-ui/apollo'
+import { GraphQLErrorNotice } from '@keystone-6/core/admin-ui/components'
+import { useFieldsObj } from './useItemState'
+
+export function InlineCreate({
+  list,
+  onCancel,
+  onCreate,
+  fields: fieldPaths,
+  selectedFields,
+}: {
+  list: ListMeta
+  selectedFields: string
+  fields: readonly string[]
+  onCancel: () => void
+  onCreate: (itemGetter: DataGetter<ItemData>) => void
+}) {
+  const toasts = useToasts()
+  const fields = useFieldsObj(list, fieldPaths)
+
+  const [createItem, { loading, error }] = useMutation(
+    gql`mutation($data: ${list.gqlNames.createInputName}!) {
+      item: ${list.gqlNames.createMutationName}(data: $data) {
+        ${selectedFields}
+    }
+  }`
+  )
+
+  const [value, setValue] = useState(() => {
+    const value: Value = {}
+    Object.keys(fields).forEach((fieldPath) => {
+      value[fieldPath] = {
+        kind: 'value',
+        value: fields[fieldPath].controller.defaultValue,
+      }
+    })
+    return value
+  })
+
+  const invalidFields = useInvalidFields(fields, value)
+
+  const [forceValidation, setForceValidation] = useState(false)
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const newForceValidation = invalidFields.size !== 0
+    setForceValidation(newForceValidation)
+
+    if (newForceValidation) return
+    const data: Record<string, any> = {}
+    const allSerializedValues = serializeValueToObjByFieldKey(fields, value)
+    Object.keys(allSerializedValues).forEach((fieldPath) => {
+      const { controller } = fields[fieldPath]
+      const serialized = allSerializedValues[fieldPath]
+      if (
+        !isDeepEqual(serialized, controller.serialize(controller.defaultValue))
+      ) {
+        Object.assign(data, serialized)
+      }
+    })
+
+    createItem({
+      variables: {
+        data,
+      },
+    })
+      .then(({ data, errors }) => {
+        // we're checking for path.length === 1 because errors with a path larger than 1 will be field level errors
+        // which are handled seperately and do not indicate a failure to update the item
+        const error = errors?.find((x) => x.path?.length === 1)
+        if (error) {
+          toasts.addToast({
+            title: 'Failed to create item',
+            tone: 'negative',
+            message: error.message,
+          })
+        } else {
+          toasts.addToast({
+            title: data.item[list.labelField] || data.item.id,
+            tone: 'positive',
+            message: 'Saved successfully',
+          })
+          onCreate(makeDataGetter(data, errors).get('item'))
+        }
+      })
+      .catch((err) => {
+        toasts.addToast({
+          title: 'Failed to update item',
+          tone: 'negative',
+          message: err.message,
+        })
+      })
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <Stack gap="xlarge">
+        {error && (
+          <GraphQLErrorNotice
+            networkError={error?.networkError}
+            errors={error?.graphQLErrors}
+          />
+        )}
+        <Fields
+          fields={fields}
+          forceValidation={forceValidation}
+          invalidFields={invalidFields}
+          onChange={setValue}
+          value={value}
+        />
+        <Stack gap="small" across>
+          <Button
+            isLoading={loading}
+            size="small"
+            tone="positive"
+            weight="bold"
+            type="submit"
+          >
+            Create {list.singular}
+          </Button>
+          <Button size="small" weight="none" onClick={onCancel}>
+            Cancel
+          </Button>
+        </Stack>
+      </Stack>
+    </form>
+  )
+}

--- a/packages/mirrordaily/lists/views/default-section-relationship/cards/InlineEdit.tsx
+++ b/packages/mirrordaily/lists/views/default-section-relationship/cards/InlineEdit.tsx
@@ -1,0 +1,160 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { Button } from '@keystone-ui/button'
+// eslint-disable-next-line
+import { jsx, Stack } from '@keystone-ui/core';
+import { useToasts } from '@keystone-ui/toast'
+import { useCallback, useState } from 'react'
+import { ListMeta } from '@keystone-6/core/types'
+import {
+  deserializeValue,
+  ItemData,
+  useInvalidFields,
+  Fields,
+  useChangedFieldsAndDataForUpdate,
+  makeDataGetter,
+  DataGetter,
+} from '@keystone-6/core/admin-ui/utils'
+import { gql, useMutation } from '@keystone-6/core/admin-ui/apollo'
+import { GraphQLErrorNotice } from '@keystone-6/core/admin-ui/components'
+import { useFieldsObj } from './useItemState'
+
+export function InlineEdit({
+  fields,
+  list,
+  selectedFields,
+  itemGetter,
+  onCancel,
+  onSave,
+}: {
+  fields: readonly string[]
+  list: ListMeta
+  selectedFields: string
+  itemGetter: DataGetter<ItemData>
+  onCancel: () => void
+  onSave: (newItemGetter: DataGetter<ItemData>) => void
+}) {
+  const fieldsObj = useFieldsObj(list, fields)
+
+  const [update, { loading, error }] = useMutation(
+    gql`mutation ($data: ${list.gqlNames.updateInputName}!, $id: ID!) {
+          item: ${list.gqlNames.updateMutationName}(where: { id: $id }, data: $data) {
+            ${selectedFields}
+          }
+        }`,
+    { errorPolicy: 'all' }
+  )
+
+  const [state, setValue] = useState(() => {
+    const value = deserializeValue(fieldsObj, itemGetter)
+    return { value, item: itemGetter.data }
+  })
+
+  if (
+    state.item !== itemGetter.data &&
+    itemGetter.errors?.every((x) => x.path?.length !== 1)
+  ) {
+    const value = deserializeValue(fieldsObj, itemGetter)
+    setValue({ value, item: itemGetter.data })
+  }
+
+  const { changedFields, dataForUpdate } = useChangedFieldsAndDataForUpdate(
+    fieldsObj,
+    itemGetter,
+    state.value
+  )
+
+  const invalidFields = useInvalidFields(fieldsObj, state.value)
+
+  const [forceValidation, setForceValidation] = useState(false)
+  const toasts = useToasts()
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        if (changedFields.size === 0) {
+          onCancel()
+          return
+        }
+        const newForceValidation = invalidFields.size !== 0
+        setForceValidation(newForceValidation)
+        if (newForceValidation) return
+
+        update({
+          variables: {
+            data: dataForUpdate,
+            id: itemGetter.get('id').data,
+          },
+        })
+          .then(({ data, errors }) => {
+            // we're checking for path.length === 1 because errors with a path larger than 1 will be field level errors
+            // which are handled seperately and do not indicate a failure to update the item
+            const error = errors?.find((x) => x.path?.length === 1)
+            if (error) {
+              toasts.addToast({
+                title: 'Failed to update item',
+                tone: 'negative',
+                message: error.message,
+              })
+            } else {
+              toasts.addToast({
+                title: data.item[list.labelField] || data.item.id,
+                tone: 'positive',
+                message: 'Saved successfully',
+              })
+              onSave(makeDataGetter(data, errors).get('item'))
+            }
+          })
+          .catch((err) => {
+            toasts.addToast({
+              title: 'Failed to update item',
+              tone: 'negative',
+              message: err.message,
+            })
+          })
+      }}
+    >
+      <Stack gap="xlarge">
+        {error && (
+          <GraphQLErrorNotice
+            networkError={error?.networkError}
+            // we're checking for path.length === 1 because errors with a path larger than 1 will be field level errors
+            // which are handled seperately and do not indicate a failure to update the item
+            errors={error?.graphQLErrors.filter((x) => x.path?.length === 1)}
+          />
+        )}
+        <Fields
+          fields={fieldsObj}
+          forceValidation={forceValidation}
+          invalidFields={invalidFields}
+          onChange={useCallback(
+            (value) => {
+              setValue((state) => ({
+                item: state.item,
+                value: value(state.value),
+              }))
+            },
+            [setValue]
+          )}
+          value={state.value}
+        />
+        <Stack across gap="small">
+          <Button
+            isLoading={loading}
+            weight="bold"
+            size="small"
+            tone="active"
+            type="submit"
+          >
+            Save
+          </Button>
+          <Button size="small" weight="none" onClick={onCancel}>
+            Cancel
+          </Button>
+        </Stack>
+      </Stack>
+    </form>
+  )
+}

--- a/packages/mirrordaily/lists/views/default-section-relationship/cards/index.tsx
+++ b/packages/mirrordaily/lists/views/default-section-relationship/cards/index.tsx
@@ -1,0 +1,465 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { ReactNode } from 'react'
+// eslint-disable-next-line
+import { jsx } from '@keystone-ui/core';
+import {
+  Box,
+  BoxProps,
+  Stack,
+  Text,
+  useTheme,
+  forwardRefWithAs,
+  VisuallyHidden,
+} from '@keystone-ui/core'
+
+import { FieldContainer, FieldLabel } from '@keystone-ui/fields'
+import { Button } from '@keystone-ui/button'
+import { Tooltip } from '@keystone-ui/tooltip'
+import { LoadingDots } from '@keystone-ui/loading'
+import { useEffect, useRef, useState } from 'react'
+import { FieldProps, ListMeta } from '@keystone-6/core/types'
+import {
+  getRootGraphQLFieldsFromFieldController,
+  makeDataGetter,
+} from '@keystone-6/core/admin-ui/utils'
+import { Link } from '@keystone-6/core/admin-ui/router'
+import { gql, useApolloClient } from '@keystone-6/core/admin-ui/apollo'
+import { controller } from '../index'
+import { RelationshipSelect } from '../RelationshipSelect'
+import { useItemState } from './useItemState'
+import { InlineEdit } from './InlineEdit'
+import { InlineCreate } from './InlineCreate'
+
+type CardContainerProps = {
+  children: ReactNode
+  mode: 'view' | 'create' | 'edit'
+} & BoxProps
+const CardContainer = forwardRefWithAs(
+  ({ mode = 'view', ...props }: CardContainerProps, ref) => {
+    const { tones } = useTheme()
+
+    const tone =
+      tones[
+        mode === 'edit' ? 'active' : mode === 'create' ? 'positive' : 'passive'
+      ]
+
+    return (
+      <Box
+        ref={ref}
+        paddingLeft="xlarge"
+        css={{
+          position: 'relative',
+
+          ':before': {
+            content: '" "',
+            backgroundColor: tone.border,
+            borderRadius: 4,
+            width: 4,
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            zIndex: 1,
+          },
+        }}
+        {...props}
+      />
+    )
+  }
+)
+
+export function Cards({
+  localList,
+  field,
+  foreignList,
+  id,
+  value,
+  onChange,
+  forceValidation,
+}: {
+  foreignList: ListMeta
+  localList: ListMeta
+  id: string | null
+  value: { kind: 'cards-view' }
+} & FieldProps<typeof controller>) {
+  const { displayOptions } = value
+  let selectedFields = [
+    ...new Set([
+      ...displayOptions.cardFields,
+      ...(displayOptions.inlineEdit?.fields || []),
+    ]),
+  ]
+    .map((fieldPath) => {
+      return foreignList.fields[fieldPath].controller.graphqlSelection
+    })
+    .join('\n')
+  if (!displayOptions.cardFields.includes('id')) {
+    selectedFields += '\nid'
+  }
+  if (
+    !displayOptions.cardFields.includes(foreignList.labelField) &&
+    foreignList.labelField !== 'id'
+  ) {
+    selectedFields += `\n${foreignList.labelField}`
+  }
+
+  const {
+    items,
+    setItems,
+    state: itemsState,
+  } = useItemState({
+    selectedFields,
+    localList,
+    id,
+    field,
+  })
+
+  const client = useApolloClient()
+
+  const [isLoadingLazyItems, setIsLoadingLazyItems] = useState(false)
+  const [showConnectItems, setShowConnectItems] = useState(false)
+  const [hideConnectItemsLabel, setHideConnectItemsLabel] = useState<
+    'Cancel' | 'Done'
+  >('Cancel')
+  const editRef = useRef<HTMLDivElement | null>(null)
+
+  const isMountedRef = useRef(false)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  })
+
+  useEffect(() => {
+    if (value.itemsBeingEdited) {
+      editRef?.current?.focus()
+    }
+  }, [value])
+
+  if (itemsState.kind === 'loading') {
+    return (
+      <div>
+        <LoadingDots label={`Loading items for ${field.label} field`} />
+      </div>
+    )
+  }
+  if (itemsState.kind === 'error') {
+    return <span css={{ color: 'red' }}>{itemsState.message}</span>
+  }
+
+  const currentIdsArrayWithFetchedItems = [...value.currentIds]
+    .map((id) => ({ itemGetter: items[id], id }))
+    .filter((x) => x.itemGetter)
+
+  return (
+    <Stack gap="medium">
+      {currentIdsArrayWithFetchedItems.length !== 0 && (
+        <Stack
+          as="ul"
+          gap="medium"
+          css={{
+            padding: 0,
+            margin: 0,
+            li: {
+              listStyle: 'none',
+            },
+          }}
+        >
+          {currentIdsArrayWithFetchedItems.map(({ id, itemGetter }, index) => {
+            const isEditMode =
+              !!(onChange !== undefined) && value.itemsBeingEdited.has(id)
+            return (
+              <CardContainer
+                role="status"
+                mode={isEditMode ? 'edit' : 'view'}
+                key={id}
+              >
+                <VisuallyHidden as="h2">{`${field.label} ${index + 1} ${
+                  isEditMode ? 'edit' : 'view'
+                } mode`}</VisuallyHidden>
+                {isEditMode ? (
+                  <InlineEdit
+                    list={foreignList}
+                    fields={displayOptions.inlineEdit!.fields}
+                    onSave={(newItemGetter) => {
+                      setItems({
+                        ...items,
+                        [id]: newItemGetter,
+                      })
+                      const itemsBeingEdited = new Set(value.itemsBeingEdited)
+                      itemsBeingEdited.delete(id)
+                      onChange!({
+                        ...value,
+                        itemsBeingEdited,
+                      })
+                    }}
+                    selectedFields={selectedFields}
+                    itemGetter={itemGetter}
+                    onCancel={() => {
+                      const itemsBeingEdited = new Set(value.itemsBeingEdited)
+                      itemsBeingEdited.delete(id)
+                      onChange!({
+                        ...value,
+                        itemsBeingEdited,
+                      })
+                    }}
+                  />
+                ) : (
+                  <Stack gap="xlarge">
+                    {displayOptions.cardFields.map((fieldPath) => {
+                      const field = foreignList.fields[fieldPath]
+                      const itemForField: Record<string, any> = {}
+                      for (const graphqlField of getRootGraphQLFieldsFromFieldController(
+                        field.controller
+                      )) {
+                        const fieldGetter = itemGetter.get(graphqlField)
+                        if (fieldGetter.errors) {
+                          const errorMessage = fieldGetter.errors[0].message
+                          return (
+                            <FieldContainer>
+                              <FieldLabel>{field.label}</FieldLabel>
+                              {errorMessage}
+                            </FieldContainer>
+                          )
+                        }
+                        itemForField[graphqlField] = fieldGetter.data
+                      }
+                      return (
+                        <field.views.CardValue
+                          key={fieldPath}
+                          field={field.controller}
+                          item={itemForField}
+                        />
+                      )
+                    })}
+                    <Stack across gap="small">
+                      {displayOptions.inlineEdit && onChange !== undefined && (
+                        <Button
+                          size="small"
+                          disabled={onChange === undefined}
+                          onClick={() => {
+                            onChange({
+                              ...value,
+                              itemsBeingEdited: new Set([
+                                ...value.itemsBeingEdited,
+                                id,
+                              ]),
+                            })
+                          }}
+                          tone="active"
+                        >
+                          Edit
+                        </Button>
+                      )}
+                      {displayOptions.removeMode === 'disconnect' &&
+                        onChange !== undefined && (
+                          <Tooltip content="This item will not be deleted. It will only be removed from this field.">
+                            {(props) => (
+                              <Button
+                                size="small"
+                                disabled={onChange === undefined}
+                                onClick={() => {
+                                  const currentIds = new Set(value.currentIds)
+                                  currentIds.delete(id)
+                                  onChange({
+                                    ...value,
+                                    currentIds,
+                                  })
+                                }}
+                                {...props}
+                                tone="negative"
+                              >
+                                Remove
+                              </Button>
+                            )}
+                          </Tooltip>
+                        )}
+                      {displayOptions.linkToItem && (
+                        <Button
+                          size="small"
+                          weight="link"
+                          tone="active"
+                          css={{ textDecoration: 'none' }}
+                          as={Link}
+                          href={`/${foreignList.path}/${id}`}
+                        >
+                          View {foreignList.singular} details
+                        </Button>
+                      )}
+                    </Stack>
+                  </Stack>
+                )}
+              </CardContainer>
+            )
+          })}
+        </Stack>
+      )}
+      {onChange === undefined ? null : displayOptions.inlineConnect &&
+        showConnectItems ? (
+        <CardContainer mode="edit">
+          <Stack
+            gap="small"
+            across
+            css={{
+              width: '100%',
+              justifyContent: 'space-between',
+              'div:first-of-type': {
+                flex: '2',
+              },
+            }}
+          >
+            <RelationshipSelect
+              autoFocus
+              controlShouldRenderValue={isLoadingLazyItems}
+              isDisabled={onChange === undefined}
+              list={foreignList}
+              labelField={field.refLabelField}
+              searchFields={field.refSearchFields}
+              isLoading={isLoadingLazyItems}
+              placeholder={`Select a ${foreignList.singular}`}
+              portalMenu
+              // The parameter `extraSelection` is added specifically for this project
+              // and is not copied from the codebase of keystone-6/core.
+              // This parameter controls the extra GraphQL query we need to fetch.
+              // See [Pull Request](https://github.com/mirror-media/Lilith/pull/698) to get more details.
+              extraSelection={
+                foreignList.label === 'Photos' ? 'imageFile {url}' : ''
+              }
+              state={{
+                kind: 'many',
+                async onChange(options) {
+                  // TODO: maybe use the extraSelection prop on RelationshipSelect here
+                  const itemsToFetchAndConnect: string[] = []
+                  options.forEach((item) => {
+                    if (!value.currentIds.has(item.id)) {
+                      itemsToFetchAndConnect.push(item.id)
+                    }
+                  })
+                  if (itemsToFetchAndConnect.length) {
+                    try {
+                      const { data, errors } = await client.query({
+                        query: gql`query ($ids: [ID!]!) {
+                      items: ${foreignList.gqlNames.listQueryName}(where: { id: { in: $ids }}) {
+                        ${selectedFields}
+                      }
+                    }`,
+                        variables: { ids: itemsToFetchAndConnect },
+                      })
+                      if (isMountedRef.current) {
+                        const dataGetters = makeDataGetter(data, errors)
+                        const itemsDataGetter = dataGetters.get('items')
+                        const newItems = { ...items }
+                        const newCurrentIds = field.many
+                          ? new Set(value.currentIds)
+                          : new Set<string>()
+                        if (Array.isArray(itemsDataGetter.data)) {
+                          itemsDataGetter.data.forEach((item, i) => {
+                            if (item?.id != null) {
+                              newCurrentIds.add(item.id)
+                              newItems[item.id] = itemsDataGetter.get(i)
+                            }
+                          })
+                        }
+                        if (newCurrentIds.size) {
+                          setItems(newItems)
+                          onChange({
+                            ...value,
+                            currentIds: newCurrentIds,
+                          })
+                          setHideConnectItemsLabel('Done')
+                        }
+                      }
+                    } finally {
+                      if (isMountedRef.current) {
+                        setIsLoadingLazyItems(false)
+                      }
+                    }
+                  }
+                },
+                value: (() => {
+                  const options: { label: string; id: string }[] = []
+                  Object.keys(items).forEach((id) => {
+                    if (value.currentIds.has(id)) {
+                      options.push({ id, label: id })
+                    }
+                  })
+                  return options
+                })(),
+              }}
+              orderBy={[{ id: 'desc' }]}
+            />
+            <Button onClick={() => setShowConnectItems(false)}>
+              {hideConnectItemsLabel}
+            </Button>
+          </Stack>
+        </CardContainer>
+      ) : value.itemBeingCreated ? (
+        <CardContainer mode="create">
+          <InlineCreate
+            selectedFields={selectedFields}
+            fields={displayOptions.inlineCreate!.fields}
+            list={foreignList}
+            onCancel={() => {
+              onChange({ ...value, itemBeingCreated: false })
+            }}
+            onCreate={(itemGetter) => {
+              const id = itemGetter.data.id
+              setItems({ ...items, [id]: itemGetter })
+              onChange({
+                ...value,
+                itemBeingCreated: false,
+                currentIds: field.many
+                  ? new Set([...value.currentIds, id])
+                  : new Set([id]),
+              })
+            }}
+          />
+        </CardContainer>
+      ) : displayOptions.inlineCreate || displayOptions.inlineConnect ? (
+        <CardContainer mode="create">
+          <Stack gap="small" across>
+            {displayOptions.inlineCreate && (
+              <Button
+                size="small"
+                disabled={onChange === undefined}
+                tone="positive"
+                onClick={() => {
+                  onChange({
+                    ...value,
+                    itemBeingCreated: true,
+                  })
+                }}
+              >
+                Create {foreignList.singular}
+              </Button>
+            )}
+            {displayOptions.inlineConnect && (
+              <Button
+                size="small"
+                weight="none"
+                tone="passive"
+                onClick={() => {
+                  setShowConnectItems(true)
+                  setHideConnectItemsLabel('Cancel')
+                }}
+              >
+                Link existing {foreignList.singular}
+              </Button>
+            )}
+          </Stack>
+        </CardContainer>
+      ) : null}
+      {/* TODO: this may not be visible to the user when they invoke the save action. Maybe scroll to it? */}
+      {forceValidation && (
+        <Text color="red600" size="small">
+          You must finish creating and editing any related{' '}
+          {foreignList.label.toLowerCase()} before saving the{' '}
+          {localList.singular.toLowerCase()}
+        </Text>
+      )}
+    </Stack>
+  )
+}

--- a/packages/mirrordaily/lists/views/default-section-relationship/cards/useItemState.tsx
+++ b/packages/mirrordaily/lists/views/default-section-relationship/cards/useItemState.tsx
@@ -1,0 +1,164 @@
+import { useCallback, useMemo, useState } from 'react'
+import { FieldMeta, ListMeta } from '@keystone-6/core/types'
+import { DataGetter, makeDataGetter } from '@keystone-6/core/admin-ui/utils'
+import { gql, useQuery } from '@keystone-6/core/admin-ui/apollo'
+import { controller } from '..'
+
+type ItemsState =
+  | {
+      kind: 'loading'
+    }
+  | { kind: 'error'; message: string }
+  | { kind: 'loaded' }
+
+type Items = Record<string, DataGetter<{ id: string; [key: string]: any }>>
+
+export function useItemState({
+  selectedFields,
+  localList,
+  id,
+  field,
+}: {
+  selectedFields: string
+  localList: ListMeta
+  field: ReturnType<typeof controller>
+  id: string | null
+}) {
+  const { data, error, loading } = useQuery(
+    gql`query($id: ID!) {
+  item: ${localList.gqlNames.itemQueryName}(where: {id: $id}) {
+    id
+    relationship: ${field.path} {
+      ${selectedFields}
+    }
+  }
+}`,
+    { variables: { id }, errorPolicy: 'all', skip: id === null }
+  )
+  const { itemsArrFromData, relationshipGetter } = useMemo(() => {
+    const dataGetter = makeDataGetter(data, error?.graphQLErrors)
+    const relationshipGetter = dataGetter.get('item').get('relationship')
+    const isMany = Array.isArray(relationshipGetter.data)
+    const itemsArrFromData: DataGetter<{
+      id: string
+      [key: string]: any
+    }>[] = (
+      isMany
+        ? relationshipGetter.data.map((_: any, i: number) =>
+            relationshipGetter.get(i)
+          )
+        : [relationshipGetter]
+    ).filter((x: DataGetter<any>) => x.data?.id != null)
+    return { relationshipGetter, itemsArrFromData }
+  }, [data, error])
+  // eslint-disable-next-line
+  let [{ items, itemsArrFromData: itemsArrFromDataState }, setItemsState] = useState<{ 
+      itemsArrFromData: DataGetter<any>[]
+      items: Record<
+        string,
+        {
+          current: DataGetter<{ id: string; [key: string]: any }>
+          fromInitialQuery:
+            | DataGetter<{ id: string; [key: string]: any }>
+            | undefined
+        }
+      >
+    }>({ itemsArrFromData: [], items: {} })
+
+  if (itemsArrFromDataState !== itemsArrFromData) {
+    const newItems: Record<
+      string,
+      {
+        current: DataGetter<{ id: string; [key: string]: any }>
+        fromInitialQuery:
+          | DataGetter<{ id: string; [key: string]: any }>
+          | undefined
+      }
+    > = {}
+
+    itemsArrFromData.forEach((item) => {
+      const initialItemInState = items[item.data.id]?.fromInitialQuery
+      if (
+        ((items[item.data.id] && initialItemInState) || !items[item.data.id]) &&
+        (!initialItemInState ||
+          item.data !== initialItemInState.data ||
+          item.errors?.length !== initialItemInState.errors?.length ||
+          (item.errors || []).some(
+            (err, i) => err !== initialItemInState.errors?.[i]
+          ))
+      ) {
+        newItems[item.data.id] = { current: item, fromInitialQuery: item }
+      } else {
+        newItems[item.data.id] = items[item.data.id]
+      }
+    })
+    items = newItems
+    setItemsState({
+      items: newItems,
+      itemsArrFromData,
+    })
+  }
+
+  return {
+    items: useMemo(() => {
+      const itemsToReturn: Items = {}
+      Object.keys(items).forEach((id) => {
+        itemsToReturn[id] = items[id].current
+      })
+      return itemsToReturn
+    }, [items]),
+    setItems: useCallback(
+      (items: Items) => {
+        setItemsState((state) => {
+          const itemsForState: (typeof state)['items'] = {}
+          Object.keys(items).forEach((id) => {
+            if (items[id] === state.items[id]?.current) {
+              itemsForState[id] = state.items[id]
+            } else {
+              itemsForState[id] = {
+                current: items[id],
+                fromInitialQuery: state.items[id]?.fromInitialQuery,
+              }
+            }
+          })
+          return {
+            itemsArrFromData: state.itemsArrFromData,
+            items: itemsForState,
+          }
+        })
+      },
+      [setItemsState]
+    ),
+    state: ((): ItemsState => {
+      if (id === null) {
+        return { kind: 'loaded' }
+      }
+      if (loading) {
+        return { kind: 'loading' }
+      }
+      if (error?.networkError) {
+        return { kind: 'error', message: error.networkError.message }
+      }
+      if (field.many && !relationshipGetter.data) {
+        return {
+          kind: 'error',
+          message: relationshipGetter.errors?.[0].message || '',
+        }
+      }
+      return { kind: 'loaded' }
+    })(),
+  }
+}
+
+export function useFieldsObj(
+  list: ListMeta,
+  fields: readonly string[] | undefined
+) {
+  return useMemo(() => {
+    const editFields: Record<string, FieldMeta> = {}
+    fields?.forEach((fieldPath) => {
+      editFields[fieldPath] = list.fields[fieldPath]
+    })
+    return editFields
+  }, [fields, list.fields])
+}

--- a/packages/mirrordaily/lists/views/default-section-relationship/index.tsx
+++ b/packages/mirrordaily/lists/views/default-section-relationship/index.tsx
@@ -1,0 +1,806 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { Fragment, useRef, useState } from 'react'
+
+import { Button } from '@keystone-ui/button'
+// eslint-disable-next-line
+import { jsx, Stack, useTheme } from '@keystone-ui/core';
+import {
+  FieldContainer,
+  FieldDescription,
+  FieldLabel,
+  FieldLegend,
+} from '@keystone-ui/fields'
+import { DrawerController } from '@keystone-ui/modals'
+import {
+  CardValueComponent,
+  CellComponent,
+  FieldController,
+  FieldControllerConfig,
+  FieldProps,
+  ListMeta,
+} from '@keystone-6/core/types'
+import { Link } from '@keystone-6/core/admin-ui/router'
+import { useKeystone, useList } from '@keystone-6/core/admin-ui/context'
+import { gql, useQuery } from '@keystone-6/core/admin-ui/apollo'
+import {
+  CellContainer,
+  CreateItemDrawer,
+} from '@keystone-6/core/admin-ui/components'
+
+import { Cards } from './cards'
+import { RelationshipSelect } from './RelationshipSelect'
+
+function LinkToRelatedItems({
+  itemId,
+  value,
+  list,
+  refFieldKey,
+}: {
+  itemId: string | null
+  value: FieldProps<typeof controller>['value'] & { kind: 'many' | 'one' }
+  list: ListMeta
+  refFieldKey?: string
+}) {
+  function constructQuery({
+    refFieldKey,
+    itemId,
+    value,
+  }: {
+    refFieldKey?: string
+    itemId: string | null
+    value: FieldProps<typeof controller>['value'] & { kind: 'many' | 'one' }
+  }) {
+    if (!!refFieldKey && itemId) {
+      return `!${refFieldKey}_matches="${itemId}"`
+    }
+    return `!id_in="${(value?.value as { id: string; label: string }[])
+      .slice(0, 100)
+      .map(({ id }: { id: string }) => id)
+      .join(',')}"`
+  }
+  const commonProps = {
+    size: 'small',
+    tone: 'active',
+    weight: 'link',
+  } as const
+
+  if (value.kind === 'many') {
+    const query = constructQuery({ refFieldKey, value, itemId })
+    return (
+      <Button {...commonProps} as={Link} href={`/${list.path}?${query}`}>
+        View related {list.plural}
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      {...commonProps}
+      as={Link}
+      href={`/${list.path}/${value.value?.id}`}
+    >
+      View {list.singular} details
+    </Button>
+  )
+}
+
+type Section = {
+  id: string
+  name: string
+}
+
+export const Field = ({
+  field,
+  autoFocus,
+  value,
+  onChange,
+  forceValidation,
+}: FieldProps<typeof controller>) => {
+  const keystone = useKeystone()
+  const foreignList = useList(field.refListKey)
+  const localList = useList(field.listKey)
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+
+  /**
+   * use Ref to prevent infinite re-render
+   * autofill only trigger during item creation
+   */
+  const isAssignedRef = useRef(value.id !== null)
+  const { data } = useQuery(
+    gql`
+      query GetAuthorAndSections(
+        $where: SectionWhereInput! = {}
+        $userId: ID!
+      ) {
+        sections(where: $where) {
+          id
+          name
+        }
+        user(where: { id: $userId }) {
+          author {
+            sections {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+    {
+      variables: {
+        where: { name: { equals: '即時' } },
+        // @ts-ignore: authenticatedItem.id exists
+        userId: keystone.authenticatedItem.id,
+      },
+    }
+  )
+
+  if (isAssignedRef.current === false && data) {
+    const sections: any[] = []
+    const idSet = new Set()
+
+    const iteratorFn = (item: Section) => {
+      const id = item.id
+
+      if (!idSet.has(id)) {
+        idSet.add(id)
+
+        sections.push({
+          id: item.id,
+          label: item.name,
+        })
+      }
+    }
+
+    if (Array.isArray(data.sections) && data.sections.length > 0) {
+      // set `即時` section as default
+      data.sections.forEach(iteratorFn)
+    }
+
+    if (
+      Array.isArray(data.user?.author?.sections) &&
+      data.user.author.sections.length > 0
+    ) {
+      // add user related sections
+      data.user.author.sections.forEach(iteratorFn)
+    }
+
+    const update = Object.assign({}, value)
+
+    if (sections.length > 0 && typeof onChange === 'function') {
+      Object.assign(update, {
+        ...update,
+        value: sections,
+      })
+
+      onChange(update)
+      isAssignedRef.current = true
+    }
+  }
+
+  if (value.kind === 'cards-view') {
+    return (
+      <FieldContainer as="fieldset">
+        <FieldLegend>{field.label}</FieldLegend>
+        <FieldDescription id={`${field.path}-description`}>
+          {field.description}
+        </FieldDescription>
+        <Cards
+          forceValidation={forceValidation}
+          field={field}
+          id={value.id}
+          value={value}
+          onChange={onChange}
+          foreignList={foreignList}
+          localList={localList}
+        />
+      </FieldContainer>
+    )
+  }
+
+  if (value.kind === 'count') {
+    return (
+      <Stack as="fieldset" gap="medium">
+        <FieldLegend>{field.label}</FieldLegend>
+        <FieldDescription id={`${field.path}-description`}>
+          {field.description}
+        </FieldDescription>
+        <div>
+          {value.count === 1
+            ? `There is 1 ${foreignList.singular} `
+            : `There are ${value.count} ${foreignList.plural} `}
+          linked to this {localList.singular}
+        </div>
+      </Stack>
+    )
+  }
+
+  const authenticatedItem = keystone.authenticatedItem
+
+  return (
+    <FieldContainer as="fieldset">
+      <FieldLabel as="legend">{field.label}</FieldLabel>
+      <FieldDescription id={`${field.path}-description`}>
+        {field.description}
+      </FieldDescription>
+      <Fragment>
+        <Stack gap="medium">
+          <RelationshipSelect
+            controlShouldRenderValue
+            aria-describedby={
+              field.description === null
+                ? undefined
+                : `${field.path}-description`
+            }
+            autoFocus={autoFocus}
+            isDisabled={onChange === undefined}
+            labelField={field.refLabelField}
+            searchFields={field.refSearchFields}
+            list={foreignList}
+            portalMenu
+            state={
+              value.kind === 'many'
+                ? {
+                    kind: 'many',
+                    value: value.value,
+                    onChange(newItems) {
+                      onChange?.({
+                        ...value,
+                        value: newItems,
+                      })
+                    },
+                  }
+                : {
+                    kind: 'one',
+                    value: value.value,
+                    onChange(newVal) {
+                      if (value.kind === 'one') {
+                        onChange?.({
+                          ...value,
+                          value: newVal,
+                        })
+                      }
+                    },
+                  }
+            }
+            orderBy={[{ id: 'desc' }]}
+          />
+          <Stack across gap="small">
+            {onChange !== undefined && !field.hideCreate && (
+              <Button
+                size="small"
+                disabled={isDrawerOpen}
+                onClick={() => {
+                  setIsDrawerOpen(true)
+                }}
+              >
+                Create related {foreignList.singular}
+              </Button>
+            )}
+            {onChange !== undefined &&
+              authenticatedItem.state === 'authenticated' &&
+              authenticatedItem.listKey === field.refListKey &&
+              (value.kind === 'many'
+                ? value.value.find((x) => x.id === authenticatedItem.id) ===
+                  undefined
+                : value.value?.id !== authenticatedItem.id) && (
+                <Button
+                  size="small"
+                  onClick={() => {
+                    const val = {
+                      label: authenticatedItem.label,
+                      id: authenticatedItem.id,
+                    }
+                    if (value.kind === 'many') {
+                      onChange({
+                        ...value,
+                        value: [...value.value, val],
+                      })
+                    } else {
+                      onChange({
+                        ...value,
+                        value: val,
+                      })
+                    }
+                  }}
+                >
+                  {value.kind === 'many' ? 'Add ' : 'Set as '}
+                  {authenticatedItem.label}
+                </Button>
+              )}
+            {!!(value.kind === 'many'
+              ? value.value.length
+              : value.kind === 'one' && value.value) && (
+              <LinkToRelatedItems
+                itemId={value.id}
+                refFieldKey={field.refFieldKey}
+                list={foreignList}
+                value={value}
+              />
+            )}
+          </Stack>
+        </Stack>
+        {onChange !== undefined && (
+          <DrawerController isOpen={isDrawerOpen}>
+            <CreateItemDrawer
+              listKey={foreignList.key}
+              onClose={() => {
+                setIsDrawerOpen(false)
+              }}
+              onCreate={(val) => {
+                setIsDrawerOpen(false)
+                if (value.kind === 'many') {
+                  onChange({
+                    ...value,
+                    value: [...value.value, val],
+                  })
+                } else if (value.kind === 'one') {
+                  onChange({
+                    ...value,
+                    value: val,
+                  })
+                }
+              }}
+            />
+          </DrawerController>
+        )}
+      </Fragment>
+    </FieldContainer>
+  )
+}
+
+export const Cell: CellComponent<typeof controller> = ({ field, item }) => {
+  const list = useList(field.refListKey)
+  const { colors } = useTheme()
+
+  if (field.display === 'count') {
+    const count = item[`${field.path}Count`] ?? 0
+    return (
+      <CellContainer>
+        {count} {count === 1 ? list.singular : list.plural}
+      </CellContainer>
+    )
+  }
+
+  const data = item[field.path]
+  const items = (Array.isArray(data) ? data : [data]).filter((item) => item)
+  const displayItems = items.length < 5 ? items : items.slice(0, 3)
+  const overflow = items.length < 5 ? 0 : items.length - 3
+  const styles = {
+    color: colors.foreground,
+    textDecoration: 'none',
+
+    ':hover': {
+      textDecoration: 'underline',
+    },
+  } as const
+
+  return (
+    <CellContainer>
+      {displayItems.map((item, index) => (
+        <Fragment key={item.id}>
+          {index ? ', ' : ''}
+          <Link
+            href={`/${list.path}/[id]`}
+            as={`/${list.path}/${item.id}`}
+            css={styles}
+          >
+            {item.label || item.id}
+          </Link>
+        </Fragment>
+      ))}
+      {overflow ? `, and ${overflow} more` : null}
+    </CellContainer>
+  )
+}
+
+export const CardValue: CardValueComponent<typeof controller> = ({
+  field,
+  item,
+}) => {
+  const list = useList(field.refListKey)
+  const data = item[field.path]
+  return (
+    <FieldContainer>
+      <FieldLabel>{field.label}</FieldLabel>
+      {(Array.isArray(data) ? data : [data])
+        .filter((item) => item)
+        .map((item, index) => (
+          <Fragment key={item.id}>
+            {index ? ', ' : ''}
+            <Link href={`/${list.path}/[id]`} as={`/${list.path}/${item.id}`}>
+              {item.label || item.id}
+            </Link>
+          </Fragment>
+        ))}
+    </FieldContainer>
+  )
+}
+
+type SingleRelationshipValue = {
+  kind: 'one'
+  id: null | string
+  initialValue: { label: string; id: string } | null
+  value: { label: string; id: string } | null
+}
+type ManyRelationshipValue = {
+  kind: 'many'
+  id: null | string
+  initialValue: { label: string; id: string }[]
+  value: { label: string; id: string }[]
+}
+type CardsRelationshipValue = {
+  kind: 'cards-view'
+  id: null | string
+  itemsBeingEdited: ReadonlySet<string>
+  itemBeingCreated: boolean
+  initialIds: ReadonlySet<string>
+  currentIds: ReadonlySet<string>
+  displayOptions: CardsDisplayModeOptions
+}
+type CountRelationshipValue = {
+  kind: 'count'
+  id: null | string
+  count: number
+}
+type CardsDisplayModeOptions = {
+  cardFields: readonly string[]
+  linkToItem: boolean
+  removeMode: 'disconnect' | 'none'
+  inlineCreate: { fields: readonly string[] } | null
+  inlineEdit: { fields: readonly string[] } | null
+  inlineConnect: boolean
+}
+
+type RelationshipController = FieldController<
+  | ManyRelationshipValue
+  | SingleRelationshipValue
+  | CardsRelationshipValue
+  | CountRelationshipValue,
+  string
+> & {
+  display: 'count' | 'cards-or-select'
+  listKey: string
+  refListKey: string
+  refFieldKey?: string
+  refLabelField: string
+  refSearchFields: string[]
+  hideCreate: boolean
+  many: boolean
+}
+
+export const controller = (
+  config: FieldControllerConfig<
+    {
+      refFieldKey?: string
+      refListKey: string
+      many: boolean
+      hideCreate: boolean
+      refLabelField: string
+      refSearchFields: string[]
+    } & (
+      | {
+          displayMode: 'select'
+        }
+      | {
+          displayMode: 'cards'
+          cardFields: readonly string[]
+          linkToItem: boolean
+          removeMode: 'disconnect' | 'none'
+          inlineCreate: { fields: readonly string[] } | null
+          inlineEdit: { fields: readonly string[] } | null
+          inlineConnect: boolean
+        }
+      | {
+          displayMode: 'count'
+        }
+    )
+  >
+): RelationshipController => {
+  const cardsDisplayOptions =
+    config.fieldMeta.displayMode === 'cards'
+      ? {
+          cardFields: config.fieldMeta.cardFields,
+          inlineCreate: config.fieldMeta.inlineCreate,
+          inlineEdit: config.fieldMeta.inlineEdit,
+          linkToItem: config.fieldMeta.linkToItem,
+          removeMode: config.fieldMeta.removeMode,
+          inlineConnect: config.fieldMeta.inlineConnect,
+        }
+      : undefined
+
+  const refLabelField = config.fieldMeta.refLabelField
+  const refSearchFields = config.fieldMeta.refSearchFields
+
+  return {
+    refFieldKey: config.fieldMeta.refFieldKey,
+    many: config.fieldMeta.many,
+    listKey: config.listKey,
+    path: config.path,
+    label: config.label,
+    description: config.description,
+    display:
+      config.fieldMeta.displayMode === 'count' ? 'count' : 'cards-or-select',
+    refLabelField,
+    refSearchFields,
+    refListKey: config.fieldMeta.refListKey,
+    graphqlSelection:
+      config.fieldMeta.displayMode === 'count'
+        ? `${config.path}Count`
+        : `${config.path} {
+              id
+              label: ${refLabelField}
+            }`,
+    hideCreate: config.fieldMeta.hideCreate,
+    // note we're not making the state kind: 'count' when ui.displayMode is set to 'count'.
+    // that ui.displayMode: 'count' is really just a way to have reasonable performance
+    // because our other UIs don't handle relationships with a large number of items well
+    // but that's not a problem here since we're creating a new item so we might as well them a better UI
+    defaultValue:
+      cardsDisplayOptions !== undefined
+        ? {
+            kind: 'cards-view',
+            currentIds: new Set(),
+            id: null,
+            initialIds: new Set(),
+            itemBeingCreated: false,
+            itemsBeingEdited: new Set(),
+            displayOptions: cardsDisplayOptions,
+          }
+        : config.fieldMeta.many
+        ? {
+            id: null,
+            kind: 'many',
+            initialValue: [],
+            value: [],
+          }
+        : { id: null, kind: 'one', value: null, initialValue: null },
+    deserialize: (data) => {
+      if (config.fieldMeta.displayMode === 'count') {
+        return {
+          id: data.id,
+          kind: 'count',
+          count: data[`${config.path}Count`] ?? 0,
+        }
+      }
+      if (cardsDisplayOptions !== undefined) {
+        const initialIds = new Set<string>(
+          (Array.isArray(data[config.path])
+            ? data[config.path]
+            : data[config.path]
+            ? [data[config.path]]
+            : []
+          ).map((x: any) => x.id)
+        )
+        return {
+          kind: 'cards-view',
+          id: data.id,
+          itemsBeingEdited: new Set(),
+          itemBeingCreated: false,
+          initialIds,
+          currentIds: initialIds,
+          displayOptions: cardsDisplayOptions,
+        }
+      }
+      if (config.fieldMeta.many) {
+        const value = (data[config.path] || []).map((x: any) => ({
+          id: x.id,
+          label: x.label || x.id,
+        }))
+        return {
+          kind: 'many',
+          id: data.id,
+          initialValue: value,
+          value,
+        }
+      }
+      let value = data[config.path]
+      if (value) {
+        value = {
+          id: value.id,
+          label: value.label || value.id,
+        }
+      }
+      return {
+        kind: 'one',
+        id: data.id,
+        value,
+        initialValue: value,
+      }
+    },
+    filter: {
+      Filter: ({ onChange, value }) => {
+        const foreignList = useList(config.fieldMeta.refListKey)
+        const { filterValues, loading } = useRelationshipFilterValues({
+          value,
+          list: foreignList,
+        })
+        const state: {
+          kind: 'many'
+          value: { label: string; id: string }[]
+          onChange: (newItems: { label: string; id: string }[]) => void
+        } = {
+          kind: 'many',
+          value: filterValues,
+          onChange(newItems) {
+            onChange(newItems.map((item) => item.id).join(','))
+          },
+        }
+        return (
+          <RelationshipSelect
+            controlShouldRenderValue
+            list={foreignList}
+            labelField={refLabelField}
+            searchFields={refSearchFields}
+            isLoading={loading}
+            isDisabled={onChange === undefined}
+            state={state}
+            orderBy={[{ id: 'desc' }]}
+          />
+        )
+      },
+      graphql: ({ value }) => {
+        const foreignIds = getForeignIds(value)
+        if (config.fieldMeta.many) {
+          return {
+            [config.path]: {
+              some: {
+                id: {
+                  in: foreignIds,
+                },
+              },
+            },
+          }
+        }
+        return {
+          [config.path]: {
+            id: {
+              in: foreignIds,
+            },
+          },
+        }
+      },
+      Label({ value }) {
+        const foreignList = useList(config.fieldMeta.refListKey)
+        const { filterValues } = useRelationshipFilterValues({
+          value,
+          list: foreignList,
+        })
+
+        if (!filterValues.length) {
+          return `has no value`
+        }
+        if (filterValues.length > 1) {
+          const values = filterValues.map((i: any) => i.label).join(', ')
+          return `is in [${values}]`
+        }
+        const optionLabel = filterValues[0].label
+        return `is ${optionLabel}`
+      },
+      types: {
+        matches: {
+          label: 'Matches',
+          initialValue: '',
+        },
+      },
+    },
+    validate(value) {
+      return (
+        value.kind !== 'cards-view' ||
+        (value.itemsBeingEdited.size === 0 && !value.itemBeingCreated)
+      )
+    },
+    serialize: (state) => {
+      if (state.kind === 'many') {
+        const newAllIds = new Set(state.value.map((x) => x.id))
+        const initialIds = new Set(state.initialValue.map((x) => x.id))
+        const disconnect = state.initialValue
+          .filter((x) => !newAllIds.has(x.id))
+          .map((x) => ({ id: x.id }))
+        const connect = state.value
+          .filter((x) => !initialIds.has(x.id))
+          .map((x) => ({ id: x.id }))
+        if (disconnect.length || connect.length) {
+          const output: any = {}
+
+          if (disconnect.length) {
+            output.disconnect = disconnect
+          }
+
+          if (connect.length) {
+            output.connect = connect
+          }
+
+          return {
+            [config.path]: output,
+          }
+        }
+      } else if (state.kind === 'one') {
+        if (state.initialValue && !state.value) {
+          return { [config.path]: { disconnect: true } }
+        } else if (state.value && state.value.id !== state.initialValue?.id) {
+          return {
+            [config.path]: {
+              connect: {
+                id: state.value.id,
+              },
+            },
+          }
+        }
+      } else if (state.kind === 'cards-view') {
+        const disconnect = [...state.initialIds]
+          .filter((id) => !state.currentIds.has(id))
+          .map((id) => ({ id }))
+        const connect = [...state.currentIds]
+          .filter((id) => !state.initialIds.has(id))
+          .map((id) => ({ id }))
+
+        if (config.fieldMeta.many) {
+          if (disconnect.length || connect.length) {
+            return {
+              [config.path]: {
+                connect: connect.length ? connect : undefined,
+                disconnect: disconnect.length ? disconnect : undefined,
+              },
+            }
+          }
+        } else if (connect.length) {
+          return {
+            [config.path]: {
+              connect: connect[0],
+            },
+          }
+        } else if (disconnect.length) {
+          return { [config.path]: { disconnect: true } }
+        }
+      }
+      return {}
+    },
+  }
+}
+
+function useRelationshipFilterValues({
+  value,
+  list,
+}: {
+  value: string
+  list: ListMeta
+}) {
+  const foreignIds = getForeignIds(value)
+  const where = { id: { in: foreignIds } }
+
+  const query = gql`
+    query FOREIGNLIST_QUERY($where: ${list.gqlNames.whereInputName}!) {
+      items: ${list.gqlNames.listQueryName}(where: $where) {
+        id
+        ${list.labelField}
+      }
+    }
+  `
+
+  const { data, loading } = useQuery(query, {
+    variables: {
+      where,
+    },
+  })
+
+  return {
+    filterValues:
+      data?.items?.map((item: any) => {
+        return {
+          id: item.id,
+          label: item[list.labelField] || item.id,
+        }
+      }) || foreignIds.map((f) => ({ label: f, id: f })),
+    loading: loading,
+  }
+}
+
+function getForeignIds(value: string) {
+  if (typeof value === 'string' && value.length > 0) {
+    return value.split(',')
+  }
+  return []
+}

--- a/packages/mirrordaily/lists/views/default-section-relationship/index.tsx
+++ b/packages/mirrordaily/lists/views/default-section-relationship/index.tsx
@@ -86,11 +86,6 @@ function LinkToRelatedItems({
   )
 }
 
-type Section = {
-  id: string
-  name: string
-}
-
 export const Field = ({
   field,
   autoFocus,
@@ -110,19 +105,16 @@ export const Field = ({
   const isAssignedRef = useRef(value.id !== null)
   const { data } = useQuery(
     gql`
-      query GetAuthorAndSections(
-        $where: SectionWhereInput! = {}
-        $userId: ID!
-      ) {
+      query GetSections($where: SectionWhereInput! = {}, $userId: ID!) {
         sections(where: $where) {
           id
-          name
+          label: name
         }
         user(where: { id: $userId }) {
           author {
             sections {
               id
-              name
+              label: name
             }
           }
         }
@@ -141,7 +133,7 @@ export const Field = ({
     const sections: any[] = []
     const idSet = new Set()
 
-    const iteratorFn = (item: Section) => {
+    const iteratorFn = (item: Value) => {
       const id = item.id
 
       if (!idSet.has(id)) {
@@ -149,7 +141,7 @@ export const Field = ({
 
         sections.push({
           id: item.id,
-          label: item.name,
+          label: item.label,
         })
       }
     }
@@ -419,17 +411,19 @@ export const CardValue: CardValueComponent<typeof controller> = ({
   )
 }
 
+type Value = { label: string; id: string }
+
 type SingleRelationshipValue = {
   kind: 'one'
   id: null | string
-  initialValue: { label: string; id: string } | null
-  value: { label: string; id: string } | null
+  initialValue: Value | null
+  value: Value | null
 }
 type ManyRelationshipValue = {
   kind: 'many'
   id: null | string
-  initialValue: { label: string; id: string }[]
-  value: { label: string; id: string }[]
+  initialValue: Value[]
+  value: Value[]
 }
 type CardsRelationshipValue = {
   kind: 'cards-view'
@@ -619,8 +613,8 @@ export const controller = (
         })
         const state: {
           kind: 'many'
-          value: { label: string; id: string }[]
-          onChange: (newItems: { label: string; id: string }[]) => void
+          value: Value[]
+          onChange: (newItems: Value[]) => void
         } = {
           kind: 'many',
           value: filterValues,


### PR DESCRIPTION
## Notes
* 增加 DefaultSectionRelationship 和 DefaultAuthorRelationship view，使文章建立時，在不同的建立 UI  (`/custom-post-creation` 和 `/posts/create`)皆可自動帶入數值
* 因為前者已經自動帶入數值了，移除在 `/custom-post-creation` 帶入數值的行為