### PR TITLE
feat(mirrortv): add afterOperation hook to trigger PromoteTopic sync service

### DIFF
--- a/packages/mirrortv/environment-variables.ts
+++ b/packages/mirrortv/environment-variables.ts
@@ -29,6 +29,7 @@ const {
   INVALID_CDN_CACHE_SERVER_URL,
   YOUTUBE_API_KEY,
   DOMAIN_URL,
+  PROMOTE_TOPIC_SERVICE_URL,
 } = process.env
 
 enum DatabaseProvider {
@@ -96,6 +97,7 @@ export default {
   autotagging: AUTO_TAGGING || 'false',
   invalidateCDNCacheServerURL: INVALID_CDN_CACHE_SERVER_URL,
   domainUrl: DOMAIN_URL || '',
+  promoteTopicServiceUrl: PROMOTE_TOPIC_SERVICE_URL,
   youtube: {
     apiKey: YOUTUBE_API_KEY,
   },

--- a/packages/mirrortv/lists/PromoteTopic.ts
+++ b/packages/mirrortv/lists/PromoteTopic.ts
@@ -2,6 +2,7 @@ import { utils } from '@mirrormedia/lilith-core'
 import { list } from '@keystone-6/core'
 import { relationship, select, integer } from '@keystone-6/core/fields'
 import { State } from '../type'
+import envVar from '../environment-variables'
 const { allowRoles, admin, moderator, editor } = utils.accessControl
 
 enum PromoteTopicState {
@@ -120,6 +121,36 @@ const listConfigurations = list({
                 .join(', ')}`
             )
           }
+        }
+      }
+    },
+    afterOperation: async ({ item, originalItem }) => {
+      const wasPublished = originalItem?.state === PromoteTopicState.Published
+      const isPublished = item?.state === PromoteTopicState.Published
+
+      if (wasPublished || isPublished) {
+        const promoteTopicSyncUrl = envVar.promoteTopicServiceUrl
+
+        if (promoteTopicSyncUrl) {
+          setTimeout(() => {
+            fetch(promoteTopicSyncUrl, {
+              method: 'POST',
+            })
+              .then(async (res) => {
+                if (res.ok) {
+                  console.log(
+                    '[Promote Topic Sync] Triggered update successfully.'
+                  )
+                } else {
+                  console.error(
+                    `[Promote Topic Sync] HTTP Error: ${res.status}`
+                  )
+                }
+              })
+              .catch((err) => {
+                console.error('[Promote Topic Sync] Fetch Error:', err)
+              })
+          }, 500)
         }
       }
     },

--- a/packages/mirrortv/lists/PromoteTopic.ts
+++ b/packages/mirrortv/lists/PromoteTopic.ts
@@ -132,25 +132,22 @@ const listConfigurations = list({
         const promoteTopicSyncUrl = envVar.promoteTopicServiceUrl
 
         if (promoteTopicSyncUrl) {
-          setTimeout(() => {
-            fetch(promoteTopicSyncUrl, {
+          try {
+            const res = await fetch(promoteTopicSyncUrl, {
               method: 'POST',
             })
-              .then(async (res) => {
-                if (res.ok) {
-                  console.log(
-                    '[Promote Topic Sync] Triggered update successfully.'
-                  )
-                } else {
-                  console.error(
-                    `[Promote Topic Sync] HTTP Error: ${res.status}`
-                  )
-                }
-              })
-              .catch((err) => {
-                console.error('[Promote Topic Sync] Fetch Error:', err)
-              })
-          }, 500)
+
+            if (res.ok) {
+              console.log('[Promote Topic Sync] Triggered update successfully.')
+            } else {
+              const errorMsg = await res.text()
+              console.error(
+                `[Promote Topic Sync] HTTP Error: ${res.status}, Message: ${errorMsg}`
+              )
+            }
+          } catch (err) {
+            console.error('[Promote Topic Sync] Fetch Error:', err)
+          }
         }
       }
     },


### PR DESCRIPTION
Changes:
   * `lists/PromoteTopic.ts`:
       * 新增 `afterOperation` Hook:
           * 當狀態涉及「已上線 (Published)」的變更時，觸發 `POST` 請求產出最新 Promote-topics JSON 的 API
           * 使用 async/await ，同步加入 try...catch 保護，並在 API 回傳非 200狀態碼時，印出錯誤訊息排查
   * `environment-variables.ts`:
       * 新增 promoteTopicServiceUrl 環境變數設定

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213905694361981