### PR TITLE
feat(mirrormedia): related posts connections

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -789,56 +789,44 @@ const listConfigurations = list({
       const removeTwoSidedConnection =
         (inputData?.related_posts?.disconnect as { id: string }[]) ?? []
 
-      // 同步相關文章(雙向關聯) relateds
-      await Promise.all(
-        addTwoSidedConnection.map(async ({ id }) => {
-          await context.db.Post.updateOne({
+      await context.db.Post.updateMany({
+        data: [
+          // 同步相關文章(雙向關聯) relateds
+          ...addTwoSidedConnection.map(({ id }) => ({
             where: { id: `${item?.id}` },
             data: {
               relateds: {
                 connect: [{ id }],
               },
             },
-          })
-        })
-      )
-      await Promise.all(
-        removeTwoSidedConnection.map(async ({ id }) => {
-          await context.db.Post.updateOne({
+          })),
+          ...removeTwoSidedConnection.map(({ id }) => ({
             where: { id: `${item?.id}` },
             data: {
               relateds: {
                 disconnect: [{ id }],
               },
             },
-          })
-        })
-      )
-      // 將 target 文章的 relateds 關聯回 current Post
-      await Promise.all(
-        addTwoSidedConnection.map(async ({ id }) => {
-          await context.db.Post.updateOne({
+          })),
+          // 將 target 文章的 relateds 關聯回 current Post
+          ...addTwoSidedConnection.map(({ id }) => ({
             where: { id },
             data: {
               relateds: {
                 connect: [{ id: item?.id }],
               },
             },
-          })
-        })
-      )
-      await Promise.all(
-        removeTwoSidedConnection.map(async ({ id }) => {
-          await context.db.Post.updateOne({
+          })),
+          ...removeTwoSidedConnection.map(({ id }) => ({
             where: { id },
             data: {
               relateds: {
                 disconnect: [{ id: item?.id }],
               },
             },
-          })
-        })
-      )
+          })),
+        ],
+      })
     },
   },
 })

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -445,13 +445,21 @@ const listConfigurations = list({
         views: './lists/views/sorted-relationship/index',
       },
     }),
