### PR TITLE
fix(daily): lockBy related errors

### DIFF
--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -112,36 +112,52 @@ const itemViewFunction: MaybeItemFunction<FieldMode, ListTypeInfo> = async ({
   context,
   item,
 }) => {
+  const currentUserId = Number(session?.data?.id)
+  const currentUserRole = session?.data?.role
+
   // @ts-ignore next line
-  if ([UserRole.Moderator, UserRole.Editor].includes(session?.data?.role)) {
-    const { lockBy } = await context.prisma.Post.findUnique({
-      where: { id: Number(item.id) },
-      select: {
-        lockBy: {
-          select: {
-            id: true,
+  if ([UserRole.Moderator, UserRole.Editor].includes(currentUserRole)) {
+    const { lockBy, lockExpireAt, createdBy } =
+      await context.prisma.Post.findUnique({
+        where: { id: Number(item.id) },
+        select: {
+          lockBy: {
+            select: {
+              id: true,
+            },
+          },
+          lockExpireAt: true,
+          createdBy: {
+            select: {
+              id: true,
+            },
           },
         },
-      },
-    })
+      })
+
+    const newLockExpireAt = new Date(
+      new Date().setMinutes(new Date().getMinutes() + envVar.lockDuration, 0, 0)
+    ).toISOString()
 
     if (!lockBy) {
-      const lockExpireAt = new Date(
-        new Date().setMinutes(
-          new Date().getMinutes() + envVar.lockDuration,
-          0,
-          0
-        )
-      ).toISOString()
+      if (createdBy) {
+        if (
+          Number(createdBy.id) !== currentUserId &&
+          currentUserRole === UserRole.Editor
+        ) {
+          return 'read'
+        }
+      }
+
       const updatedPost = await context.prisma.Post.update({
         where: { id: Number(item.id) },
         data: {
           lockBy: {
             connect: {
-              id: Number(session?.data?.id),
+              id: currentUserId,
             },
           },
-          lockExpireAt: lockExpireAt,
+          lockExpireAt: newLockExpireAt,
         },
         select: {
           lockBy: {
@@ -157,6 +173,35 @@ const itemViewFunction: MaybeItemFunction<FieldMode, ListTypeInfo> = async ({
         : 'read'
     } else if (Number(lockBy.id) == Number(session?.data?.id)) {
       return 'edit'
+    } else if (new Date(lockExpireAt).valueOf() < Date.now()) {
+      // 過期的自動讓出，讓出對象為 Moderator 或者文章建立者
+      if (
+        currentUserRole === UserRole.Moderator ||
+        currentUserId === Number(createdBy?.id)
+      ) {
+        const updatedPost = await context.prisma.Post.update({
+          where: { id: Number(item.id) },
+          data: {
+            lockBy: {
+              connect: {
+                id: currentUserId,
+              },
+            },
+            lockExpireAt: newLockExpireAt,
+          },
+          select: {
+            lockBy: {
+              select: {
+                id: true,
+              },
+            },
+          },
+        })
+
+        return Number(updatedPost.lockBy?.id) === Number(session?.data?.id)
+          ? 'edit'
+          : 'read'
+      }
     }
     return 'hidden'
   }
@@ -838,20 +883,24 @@ const listConfigurations = list({
     validateInput: async ({ operation, item, context, addValidationError }) => {
       if (context.session?.data?.role !== UserRole.Admin) {
         if (operation === 'update') {
-          const { lockBy } = await context.prisma.Post.findUnique({
-            where: { id: Number(item.id) },
-            select: {
-              lockBy: {
-                select: {
-                  id: true,
+          const { lockBy, lockExpireAt } = await context.prisma.Post.findUnique(
+            {
+              where: { id: Number(item.id) },
+              select: {
+                lockBy: {
+                  select: {
+                    id: true,
+                  },
                 },
+                lockExpireAt: true,
               },
-            },
-          })
+            }
+          )
 
           if (
             lockBy?.id &&
-            Number(lockBy.id) !== Number(context.session?.data?.id)
+            Number(lockBy.id) !== Number(context.session?.data?.id) &&
+            new Date(lockExpireAt).valueOf() > Date.now()
           ) {
             addValidationError('可能有其他人正在編輯，請重新整理頁面。')
           }


### PR DESCRIPTION
## Notable Changes
* 修正與 Post list lockBy 相關的錯誤

## Notes
* 由於定期解 lock 的 cronjob 似乎尚未部屬，所以在上 lock 與解 lock 處理上，皆用 CMS 自己的方式解決。
* 寫入 lock 資訊時，如果使用者角色是 Editor，且並非文章建立者，則會被擋下
* lock 過期時，可以讓渡 lock 給角色是 Moderator 的使用者，或是文章建立者
* 驗證送出的修改訊息時，會驗證 lock 是否過期