### PR TITLE
feat(mirrortv): trigger CDN cache invalidation on External state change

### DIFF
--- a/packages/mirrortv/lists/External.ts
+++ b/packages/mirrortv/lists/External.ts
@@ -1,3 +1,4 @@
+import envVar from '../environment-variables'
 import { utils, customFields } from '@mirrormedia/lilith-core'
 import { list, graphql } from '@keystone-6/core'
 import {
@@ -192,14 +193,7 @@ const listConfigurations = list({
     labelField: 'label',
 
     listView: {
-      initialColumns: [
-        'name',
-        'slug',
-        'state',
-        'publishTime',
-        'partner',
-        'createdBy',
-      ],
+      initialColumns: ['name', 'slug', 'state', 'publishTime', 'partner'],
       initialSort: { field: 'publishTime', direction: 'DESC' },
       pageSize: 50,
     },
@@ -212,4 +206,32 @@ const listConfigurations = list({
   },
 })
 
-export default utils.addTrackingFields(listConfigurations)
+const extendedListConfigurations = utils.addTrackingFields(listConfigurations)
+
+if (typeof envVar.invalidateCDNCacheServerURL === 'string') {
+  extendedListConfigurations.hooks = {
+    ...extendedListConfigurations.hooks,
+    afterOperation: async ({ item, originalItem }) => {
+      if (item?.state !== originalItem?.state) {
+        const slug = item?.slug || originalItem?.slug
+        if (slug) {
+          try {
+            await fetch(`${envVar.invalidateCDNCacheServerURL}/external`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ slug }),
+            })
+            console.log(`[External CDN Cache] Refreshing external: ${slug}`)
+          } catch (error) {
+            console.error(
+              `[External CDN Cache] Failed to refresh external ${slug}:`,
+              error
+            )
+          }
+        }
+      }
+    },
+  }
+}
+
+export default extendedListConfigurations

--- a/packages/mirrortv/lists/External.ts
+++ b/packages/mirrortv/lists/External.ts
@@ -208,10 +208,18 @@ const listConfigurations = list({
 
 const extendedListConfigurations = utils.addTrackingFields(listConfigurations)
 
-if (typeof envVar.invalidateCDNCacheServerURL === 'string') {
+if (envVar.invalidateCDNCacheServerURL) {
+  const originalAfterOperation =
+    extendedListConfigurations.hooks?.afterOperation
+
   extendedListConfigurations.hooks = {
     ...extendedListConfigurations.hooks,
-    afterOperation: async ({ item, originalItem }) => {
+    afterOperation: async (params) => {
+      if (typeof originalAfterOperation === 'function') {
+        await originalAfterOperation(params)
+      }
+
+      const { item, originalItem } = params
       if (item?.state !== originalItem?.state) {
         const slug = item?.slug || originalItem?.slug
         if (slug) {

--- a/packages/mirrortv/lists/External.ts
+++ b/packages/mirrortv/lists/External.ts
@@ -193,7 +193,14 @@ const listConfigurations = list({
     labelField: 'label',
 
     listView: {
-      initialColumns: ['name', 'slug', 'state', 'publishTime', 'partner'],
+      initialColumns: [
+        'name',
+        'slug',
+        'state',
+        'publishTime',
+        'partner',
+        'createdBy',
+      ],
       initialSort: { field: 'publishTime', direction: 'DESC' },
       pageSize: 50,
     },
@@ -224,12 +231,23 @@ if (envVar.invalidateCDNCacheServerURL) {
         const slug = item?.slug || originalItem?.slug
         if (slug) {
           try {
-            await fetch(`${envVar.invalidateCDNCacheServerURL}/external`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ slug }),
-            })
-            console.log(`[External CDN Cache] Refreshing external: ${slug}`)
+            const res = await fetch(
+              `${envVar.invalidateCDNCacheServerURL}/external`,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ slug }),
+              }
+            )
+
+            if (!res.ok) {
+              const errorText = await res.text()
+              console.error(
+                `[External CDN Cache] Failed to refresh external ${slug}. Status: ${res.status}, Error: ${errorText}`
+              )
+            } else {
+              console.log(`[External CDN Cache] Refreshing external: ${slug}`)
+            }
           } catch (error) {
             console.error(
               `[External CDN Cache] Failed to refresh external ${slug}:`,


### PR DESCRIPTION
#### Changes:
   * `lists/External.ts`:
       * 清除快取 API: 若文章狀態變更，觸發 `${envVar.invalidateCDNCacheServerURL}/external`，並將 external 的 slug 作為 Payload 發送 POST 請求給 invalidate-cdn-cache
  * `invalidate-cdn-cache-[env]` (Cloud run): 修改環境變數