### PR TITLE
feat(mirrormedia): add PromoteTopic list with order validation and auto-archive

### DIFF
--- a/packages/mirrormedia/lists/PromoteTopic.ts
+++ b/packages/mirrormedia/lists/PromoteTopic.ts
@@ -1,0 +1,119 @@
+import { utils } from '@mirrormedia/lilith-core'
+import { list } from '@keystone-6/core'
+import { relationship, select, integer } from '@keystone-6/core/fields'
+import { State } from '../type'
+
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+enum PromoteTopicState {
+  Draft = State.Draft,
+  Published = State.Published,
+  Archived = State.Archived,
+}
+
+const listConfigurations = list({
+  fields: {
+    order: integer({
+      label: '排序',
+      isIndexed: 'unique',
+      validation: {
+        min: 1,
+        max: 9999,
+      },
+    }),
+    topics: relationship({
+      label: '精選專題',
+      ref: 'Topic',
+      ui: {
+        views: './lists/views/sorted-relationship/index',
+        labelField: 'name',
+      },
+    }),
+    state: select({
+      label: '狀態',
+      options: [
+        { label: '草稿', value: PromoteTopicState.Draft },
+        { label: '已上線', value: PromoteTopicState.Published },
+        { label: '已下線', value: PromoteTopicState.Archived },
+      ],
+      defaultValue: PromoteTopicState.Draft,
+      isIndexed: true,
+    }),
+  },
+  ui: {
+    labelField: 'id',
+    listView: {
+      initialColumns: ['id', 'order', 'topics', 'state'],
+      initialSort: { field: 'id', direction: 'DESC' },
+      pageSize: 50,
+    },
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator, editor),
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  },
+  hooks: {
+    validateInput: async ({
+      resolvedData,
+      addValidationError,
+      context,
+      item,
+    }) => {
+      const { order } = resolvedData || {}
+      if (order !== undefined) {
+        const existingCount = await context.query.PromoteTopic.count({
+          where: {
+            order: { equals: order },
+            id: { not: { equals: item?.id } },
+          },
+        })
+        if (existingCount > 0) {
+          addValidationError(`Order ${order} is already in use.`)
+        }
+      }
+    },
+
+    // 只能有三個 topic 是已上線狀態的
+    beforeOperation: async ({ operation, resolvedData, item, context }) => {
+      const { state: newState } = resolvedData || {}
+      const oldState = item?.state
+
+      const isTurningPublished =
+        (operation === 'create' && newState === PromoteTopicState.Published) ||
+        (operation === 'update' &&
+          newState === PromoteTopicState.Published &&
+          oldState !== PromoteTopicState.Published)
+
+      if (isTurningPublished) {
+        const publishedItems = await context.query.PromoteTopic.findMany({
+          where: { state: { equals: 'published' } },
+          orderBy: { updatedAt: 'asc' },
+          query: 'id',
+        })
+
+        if (publishedItems.length >= 3) {
+          const numToArchive = publishedItems.length - 2
+          const itemsToArchive = publishedItems.slice(
+            0,
+            Math.max(0, numToArchive)
+          )
+
+          for (const targetItem of itemsToArchive) {
+            await context.db.PromoteTopic.updateOne({
+              where: { id: targetItem.id },
+              data: { state: PromoteTopicState.Archived },
+            })
+            console.log(
+              `[PromoteTopic] Limit reached. Auto-archived item ID: ${targetItem.id}`
+            )
+          }
+        }
+      }
+    },
+  },
+})
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/mirrormedia/lists/index.ts
+++ b/packages/mirrormedia/lists/index.ts
@@ -18,6 +18,7 @@ import Header from './Header'
 import Group from './Group'
 import AnnouncementScope from './AnnouncementScope'
 import Announcement from './Announcement'
