### PR TITLE
feat(mirrortv): add PromoteTopic list and database migration

### DIFF
--- a/packages/mirrortv/lists/PromoteTopic.ts
+++ b/packages/mirrortv/lists/PromoteTopic.ts
@@ -9,6 +9,7 @@ enum PromoteTopicState {
   Published = State.Published,
   Archived = State.Archived,
 }
+const MAX_PUBLISHED_ITEMS = 3
 
 const listConfigurations = list({
   fields: {
@@ -63,7 +64,7 @@ const listConfigurations = list({
       item,
     }) => {
       const { order } = resolvedData || {}
-      if (order !== undefined) {
+      if (order !== undefined && order !== null) {
         const existingCount = await context.query.PromoteTopic.count({
           where: {
             order: { equals: order },
@@ -94,8 +95,8 @@ const listConfigurations = list({
           query: 'id',
         })
 
-        if (publishedItems.length >= 3) {
-          const numToArchive = publishedItems.length - 2
+        if (publishedItems.length >= MAX_PUBLISHED_ITEMS) {
+          const numToArchive = publishedItems.length + 1 - MAX_PUBLISHED_ITEMS
           const itemsToArchive = publishedItems.slice(
             0,
             Math.max(0, numToArchive)

--- a/packages/mirrortv/lists/PromoteTopic.ts
+++ b/packages/mirrortv/lists/PromoteTopic.ts
@@ -1,0 +1,127 @@
+import { utils } from '@mirrormedia/lilith-core'
+import { list } from '@keystone-6/core'
+import { relationship, select, integer } from '@keystone-6/core/fields'
+import { State } from '../type'
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+enum PromoteTopicState {
+  Draft = State.Draft,
+  Published = State.Published,
+  Archived = State.Archived,
+}
+
+const listConfigurations = list({
+  fields: {
+    order: integer({
+      label: '排序',
+      isIndexed: 'unique',
+      validation: {
+        min: 1,
+        max: 9999,
+      },
+    }),
+    topics: relationship({
+      label: '精選專題',
+      ref: 'Topic',
+      ui: {
+        views: './lists/views/sorted-relationship/index',
+        labelField: 'name',
+      },
+    }),
+    state: select({
+      label: '狀態',
+      options: [
+        { label: '草稿', value: PromoteTopicState.Draft },
+        { label: '已上線', value: PromoteTopicState.Published },
+        { label: '已下線', value: PromoteTopicState.Archived },
+      ],
+      defaultValue: PromoteTopicState.Draft,
+      isIndexed: true,
+    }),
+  },
+  ui: {
+    labelField: 'id',
+    listView: {
+      initialColumns: ['id', 'order', 'topics', 'state'],
+      initialSort: { field: 'id', direction: 'DESC' },
+      pageSize: 50,
+    },
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator, editor),
+      update: allowRoles(admin, moderator),
+      create: allowRoles(admin, moderator),
+      delete: allowRoles(admin),
+    },
+  },
+  hooks: {
+    validateInput: async ({
+      resolvedData,
+      addValidationError,
+      context,
+      item,
+    }) => {
+      const { order } = resolvedData || {}
+      if (order !== undefined) {
+        const existingCount = await context.query.PromoteTopic.count({
+          where: {
+            order: { equals: order },
+            id: { not: { equals: item?.id } },
+          },
+        })
+        if (existingCount > 0) {
+          addValidationError(`Order ${order} is already in use.`)
+        }
+      }
+    },
+
+    // 只能有三個 topic 是已上線狀態的
+    beforeOperation: async ({ operation, resolvedData, item, context }) => {
+      const { state: newState } = resolvedData || {}
+      const oldState = item?.state
+
+      const isTurningPublished =
+        (operation === 'create' && newState === PromoteTopicState.Published) ||
+        (operation === 'update' &&
+          newState === PromoteTopicState.Published &&
+          oldState !== PromoteTopicState.Published)
+
+      if (isTurningPublished) {
+        const publishedItems = await context.query.PromoteTopic.findMany({
+          where: { state: { equals: PromoteTopicState.Published } },
+          orderBy: { updatedAt: 'asc' },
+          query: 'id',
+        })
+
+        if (publishedItems.length >= 3) {
+          const numToArchive = publishedItems.length - 2
+          const itemsToArchive = publishedItems.slice(
+            0,
+            Math.max(0, numToArchive)
+          )
+
+          if (itemsToArchive.length > 0) {
+            await context.prisma.promoteTopic.updateMany({
+              where: {
+                id: {
+                  in: itemsToArchive.map((i) => Number(i.id)),
+                },
+              },
+              data: {
+                state: PromoteTopicState.Archived,
+              },
+            })
+
+            console.log(
+              `[PromoteTopic] Batch archived IDs: ${itemsToArchive
+                .map((i) => i.id)
+                .join(', ')}`
+            )
+          }
+        }
+      }
+    },
+  },
+})
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/mirrortv/lists/index.ts
+++ b/packages/mirrortv/lists/index.ts
@@ -21,6 +21,7 @@ import Sponsor from './Sponsor'
 import Download from './Download'
 import VideoEditorChoice from './VideoEditorChoice'
 import Video from './Video'
+import PromoteTopic from './PromoteTopic'
 
 export const listDefinition = {
   ArtShow,
@@ -36,6 +37,7 @@ export const listDefinition = {
   Partner,
   Post,
   PromotionVideo,
+  PromoteTopic,
   Sale,
   Section,
   Serie,

--- a/packages/mirrortv/migrations/20260410094800_add_promote_topic_list/migration.sql
+++ b/packages/mirrortv/migrations/20260410094800_add_promote_topic_list/migration.sql
@@ -1,0 +1,37 @@
+-- CreateTable
+CREATE TABLE "PromoteTopic" (
+    "id" SERIAL NOT NULL,
+    "order" INTEGER,
+    "topics" INTEGER,
+    "state" TEXT DEFAULT 'draft',
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "PromoteTopic_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PromoteTopic_order_key" ON "PromoteTopic"("order");
+
+-- CreateIndex
+CREATE INDEX "PromoteTopic_topics_idx" ON "PromoteTopic"("topics");
+
+-- CreateIndex
+CREATE INDEX "PromoteTopic_state_idx" ON "PromoteTopic"("state");
+
+-- CreateIndex
+CREATE INDEX "PromoteTopic_createdBy_idx" ON "PromoteTopic"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "PromoteTopic_updatedBy_idx" ON "PromoteTopic"("updatedBy");
+
+-- AddForeignKey
+ALTER TABLE "PromoteTopic" ADD CONSTRAINT "PromoteTopic_topics_fkey" FOREIGN KEY ("topics") REFERENCES "Topic"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PromoteTopic" ADD CONSTRAINT "PromoteTopic_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PromoteTopic" ADD CONSTRAINT "PromoteTopic_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/mirrortv/schema.graphql
+++ b/packages/mirrortv/schema.graphql
@@ -1791,6 +1791,69 @@ input PromotionVideoCreateInput {
   updatedBy: UserRelateToOneForCreateInput
 }
 
+type PromoteTopic {
+  id: ID!
+  order: Int
+  topics: Topic
+  state: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+input PromoteTopicWhereUniqueInput {
+  id: ID
+  order: Int
+}
+
+input PromoteTopicWhereInput {
+  AND: [PromoteTopicWhereInput!]
+  OR: [PromoteTopicWhereInput!]
+  NOT: [PromoteTopicWhereInput!]
+  id: IDFilter
+  order: IntNullableFilter
+  topics: TopicWhereInput
+  state: StringNullableFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input PromoteTopicOrderByInput {
+  id: OrderDirection
+  order: OrderDirection
+  state: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input PromoteTopicUpdateInput {
+  order: Int
+  topics: TopicRelateToOneForUpdateInput
+  state: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input PromoteTopicUpdateArgs {
+  where: PromoteTopicWhereUniqueInput!
+  data: PromoteTopicUpdateInput!
+}
+
+input PromoteTopicCreateInput {
+  order: Int
+  topics: TopicRelateToOneForCreateInput
+  state: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
 type Sale {
   id: ID!
   sortOrder: Int
@@ -2983,6 +3046,12 @@ type Mutation {
   updatePromotionVideos(data: [PromotionVideoUpdateArgs!]!): [PromotionVideo]
   deletePromotionVideo(where: PromotionVideoWhereUniqueInput!): PromotionVideo
   deletePromotionVideos(where: [PromotionVideoWhereUniqueInput!]!): [PromotionVideo]
+  createPromoteTopic(data: PromoteTopicCreateInput!): PromoteTopic
+  createPromoteTopics(data: [PromoteTopicCreateInput!]!): [PromoteTopic]
+  updatePromoteTopic(where: PromoteTopicWhereUniqueInput!, data: PromoteTopicUpdateInput!): PromoteTopic
+  updatePromoteTopics(data: [PromoteTopicUpdateArgs!]!): [PromoteTopic]
+  deletePromoteTopic(where: PromoteTopicWhereUniqueInput!): PromoteTopic
+  deletePromoteTopics(where: [PromoteTopicWhereUniqueInput!]!): [PromoteTopic]
   createSale(data: SaleCreateInput!): Sale
   createSales(data: [SaleCreateInput!]!): [Sale]
   updateSale(where: SaleWhereUniqueInput!, data: SaleUpdateInput!): Sale
@@ -3106,6 +3175,9 @@ type Query {
   promotionVideos(where: PromotionVideoWhereInput! = {}, orderBy: [PromotionVideoOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PromotionVideoWhereUniqueInput): [PromotionVideo!]
   promotionVideo(where: PromotionVideoWhereUniqueInput!): PromotionVideo
   promotionVideosCount(where: PromotionVideoWhereInput! = {}): Int
+  promoteTopics(where: PromoteTopicWhereInput! = {}, orderBy: [PromoteTopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PromoteTopicWhereUniqueInput): [PromoteTopic!]
+  promoteTopic(where: PromoteTopicWhereUniqueInput!): PromoteTopic
+  promoteTopicsCount(where: PromoteTopicWhereInput! = {}): Int
   sales(where: SaleWhereInput! = {}, orderBy: [SaleOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: SaleWhereUniqueInput): [Sale!]
   sale(where: SaleWhereUniqueInput!): Sale
   salesCount(where: SaleWhereInput! = {}): Int

--- a/packages/mirrortv/schema.prisma
+++ b/packages/mirrortv/schema.prisma
@@ -446,6 +446,25 @@ model PromotionVideo {
   @@index([updatedById])
 }
 
+model PromoteTopic {
+  id          Int       @id @default(autoincrement())
+  order       Int?      @unique
+  topics      Topic?    @relation("PromoteTopic_topics", fields: [topicsId], references: [id])
+  topicsId    Int?      @map("topics")
+  state       String?   @default("draft")
+  createdAt   DateTime?
+  updatedAt   DateTime?
+  createdBy   User?     @relation("PromoteTopic_createdBy", fields: [createdById], references: [id])
+  createdById Int?      @map("createdBy")
+  updatedBy   User?     @relation("PromoteTopic_updatedBy", fields: [updatedById], references: [id])
+  updatedById Int?      @map("updatedBy")
+
+  @@index([topicsId])
+  @@index([state])
+  @@index([createdById])
+  @@index([updatedById])
+}
+
 model Sale {
   id          Int            @id @default(autoincrement())
   sortOrder   Int
@@ -605,48 +624,49 @@ model Tag {
 }
 
 model Topic {
-  id                       Int        @id @default(autoincrement())
-  slug                     String     @unique @default("")
-  sortOrder                Int?       @unique
-  name                     String     @default("")
-  leading                  String?    @default("image")
-  heroImage                Image?     @relation("Topic_heroImage", fields: [heroImageId], references: [id])
-  heroImageId              Int?       @map("heroImage")
-  heroVideo                Video?     @relation("Topic_heroVideo", fields: [heroVideoId], references: [id])
-  heroVideoId              Int?       @map("heroVideo")
-  slideshow                Post[]     @relation("Topic_slideshow")
+  id                       Int            @id @default(autoincrement())
+  slug                     String         @unique @default("")
+  sortOrder                Int?           @unique
+  name                     String         @default("")
+  leading                  String?        @default("image")
+  heroImage                Image?         @relation("Topic_heroImage", fields: [heroImageId], references: [id])
+  heroImageId              Int?           @map("heroImage")
+  heroVideo                Video?         @relation("Topic_heroVideo", fields: [heroVideoId], references: [id])
+  heroVideoId              Int?           @map("heroVideo")
+  slideshow                Post[]         @relation("Topic_slideshow")
   manualOrderOfSlideshows  Json?
-  multivideo               Video[]    @relation("Topic_multivideo")
+  multivideo               Video[]        @relation("Topic_multivideo")
   manualOrderOfMultivideos Json?
-  post                     Post[]     @relation("Topic_post")
+  post                     Post[]         @relation("Topic_post")
   manualOrderOfPosts       Json?
-  sortDir                  String?    @default("desc")
-  categories               Category[] @relation("Topic_categories")
+  sortDir                  String?        @default("desc")
+  categories               Category[]     @relation("Topic_categories")
   manualOrderOfCategories  Json?
-  tags                     Tag[]      @relation("Topic_tags")
+  tags                     Tag[]          @relation("Topic_tags")
   manualOrderOfTags        Json?
-  state                    String?    @default("draft")
+  state                    String?        @default("draft")
   brief                    Json?
   briefApiData             Json?
-  briefHtml                String     @default("")
-  facebook                 String     @default("")
-  instagram                String     @default("")
-  line                     String     @default("")
-  ogTitle                  String     @default("")
-  ogDescription            String     @default("")
-  ogImage                  Image?     @relation("Topic_ogImage", fields: [ogImageId], references: [id])
-  ogImageId                Int?       @map("ogImage")
-  isFeatured               Boolean    @default(false)
+  briefHtml                String         @default("")
+  facebook                 String         @default("")
+  instagram                String         @default("")
+  line                     String         @default("")
+  ogTitle                  String         @default("")
+  ogDescription            String         @default("")
+  ogImage                  Image?         @relation("Topic_ogImage", fields: [ogImageId], references: [id])
+  ogImageId                Int?           @map("ogImage")
+  isFeatured               Boolean        @default(false)
   createdAt                DateTime?
   updatedAt                DateTime?
-  createdBy                User?      @relation("Topic_createdBy", fields: [createdById], references: [id])
-  createdById              Int?       @map("createdBy")
-  updatedBy                User?      @relation("Topic_updatedBy", fields: [updatedById], references: [id])
-  updatedById              Int?       @map("updatedBy")
-  from_Image_topic         Image[]    @relation("Image_topic")
-  from_Post_topics         Post[]     @relation("Post_topics")
-  from_Post_relatedTopic   Post[]     @relation("Post_relatedTopic")
-  from_Sponsor_topic       Sponsor[]  @relation("Sponsor_topic")
+  createdBy                User?          @relation("Topic_createdBy", fields: [createdById], references: [id])
+  createdById              Int?           @map("createdBy")
+  updatedBy                User?          @relation("Topic_updatedBy", fields: [updatedById], references: [id])
+  updatedById              Int?           @map("updatedBy")
+  from_Image_topic         Image[]        @relation("Image_topic")
+  from_Post_topics         Post[]         @relation("Post_topics")
+  from_Post_relatedTopic   Post[]         @relation("Post_relatedTopic")
+  from_PromoteTopic_topics PromoteTopic[] @relation("PromoteTopic_topics")
+  from_Sponsor_topic       Sponsor[]      @relation("Sponsor_topic")
 
   @@index([heroImageId])
   @@index([heroVideoId])
@@ -696,6 +716,8 @@ model User {
   from_Post_updatedBy              Post[]              @relation("Post_updatedBy")
   from_PromotionVideo_createdBy    PromotionVideo[]    @relation("PromotionVideo_createdBy")
   from_PromotionVideo_updatedBy    PromotionVideo[]    @relation("PromotionVideo_updatedBy")
+  from_PromoteTopic_createdBy      PromoteTopic[]      @relation("PromoteTopic_createdBy")
+  from_PromoteTopic_updatedBy      PromoteTopic[]      @relation("PromoteTopic_updatedBy")
   from_Sale_createdBy              Sale[]              @relation("Sale_createdBy")
   from_Sale_updatedBy              Sale[]              @relation("Sale_updatedBy")
   from_Section_createdBy           Section[]           @relation("Section_createdBy")


### PR DESCRIPTION
#### Changes:
- 建立 PromoteTopic List：包含 order (排序)、topics (精選專題) 及 state (狀態) 欄位
- 排序檢查：增加 validateInput 確保「自動下線舊專題」的邏輯執行前，先驗證新專題的 order 不重複
- 自動下線機制：「已上線」項目上限為 3 個，系統將依時間順序自動下線 (Archived) 最舊項目
- 同步資料庫：更新 Prisma Schema、GraphQL 並產生資料庫遷移檔 (Migration)

p.s. 後續 cronjob 完成要補增加 hook 每次更新需要觸發產生新的 json