-    relateds: relationship({
+    related_posts: relationship({
       label: '相關文章',
       ref: 'Post',
       many: true,
+    }),
+    related_posts_order: json({
+      label: '相關文章順序',
       ui: {
-        views: './lists/views/sorted-relationship/index',
+        views: './lists/views/related-posts-order/index',
       },
+    }),
+    relateds: relationship({
+      label: '相關文章(雙向關聯)',
+      ref: 'Post',
+      many: true,
     }),
     from_External_relateds: relationship({
       label: '相關外部文章(發佈後由演算法自動計算)',
@@ -480,6 +488,10 @@ const listConfigurations = list({
     manualOrderOfRelateds: json({
       label: '相關文章手動排序結果',
       isFilterable: false,
+      ui: {
+        itemView: { fieldMode: 'hidden' },
+        createView: { fieldMode: 'hidden' },
+      },
     }),
     tags: relationship({
       label: '標籤',
@@ -741,6 +753,7 @@ const listConfigurations = list({
         resolvedData.updatedAt = new Date()
         resolvedData.updateTimeStamp = false
       }
+
       return resolvedData
     },
     beforeOperation: async ({ operation, resolvedData }) => {
@@ -769,88 +782,63 @@ const listConfigurations = list({
       }
       return
     },
-    afterOperation: async ({ operation, inputData, item, context }) => {
-      if (operation === 'update') {
-        await context.prisma.post.update({
-          where: { id: Number(item.id) },
-          data: {
-            lockBy: { disconnect: true },
-            lockExpireAt: null,
-          },
-        })
-      }
+    afterOperation: async ({ inputData, item, context }) => {
+      // 取出 user 所設定的相關文章 related_posts
+      const addTwoSidedConnection =
+        (inputData?.related_posts?.connect as { id: string }[]) ?? []
+      const removeTwoSidedConnection =
+        (inputData?.related_posts?.disconnect as { id: string }[]) ?? []
 
-      if (operation === 'delete') return
-
-      const itemId = Number(item?.id)
-
-      const updatePostRelations = async (
-        postIds: string[],
-        operation: 'connect' | 'disconnect'
-      ) => {
-        // 檢查被更新的相關文章
-        const posts = await context.prisma.Post.findMany({
-          where: { id: { in: postIds.map(Number) } },
-          select: {
-            id: true,
-            relateds: {
-              select: {
-                id: true,
+      // 同步相關文章(雙向關聯) relateds
+      await Promise.all(
+        addTwoSidedConnection.map(async ({ id }) => {
+          await context.db.Post.updateOne({
+            where: { id: `${item?.id}` },
+            data: {
+              relateds: {
+                connect: [{ id }],
               },
             },
-          },
+          })
         })
-
-        // 刪掉已經有連結 or 已經沒有連結的
-        const postsToUpdate = posts.filter((post: any) => {
-          const hasRelated = post?.relateds?.some(
-            (post: any) => Number(post.id) === itemId
-          )
-          return operation === 'connect' ? !hasRelated : hasRelated
+      )
+      await Promise.all(
+        removeTwoSidedConnection.map(async ({ id }) => {
+          await context.db.Post.updateOne({
+            where: { id: `${item?.id}` },
+            data: {
+              relateds: {
+                disconnect: [{ id }],
+              },
+            },
+          })
         })
-
-        if (postsToUpdate.length) {
-          const results = await Promise.allSettled(
-            postsToUpdate.map((post: any) =>
-              context.prisma.Post.update({
-                where: {
-                  id: Number(post.id),
-                },
-                data: {
-                  relateds: {
-                    [operation]: {
-                      id: itemId,
-                    },
-                  },
-                },
-              })
-            )
-          )
-
-          results.forEach((result) =>
-            result.status === 'rejected'
-              ? console.error(result.reason)
-              : undefined
-          )
-        }
-      }
-
-      const { relateds = {} } = inputData
-      const connect = relateds?.connect
-      const disconnect = relateds?.disconnect
-
-      if (connect && itemId) {
-        updatePostRelations(
-          connect.map((post: any) => post.id),
-          'connect'
-        )
-      }
-      if (disconnect && itemId) {
-        updatePostRelations(
-          disconnect.map((post: any) => post.id),
-          'disconnect'
-        )
-      }
+      )
+      // 將 target 文章的 relateds 關聯回 current Post
+      await Promise.all(
+        addTwoSidedConnection.map(async ({ id }) => {
+          await context.db.Post.updateOne({
+            where: { id },
+            data: {
+              relateds: {
+                connect: [{ id: item?.id }],
+              },
+            },
+          })
+        })
+      )
+      await Promise.all(
+        removeTwoSidedConnection.map(async ({ id }) => {
+          await context.db.Post.updateOne({
+            where: { id },
+            data: {
+              relateds: {
+                disconnect: [{ id: item?.id }],
+              },
+            },
+          })
+        })
+      )
     },
   },
 })

--- a/packages/mirrormedia/lists/views/related-posts-order/index.tsx
+++ b/packages/mirrormedia/lists/views/related-posts-order/index.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState, Fragment } from 'react'
+import { FieldContainer, FieldLabel, MultiSelect } from '@keystone-ui/fields'
+import type {
+  FieldProps,
+  FieldControllerConfig,
+  CellComponent,
+} from '@keystone-6/core/types'
+import { useList } from '@keystone-6/core/admin-ui/context'
+import { Link } from '@keystone-6/core/admin-ui/router'
+import { CellContainer } from '@keystone-6/core/admin-ui/components'
+import { useQuery, gql } from '@keystone-6/core/admin-ui/apollo'
+import { useTheme } from '@keystone-ui/core'
+
+const RELATED_POSTS_QUERY = gql`
+  query {
+    posts {
+      id
+      slug
+    }
+  }
+`
+
+type RelatedPostsQueryData = {
+  posts: {
+    id: string
+    slug: string
+  }[]
+}
+
+type Selection = {
+  label: string
+  value: string
+}
+
+export const Field = ({
+  value,
+  onChange,
+  autoFocus,
+  field,
+}: FieldProps<typeof controller>) => {
+  const { data, error, loading } =
+    useQuery<RelatedPostsQueryData>(RELATED_POSTS_QUERY)
+  const [options, setOptions] = useState<Selection[]>([])
+
+  useEffect(() => {
+    if (data?.posts) {
+      const formatted = data.posts.map(({ id, slug }) => ({
+        label: slug,
+        value: id,
+      }))
+      setOptions(formatted)
+    }
+  }, [data])
+
+  if (loading) {
+    return <div>Loading...</div>
+  }
+
+  if (error) {
+    return <div>Error loading posts: {error.message}</div>
+  }
+
+  return (
+    <FieldContainer>
+      <FieldLabel>{field.label}</FieldLabel>
+      <MultiSelect
+        options={options}
+        value={((value as RelatedPostsQueryData['posts']) || []).map(
+          (post) => ({
+            label: post.slug,
+            value: post.id,
+          })
+        )}
+        onChange={(newValue) => {
+          onChange?.(
+            newValue.map((item) => ({ id: item.value, slug: item.label }))
+          )
+        }}
+        autoFocus={autoFocus}
+      />
+    </FieldContainer>
+  )
+}
+
+export const Cell: CellComponent<typeof controller> = ({ item, field }) => {
+  const value = item[field.path] ?? []
+  const list = useList(field.refListKey)
+  const { colors, spacing } = useTheme()
+
+  return (
+    <CellContainer>
+      {value.map((post: { id: string; slug: string }) => (
+        <Fragment key={post.id}>
+          <Link
+            style={{
+              color: colors.foreground,
+              display: 'block',
+              padding: spacing.xxsmall,
+              textDecoration: 'none',
+            }}
+            onMouseOver={(e) => {
+              e.currentTarget.style.textDecoration = 'underline'
+              e.currentTarget.style.color = colors.linkHoverColor
+            }}
+            onMouseOut={(e) => {
+              e.currentTarget.style.textDecoration = 'none'
+              e.currentTarget.style.color = colors.foreground
+            }}
+            href={`/${list.path}/${post.id}`}
+          >
+            {post.slug}
+          </Link>
+        </Fragment>
+      ))}
+    </CellContainer>
+  )
+}
+
+Cell.supportsLinkTo = true
+
+export const controller = (config: FieldControllerConfig) => ({
+  path: config.path,
+  label: config.label,
+  graphqlSelection: config.path,
+  defaultValue: [],
+  description: config.description || '',
+  deserialize: (data: Record<string, unknown>) =>
+    Array.isArray(data[config.path]) ? data[config.path] : [],
+  serialize: (value: RelatedPostsQueryData['posts']) => ({
+    [config.path]: value,
+  }),
+  refListKey: config.listKey,
+})

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -1341,6 +1341,9 @@ type Post {
   isMember: Boolean
   memberFeed: Boolean
   topics: Topic
+  related_posts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
+  related_postsCount(where: PostWhereInput! = {}): Int
+  related_posts_order: JSON
   relateds(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
   relatedsCount(where: PostWhereInput! = {}): Int
   from_External_relateds(where: ExternalWhereInput! = {}, orderBy: [ExternalOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ExternalWhereUniqueInput): [External!]
@@ -1412,6 +1415,7 @@ input PostWhereInput {
   isMember: BooleanFilter
   memberFeed: BooleanFilter
   topics: TopicWhereInput
+  related_posts: PostManyRelationFilter
   relateds: PostManyRelationFilter
   tags: TagManyRelationFilter
   og_title: StringFilter
@@ -1499,6 +1503,8 @@ input PostUpdateInput {
   isMember: Boolean
   memberFeed: Boolean
   topics: TopicRelateToOneForUpdateInput
+  related_posts: PostRelateToManyForUpdateInput
+  related_posts_order: JSON
   relateds: PostRelateToManyForUpdateInput
   from_External_relateds: ExternalRelateToManyForUpdateInput
   groups: GroupRelateToManyForUpdateInput
@@ -1601,6 +1607,8 @@ input PostCreateInput {
   isMember: Boolean
   memberFeed: Boolean
   topics: TopicRelateToOneForCreateInput
+  related_posts: PostRelateToManyForCreateInput
+  related_posts_order: JSON
   relateds: PostRelateToManyForCreateInput
   from_External_relateds: ExternalRelateToManyForCreateInput
   groups: GroupRelateToManyForCreateInput

--- a/packages/mirrormedia/schema.prisma
+++ b/packages/mirrormedia/schema.prisma
@@ -340,6 +340,8 @@ model Post {
   memberFeed                 Boolean        @default(false)
   topics                     Topic?         @relation("Post_topics", fields: [topicsId], references: [id])
   topicsId                   Int?           @map("topics")
+  related_posts              Post[]         @relation("Post_related_posts")
+  related_posts_order        Json?
   relateds                   Post[]         @relation("Post_relateds")
   from_External_relateds     External[]     @relation("External_relateds")
   groups                     Group[]        @relation("Group_posts")
@@ -368,6 +370,7 @@ model Post {
   updatedBy                  User?          @relation("Post_updatedBy", fields: [updatedById], references: [id])
   updatedById                Int?           @map("updatedBy")
   from_EditorChoice_choices  EditorChoice[] @relation("EditorChoice_choices")
+  from_Post_related_posts    Post[]         @relation("Post_related_posts")
   from_Post_relateds         Post[]         @relation("Post_relateds")
 
   @@index([lockById])


### PR DESCRIPTION
## Notable Change
- 新增使用者操作「相關文章」為單向關聯 `related_posts`
- 新增使用者設定「相關文章」的順序 `related_posts_order`
- 同步單向關聯 `related_posts` 和 雙向關聯 `relateds` (待PM驗收後會隱藏 `relateds`)
- 因 `relationship()` 沒有 order control, 因此須由 client-side fetch data 後做 `related_posts/relateds` 和 `related_posts_order` 處理顯示排序邏輯

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209933674266086
  - https://app.asana.com/0/0/1209945127522883