### PR TITLE
feat(mirrordaily): add afterOperation hook to trigger JSON regeneration

### DIFF
--- a/packages/mirrordaily/environment-variables.ts
+++ b/packages/mirrordaily/environment-variables.ts
@@ -30,6 +30,7 @@ const {
   INVALID_CDN_CACHE_SERVER_URL,
   YOUTUBE_API_KEY,
   TOPIC_SERVICE_URL,
+  PROMOTE_TOPIC_SERVICE_URL,
 } = process.env
 
 enum DatabaseProvider {
@@ -98,6 +99,7 @@ export default {
   dataServiceApi: DATA_SERVICE_API,
   topicServiceApi: TOPIC_SERVICE_API,
   topicServiceUrl: TOPIC_SERVICE_URL,
+  promoteTopicServiceUrl: PROMOTE_TOPIC_SERVICE_URL,
   autotagging: AUTO_TAGGING || 'false',
   invalidateCDNCacheServerURL: INVALID_CDN_CACHE_SERVER_URL,
   youtube: {


### PR DESCRIPTION
#### Change:
- afterOperation hook 增加只要變動涉及 published 狀態會觸發 API 重新產生 JSON