### PR TITLE
fix: external page sections load failed

### DIFF
--- a/packages/mirrordaily/lists/External.ts
+++ b/packages/mirrordaily/lists/External.ts
@@ -103,7 +103,7 @@ const listConfigurations = list({
       many: true,
       ui: {
         labelField: 'name',
-        views: './lists/views/post/sections/index',
+        // views: './lists/views/post/sections/index',
       },
     }),
     categories: relationship({


### PR DESCRIPTION
先暫時解掉 external 單篇文章 load failed 問題，大分類會回到無法自定義排序（之前實驗此功能留下的），若確認有需要自定義排序，再改用 `sectionsInInputOrder` 應該能解