### PR TITLE
feat(mirrormedia): trigger promote-topics.json sync on state change

### DIFF
--- a/packages/mirrormedia/environment-variables.ts
+++ b/packages/mirrormedia/environment-variables.ts
@@ -26,6 +26,7 @@ const {
   QUEUE_NAME,
   PROJECT_ID,
   LOCATION,
+  PROMOTE_TOPIC_SERVICE_URL,
 } = process.env
 
 enum DatabaseProvider {
@@ -89,4 +90,5 @@ export default {
   queueName: QUEUE_NAME || 'external-tagging-dev',
   projectID: PROJECT_ID || 'mirrormedia',
   location: LOCATION || 'asia-east1',
+  promoteTopicServiceUrl: PROMOTE_TOPIC_SERVICE_URL,
 }

--- a/packages/mirrormedia/lists/PromoteTopic.ts
+++ b/packages/mirrormedia/lists/PromoteTopic.ts
@@ -2,9 +2,8 @@ import { utils } from '@mirrormedia/lilith-core'
 import { list } from '@keystone-6/core'
 import { relationship, select, integer } from '@keystone-6/core/fields'
 import { State } from '../type'
-
-const { allowRoles, admin, moderator, editor } = utils.accessControl
 import envVar from '../environment-variables'
+const { allowRoles, admin, moderator, editor } = utils.accessControl
 
 enum PromoteTopicState {
   Draft = State.Draft,

--- a/packages/mirrormedia/lists/PromoteTopic.ts
+++ b/packages/mirrormedia/lists/PromoteTopic.ts
@@ -4,6 +4,7 @@ import { relationship, select, integer } from '@keystone-6/core/fields'
 import { State } from '../type'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
+import envVar from '../environment-variables'
 
 enum PromoteTopicState {
   Draft = State.Draft,
@@ -90,7 +91,7 @@ const listConfigurations = list({
 
       if (isTurningPublished) {
         const publishedItems = await context.query.PromoteTopic.findMany({
-          where: { state: { equals: 'published' } },
+          where: { state: { equals: PromoteTopicState.Published } },
           orderBy: { updatedAt: 'asc' },
           query: 'id',
         })
@@ -102,15 +103,53 @@ const listConfigurations = list({
             Math.max(0, numToArchive)
           )
 
-          for (const targetItem of itemsToArchive) {
-            await context.db.PromoteTopic.updateOne({
-              where: { id: targetItem.id },
-              data: { state: PromoteTopicState.Archived },
+          if (itemsToArchive.length > 0) {
+            await context.db.PromoteTopic.updateMany({
+              data: itemsToArchive.map((targetItem) => ({
+                where: { id: targetItem.id },
+                data: { state: PromoteTopicState.Archived },
+              })),
             })
+
             console.log(
-              `[PromoteTopic] Limit reached. Auto-archived item ID: ${targetItem.id}`
+              `[PromoteTopic] Batch archived IDs: ${itemsToArchive
+                .map((i) => i.id)
+                .join(', ')}`
             )
           }
+        }
+      }
+    },
+    afterOperation: async ({ item, originalItem }) => {
+      const wasPublished = originalItem?.state === PromoteTopicState.Published
+      const isPublished = item?.state === PromoteTopicState.Published
+
+      if (wasPublished || isPublished) {
+        const promoteTopicSyncUrl = envVar.promoteTopicServiceUrl
+
+        if (promoteTopicSyncUrl) {
+          fetch(promoteTopicSyncUrl)
+            .then((res) => {
+              if (res.ok) {
+                console.log(
+                  '[Promote Topic Sync] Successfully triggered promote-topics.json update.'
+                )
+              } else {
+                console.error(
+                  `[Promote Topic Sync] Service returned error. Status: ${res.status}`
+                )
+              }
+            })
+            .catch((err) => {
+              console.error(
+                '[Promote Topic Sync Error] Network or URL error:',
+                err
+              )
+            })
+        } else {
+          console.warn(
+            '[Promote Topic Sync] Skip: promoteTopicServiceUrl is missing in env.'
+          )
         }
       }
     },


### PR DESCRIPTION
#### Changes
- 新增 promoteTopicServiceUrl 環境變數
- PromoteTopic list 補 afterOperation hook，當狀態涉及「已上線」時自動觸發同步更新 JSON
- 修正上一版 Gemini review 建議的調整

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213799707742378