### PR TITLE
feat(mirrortv): add video auto-timestamp and update post editor permissions

### DIFF
--- a/packages/mirrortv/lists/Post.ts
+++ b/packages/mirrortv/lists/Post.ts
@@ -421,7 +421,7 @@ const listConfigurations = list({
   access: {
     operation: {
       query: allowRoles(admin, moderator, editor, contributor, owner),
-      update: allowRoles(admin, moderator, editor, contributor, owner),
+      update: allowRoles(admin, moderator, contributor, owner),
       create: allowRoles(admin, moderator, editor, contributor),
       delete: allowRoles(admin, moderator),
     },

--- a/packages/mirrortv/lists/Video.ts
+++ b/packages/mirrortv/lists/Video.ts
@@ -138,6 +138,11 @@ const listConfigurations = list({
     publishTime: timestamp({
       label: '發佈時間',
     }),
+    updateTimeStamp: checkbox({
+      label: '下次存檔時自動更改成「現在時間」',
+      isFilterable: false,
+      defaultValue: true,
+    }),
 
     fileDuration: virtual({
       label: '影片檔案時長',
@@ -249,6 +254,21 @@ const listConfigurations = list({
 
     resolveInput: async ({ resolvedData, item }) => {
       const inputData = { ...resolvedData }
+
+      // 自動更新時間邏輯
+      const updateTimeStamp = inputData.updateTimeStamp
+      const publishTime = inputData.publishTime
+
+      if (updateTimeStamp === true) {
+        const now = new Date()
+        now.setSeconds(0, 0)
+        inputData.publishTime = now.toISOString()
+        inputData.updateTimeStamp = false
+      } else if (publishTime) {
+        const customDate = new Date(publishTime)
+        customDate.setSeconds(0, 0)
+        inputData.publishTime = customDate.toISOString()
+      }
 
       if (inputData.youtubeUrl === undefined) {
         return inputData

--- a/packages/mirrortv/migrations/20260204080247_video_update_timestamp_field/migration.sql
+++ b/packages/mirrortv/migrations/20260204080247_video_update_timestamp_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Video" ADD COLUMN     "updateTimeStamp" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/mirrortv/schema.graphql
+++ b/packages/mirrortv/schema.graphql
@@ -2707,6 +2707,7 @@ type Video {
   tagsCount(where: TagWhereInput! = {}): Int
   state: String
   publishTime: DateTime
+  updateTimeStamp: Boolean
   fileDuration: String
   youtubeDuration: String
   videoSrc: String
@@ -2761,6 +2762,7 @@ input VideoOrderByInput {
   youtubeDuration_internal: OrderDirection
   state: OrderDirection
   publishTime: OrderDirection
+  updateTimeStamp: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
@@ -2783,6 +2785,7 @@ input VideoUpdateInput {
   tags: TagRelateToManyForUpdateInput
   state: String
   publishTime: DateTime
+  updateTimeStamp: Boolean
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
@@ -2812,6 +2815,7 @@ input VideoCreateInput {
   tags: TagRelateToManyForCreateInput
   state: String
   publishTime: DateTime
+  updateTimeStamp: Boolean
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput

--- a/packages/mirrortv/schema.prisma
+++ b/packages/mirrortv/schema.prisma
@@ -745,6 +745,7 @@ model Video {
   tags                     Tag[]      @relation("Video_tags")
   state                    String?    @default("draft")
   publishTime              DateTime?
+  updateTimeStamp          Boolean    @default(true)
   createdAt                DateTime?
   updatedAt                DateTime?
   createdBy                User?      @relation("Video_createdBy", fields: [createdById], references: [id])


### PR DESCRIPTION
#### Changes:
- `lists/Video.ts`: 新增時間更新邏輯與欄位
- `lists/Post.ts`: 修改 Editor 更新權限
- `schema.prisma & schema.graphql & migration`: 更新資料庫與 GraphQL Schema