### PR TITLE
feat(mirrordaily): add isPromoted to Topic and auto-update Topic timestamp

### DIFF
--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -1109,6 +1109,34 @@ const listConfigurations = list({
       return
     },
     afterOperation: async ({ operation, item, context, resolvedData }) => {
+      // 更新 Topic 的 updatedAt
+      if (operation === 'update' || operation === 'create') {
+        if (resolvedData?.topics) {
+          const topicIds = []
+
+          if (resolvedData.topics.connect) {
+            if (Array.isArray(resolvedData.topics.connect)) {
+              topicIds.push(
+                ...resolvedData.topics.connect.map((t: any) => t.id)
+              )
+            } else {
+              topicIds.push(resolvedData.topics.connect.id)
+            }
+          }
+
+          // 更新所有相關的 topics
+          if (topicIds.length > 0) {
+            await Promise.all(
+              topicIds.map((topicId: number) =>
+                context.prisma.topic.update({
+                  where: { id: topicId },
+                  data: { updatedAt: new Date() },
+                })
+              )
+            )
+          }
+        }
+      }
       if (item?.topicsId) {
         const result = fetch(
           envVar.topicServiceApi + '?topic_id=' + item?.topicsId,

--- a/packages/mirrordaily/lists/Topic.ts
+++ b/packages/mirrordaily/lists/Topic.ts
@@ -220,6 +220,9 @@ const listConfigurations = list({
     isFeatured: checkbox({
       label: '置頂',
     }),
+    isPromoted: checkbox({
+      label: '推廣區',
+    }),
     title_style: select({
       label: '專題樣式',
       options: [{ label: 'Feature', value: 'feature' }],

--- a/packages/mirrordaily/migrations/20260202035237_add_is_promoted_to_topic/migration.sql
+++ b/packages/mirrordaily/migrations/20260202035237_add_is_promoted_to_topic/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Topic" ADD COLUMN     "isPromoted" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/mirrordaily/schema.graphql
+++ b/packages/mirrordaily/schema.graphql
@@ -1205,6 +1205,7 @@ type Post {
   state: String
   publishedDate: DateTime
   updateTimeStamp: Boolean
+  pv: Int
   preview: JSON
   isFeatured: Boolean
   isAdvertised: Boolean
@@ -1218,7 +1219,6 @@ type Post {
   css: String
   apiDataBrief: JSON
   apiData: JSON
-  pv: Int
   publishedDateString: String
   trimmedApiData: JSON
   createdAt: DateTime
@@ -1265,6 +1265,7 @@ input PostWhereInput {
   og_title: StringFilter
   state: StringNullableFilter
   publishedDate: DateTimeFilter
+  pv: IntNullableFilter
   isFeatured: BooleanFilter
   isAdvertised: BooleanFilter
   hiddenAdvertised: BooleanFilter
@@ -1274,7 +1275,6 @@ input PostWhereInput {
   redirect: StringFilter
   adTrace: StringFilter
   css: StringFilter
-  pv: IntNullableFilter
   publishedDateString: StringFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
@@ -1308,6 +1308,7 @@ input PostOrderByInput {
   state: OrderDirection
   publishedDate: OrderDirection
   updateTimeStamp: OrderDirection
+  pv: OrderDirection
   isFeatured: OrderDirection
   isAdvertised: OrderDirection
   hiddenAdvertised: OrderDirection
@@ -1315,7 +1316,6 @@ input PostOrderByInput {
   redirect: OrderDirection
   adTrace: OrderDirection
   css: OrderDirection
-  pv: OrderDirection
   publishedDateString: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
@@ -1365,6 +1365,7 @@ input PostUpdateInput {
   state: String
   publishedDate: DateTime
   updateTimeStamp: Boolean
+  pv: Int
   isFeatured: Boolean
   isAdvertised: Boolean
   hiddenAdvertised: Boolean
@@ -1376,7 +1377,6 @@ input PostUpdateInput {
   css: String
   apiDataBrief: JSON
   apiData: JSON
-  pv: Int
   publishedDateString: String
   createdAt: DateTime
   updatedAt: DateTime
@@ -1466,6 +1466,7 @@ input PostCreateInput {
   state: String
   publishedDate: DateTime
   updateTimeStamp: Boolean
+  pv: Int
   isFeatured: Boolean
   isAdvertised: Boolean
   hiddenAdvertised: Boolean
@@ -1477,7 +1478,6 @@ input PostCreateInput {
   css: String
   apiDataBrief: JSON
   apiData: JSON
-  pv: Int
   publishedDateString: String
   createdAt: DateTime
   updatedAt: DateTime
@@ -1774,6 +1774,7 @@ type Topic {
   externalsCount(where: ExternalWhereInput! = {}): Int
   style: String
   isFeatured: Boolean
+  isPromoted: Boolean
   title_style: String
   sections(where: SectionWhereInput! = {}, orderBy: [SectionOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: SectionWhereUniqueInput): [Section!]
   sectionsCount(where: SectionWhereInput! = {}): Int
@@ -1816,6 +1817,7 @@ input TopicWhereInput {
   externals: ExternalManyRelationFilter
   style: StringFilter
   isFeatured: BooleanFilter
+  isPromoted: BooleanFilter
   title_style: StringNullableFilter
   sections: SectionManyRelationFilter
   javascript: StringFilter
@@ -1847,6 +1849,7 @@ input TopicOrderByInput {
   type: OrderDirection
   style: OrderDirection
   isFeatured: OrderDirection
+  isPromoted: OrderDirection
   title_style: OrderDirection
   javascript: OrderDirection
   dfp: OrderDirection
@@ -1878,6 +1881,7 @@ input TopicUpdateInput {
   externals: ExternalRelateToManyForUpdateInput
   style: String
   isFeatured: Boolean
+  isPromoted: Boolean
   title_style: String
   sections: SectionRelateToManyForUpdateInput
   javascript: String
@@ -1924,6 +1928,7 @@ input TopicCreateInput {
   externals: ExternalRelateToManyForCreateInput
   style: String
   isFeatured: Boolean
+  isPromoted: Boolean
   title_style: String
   sections: SectionRelateToManyForCreateInput
   javascript: String

--- a/packages/mirrordaily/schema.prisma
+++ b/packages/mirrordaily/schema.prisma
@@ -313,6 +313,7 @@ model Post {
   state                      String?        @default("draft")
   publishedDate              DateTime       @default(now())
   updateTimeStamp            Boolean        @default(true)
+  pv                         Int?           @default(0)
   isFeatured                 Boolean        @default(false)
   isAdvertised               Boolean        @default(false)
   hiddenAdvertised           Boolean        @default(false)
@@ -325,7 +326,6 @@ model Post {
   css                        String         @default("")
   apiDataBrief               Json?
   apiData                    Json?
-  pv                         Int?           @default(0)
   publishedDateString        String         @default("")
   createdAt                  DateTime?
   updatedAt                  DateTime?
@@ -353,8 +353,8 @@ model Post {
   @@index([og_imageId])
   @@index([state])
   @@index([publishedDate])
-  @@index([WarningId])
   @@index([pv])
+  @@index([WarningId])
   @@index([createdById])
   @@index([updatedById])
 }
@@ -440,6 +440,7 @@ model Topic {
   externals                    External[] @relation("External_topics")
   style                        String     @default("")
   isFeatured                   Boolean    @default(false)
+  isPromoted                   Boolean    @default(false)
   title_style                  String?    @default("feature")
   sections                     Section[]  @relation("Section_topics")
   javascript                   String     @default("")


### PR DESCRIPTION
#### Changes
- 在 `Topic` 新增 `isPromoted`（推廣區）欄位
- 當 `Post` 關聯到 `Topic` 時，自動更新 `Topic` 的 `updatedAt`