+import PromoteTopic from './PromoteTopic'
 
 export const listDefinition = {
   AudioFile: Audio,
@@ -34,6 +35,7 @@ export const listDefinition = {
   Partner,
   Photo: Image,
   Post,
+  PromoteTopic,
   Section,
   Tag,
   Topic,

--- a/packages/mirrormedia/migrations/20260410022008_add_promote_topic_list/migration.sql
+++ b/packages/mirrormedia/migrations/20260410022008_add_promote_topic_list/migration.sql
@@ -1,0 +1,37 @@
+-- CreateTable
+CREATE TABLE "PromoteTopic" (
+    "id" SERIAL NOT NULL,
+    "order" INTEGER,
+    "topics" INTEGER,
+    "state" TEXT DEFAULT 'draft',
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "PromoteTopic_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PromoteTopic_order_key" ON "PromoteTopic"("order");
+
+-- CreateIndex
+CREATE INDEX "PromoteTopic_topics_idx" ON "PromoteTopic"("topics");
+
+-- CreateIndex
+CREATE INDEX "PromoteTopic_state_idx" ON "PromoteTopic"("state");
+
+-- CreateIndex
+CREATE INDEX "PromoteTopic_createdBy_idx" ON "PromoteTopic"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "PromoteTopic_updatedBy_idx" ON "PromoteTopic"("updatedBy");
+
+-- AddForeignKey
+ALTER TABLE "PromoteTopic" ADD CONSTRAINT "PromoteTopic_topics_fkey" FOREIGN KEY ("topics") REFERENCES "Topic"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PromoteTopic" ADD CONSTRAINT "PromoteTopic_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PromoteTopic" ADD CONSTRAINT "PromoteTopic_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -1787,6 +1787,69 @@ input VideoRelateToManyForCreateInput {
   connect: [VideoWhereUniqueInput!]
 }
 
+type PromoteTopic {
+  id: ID!
+  order: Int
+  topics: Topic
+  state: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+input PromoteTopicWhereUniqueInput {
+  id: ID
+  order: Int
+}
+
+input PromoteTopicWhereInput {
+  AND: [PromoteTopicWhereInput!]
+  OR: [PromoteTopicWhereInput!]
+  NOT: [PromoteTopicWhereInput!]
+  id: IDFilter
+  order: IntNullableFilter
+  topics: TopicWhereInput
+  state: StringNullableFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input PromoteTopicOrderByInput {
+  id: OrderDirection
+  order: OrderDirection
+  state: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input PromoteTopicUpdateInput {
+  order: Int
+  topics: TopicRelateToOneForUpdateInput
+  state: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input PromoteTopicUpdateArgs {
+  where: PromoteTopicWhereUniqueInput!
+  data: PromoteTopicUpdateInput!
+}
+
+input PromoteTopicCreateInput {
+  order: Int
+  topics: TopicRelateToOneForCreateInput
+  state: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
 type Section {
   id: ID!
   name: String
@@ -2523,6 +2586,12 @@ type Mutation {
   updatePosts(data: [PostUpdateArgs!]!): [Post]
   deletePost(where: PostWhereUniqueInput!): Post
   deletePosts(where: [PostWhereUniqueInput!]!): [Post]
+  createPromoteTopic(data: PromoteTopicCreateInput!): PromoteTopic
+  createPromoteTopics(data: [PromoteTopicCreateInput!]!): [PromoteTopic]
+  updatePromoteTopic(where: PromoteTopicWhereUniqueInput!, data: PromoteTopicUpdateInput!): PromoteTopic
+  updatePromoteTopics(data: [PromoteTopicUpdateArgs!]!): [PromoteTopic]
+  deletePromoteTopic(where: PromoteTopicWhereUniqueInput!): PromoteTopic
+  deletePromoteTopics(where: [PromoteTopicWhereUniqueInput!]!): [PromoteTopic]
   createSection(data: SectionCreateInput!): Section
   createSections(data: [SectionCreateInput!]!): [Section]
   updateSection(where: SectionWhereUniqueInput!, data: SectionUpdateInput!): Section
@@ -2625,6 +2694,9 @@ type Query {
   posts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
   post(where: PostWhereUniqueInput!): Post
   postsCount(where: PostWhereInput! = {}): Int
+  promoteTopics(where: PromoteTopicWhereInput! = {}, orderBy: [PromoteTopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PromoteTopicWhereUniqueInput): [PromoteTopic!]
+  promoteTopic(where: PromoteTopicWhereUniqueInput!): PromoteTopic
+  promoteTopicsCount(where: PromoteTopicWhereInput! = {}): Int
   sections(where: SectionWhereInput! = {}, orderBy: [SectionOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: SectionWhereUniqueInput): [Section!]
   section(where: SectionWhereUniqueInput!): Section
   sectionsCount(where: SectionWhereInput! = {}): Int

--- a/packages/mirrormedia/schema.prisma
+++ b/packages/mirrormedia/schema.prisma
@@ -420,6 +420,25 @@ model Post {
   @@index([updatedById])
 }
 
+model PromoteTopic {
+  id          Int       @id @default(autoincrement())
+  order       Int?      @unique
+  topics      Topic?    @relation("PromoteTopic_topics", fields: [topicsId], references: [id])
+  topicsId    Int?      @map("topics")
+  state       String?   @default("draft")
+  createdAt   DateTime?
+  updatedAt   DateTime?
+  createdBy   User?     @relation("PromoteTopic_createdBy", fields: [createdById], references: [id])
+  createdById Int?      @map("createdBy")
+  updatedBy   User?     @relation("PromoteTopic_updatedBy", fields: [updatedById], references: [id])
+  updatedById Int?      @map("updatedBy")
+
+  @@index([topicsId])
+  @@index([state])
+  @@index([createdById])
+  @@index([updatedById])
+}
+
 model Section {
   id                    Int        @id @default(autoincrement())
   name                  String     @unique @default("")
@@ -474,38 +493,39 @@ model Tag {
 }
 
 model Topic {
-  id                           Int       @id @default(autoincrement())
-  name                         String    @unique @default("")
-  slug                         String    @unique @default("")
+  id                           Int            @id @default(autoincrement())
+  name                         String         @unique @default("")
+  slug                         String         @unique @default("")
   sortOrder                    Int?
-  state                        String?   @default("draft")
+  state                        String?        @default("draft")
   brief                        Json?
-  heroImage                    Photo?    @relation("Topic_heroImage", fields: [heroImageId], references: [id])
-  heroImageId                  Int?      @map("heroImage")
+  heroImage                    Photo?         @relation("Topic_heroImage", fields: [heroImageId], references: [id])
+  heroImageId                  Int?           @map("heroImage")
   heroUrl                      String?
   leading                      String?
-  sections                     Section[] @relation("Section_topics")
-  og_title                     String    @default("")
-  og_description               String    @default("")
-  og_image                     Photo?    @relation("Topic_og_image", fields: [og_imageId], references: [id])
-  og_imageId                   Int?      @map("og_image")
-  isFeatured                   Boolean   @default(false)
-  title_style                  String?   @default("feature")
-  type                         String?   @default("list")
-  style                        String    @default("")
-  tags                         Tag[]     @relation("Tag_topics")
-  slideshow_images             Photo[]   @relation("Topic_slideshow_images")
+  sections                     Section[]      @relation("Section_topics")
+  og_title                     String         @default("")
+  og_description               String         @default("")
+  og_image                     Photo?         @relation("Topic_og_image", fields: [og_imageId], references: [id])
+  og_imageId                   Int?           @map("og_image")
+  isFeatured                   Boolean        @default(false)
+  title_style                  String?        @default("feature")
+  type                         String?        @default("list")
+  style                        String         @default("")
+  tags                         Tag[]          @relation("Tag_topics")
+  slideshow_images             Photo[]        @relation("Topic_slideshow_images")
   manualOrderOfSlideshowImages Json?
-  posts                        Post[]    @relation("Post_topics")
-  javascript                   String    @default("")
-  dfp                          String    @default("")
-  mobile_dfp                   String    @default("")
+  posts                        Post[]         @relation("Post_topics")
+  javascript                   String         @default("")
+  dfp                          String         @default("")
+  mobile_dfp                   String         @default("")
   createdAt                    DateTime?
   updatedAt                    DateTime?
-  createdBy                    User?     @relation("Topic_createdBy", fields: [createdById], references: [id])
-  createdById                  Int?      @map("createdBy")
-  updatedBy                    User?     @relation("Topic_updatedBy", fields: [updatedById], references: [id])
-  updatedById                  Int?      @map("updatedBy")
+  createdBy                    User?          @relation("Topic_createdBy", fields: [createdById], references: [id])
+  createdById                  Int?           @map("createdBy")
+  updatedBy                    User?          @relation("Topic_updatedBy", fields: [updatedById], references: [id])
+  updatedById                  Int?           @map("updatedBy")
+  from_PromoteTopic_topics     PromoteTopic[] @relation("PromoteTopic_topics")
 
   @@index([state])
   @@index([heroImageId])
@@ -554,6 +574,8 @@ model User {
   from_Post_lockBy                 Post[]              @relation("Post_lockBy")
   from_Post_createdBy              Post[]              @relation("Post_createdBy")
   from_Post_updatedBy              Post[]              @relation("Post_updatedBy")
+  from_PromoteTopic_createdBy      PromoteTopic[]      @relation("PromoteTopic_createdBy")
+  from_PromoteTopic_updatedBy      PromoteTopic[]      @relation("PromoteTopic_updatedBy")
   from_Section_createdBy           Section[]           @relation("Section_createdBy")
   from_Section_updatedBy           Section[]           @relation("Section_updatedBy")
   from_Tag_createdBy               Tag[]               @relation("Tag_createdBy")


### PR DESCRIPTION
#### Changes
- 建立 `PromoteTopic` List：包含 `order` (排序)、`topics` (精選專題) 及 `state` (狀態) 欄位
- 排序檢查：增加 validateInput 確保「自動下線舊專題」的邏輯執行前，先驗證新專題的 order 不重複
- 自動下線機制：「已上線」項目上限為 3 個，系統將依時間順序自動下線 (Archived) 最舊項目
- 同步資料庫：更新 Prisma Schema、GraphQL 並產生資料庫遷移檔 (Migration)

p.s. 後續 cronjob 完成要補增加 hook 每次更新需要觸發產生新的 json