### PR TITLE
refactor(mirrortv): allow multiple nulls in Category sortOrder and sync schema

### DIFF
--- a/packages/mirrortv/lists/Category.ts
+++ b/packages/mirrortv/lists/Category.ts
@@ -13,8 +13,25 @@ const listConfigurations = list({
   fields: {
     sortOrder: integer({
       label: '排序順位',
-      isIndexed: 'unique',
+      isIndexed: true,
       validation: { isRequired: false },
+      hooks: {
+        validateInput: async ({
+          resolvedData,
+          addValidationError,
+          context,
+        }) => {
+          const { sortOrder } = resolvedData
+          if (sortOrder !== null && sortOrder !== undefined) {
+            const existing = await context.db.Category.findMany({
+              where: { sortOrder: { equals: sortOrder } },
+            })
+            if (existing.length > 0) {
+              addValidationError('排序順位不能重複！')
+            }
+          }
+        },
+      },
     }),
 
     slug: text({

--- a/packages/mirrortv/migrations/20260123041029_remove_unique_from_sort_order/migration.sql
+++ b/packages/mirrortv/migrations/20260123041029_remove_unique_from_sort_order/migration.sql
@@ -1,0 +1,8 @@
+-- DropIndex
+DROP INDEX "Category_sortOrder_key";
+
+-- AlterTable
+ALTER TABLE "Category" ALTER COLUMN "sortOrder" DROP NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "Category_sortOrder_idx" ON "Category"("sortOrder");

--- a/packages/mirrortv/schema.graphql
+++ b/packages/mirrortv/schema.graphql
@@ -413,7 +413,6 @@ type Category {
 
 input CategoryWhereUniqueInput {
   id: ID
-  sortOrder: Int
   slug: String
 }
 

--- a/packages/mirrortv/schema.prisma
+++ b/packages/mirrortv/schema.prisma
@@ -70,7 +70,7 @@ model Audio {
 
 model Category {
   id                       Int        @id @default(autoincrement())
-  sortOrder                Int?       @unique
+  sortOrder                Int?
   slug                     String     @unique @default("")
   name                     String     @default("")
   ogTitle                  String     @default("")
@@ -91,6 +91,7 @@ model Category {
   from_Topic_categories    Topic[]    @relation("Topic_categories")
   from_Video_categories    Video[]    @relation("Video_categories")
 
+  @@index([sortOrder])
   @@index([ogImageId])
   @@index([createdById])
   @@index([updatedById])


### PR DESCRIPTION
#### 修改內容
- 調整 `sortOrder` 的唯一索引（Unique Index），確保輸入數值不可重複，且允許空值