### PR TITLE
chore: cherry-pick mirrortv image auth from staging to prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a monorepo containing sub-packages:
 - [@mirrormedia/lilith-editools](./packages/editools): see `packages/editools`
 - [@mirrormedia/lilith-mesh](./packages/mesh): see `packages/mesh`
 - [@mirrormedia/lilith-mirrormedia](./packages/mirrormedia): see `packages/mirrormedia`
+- [@mirrormedia/lilith-mirrortv](./packages/mirrortv): see `packages/mirrortv`
 - [@mirrormedia/lilith-readr](./packages/readr): see `packages/readr`
 - [@mirrormedia/lilith-openrelationship](./packages/openrelationship): see `packages/openrelationship`
 - [@mirrormedia/lilith-mirrordaily](./packages/mirrordaily): see `packages/mirrordaily`

--- a/packages/mirrortv/express-mini-apps/images/app.js
+++ b/packages/mirrortv/express-mini-apps/images/app.js
@@ -17,11 +17,15 @@ export function createImageAuthMiniApp({ keystoneContext }) {
    *  @param {express.NextFunction} next
    */
   const authenticationMw = async (req, res, next) => {
-    const context = await keystoneContext.withRequest(req, res)
-    if (context?.session?.data) {
-      return next()
+    try {
+      const context = await keystoneContext.withRequest(req, res)
+      if (context?.session?.data) {
+        return next()
+      }
+      res.status(401).send('Unauthorized')
+    } catch (error) {
+      next(error)
     }
-    res.status(401).send('Unauthorized')
   }
 
   // Protect /images path. /files and /video-files reserved for future use.

--- a/packages/mirrortv/express-mini-apps/images/app.js
+++ b/packages/mirrortv/express-mini-apps/images/app.js
@@ -1,0 +1,31 @@
+import express from 'express'
+
+/**
+ *  @typedef {import('@keystone-6/core/types').KeystoneContext} KeystoneContext
+ *
+ *  @param {Object} opts
+ *  @param {KeystoneContext} opts.keystoneContext
+ *  @returns {express.Router}
+ */
+export function createImageAuthMiniApp({ keystoneContext }) {
+  const router = express.Router()
+
+  /**
+   *  Check if the request is sent by an authenticated user
+   *  @param {express.Request} req
+   *  @param {express.Response} res
+   *  @param {express.NextFunction} next
+   */
+  const authenticationMw = async (req, res, next) => {
+    const context = await keystoneContext.withRequest(req, res)
+    if (context?.session?.data) {
+      return next()
+    }
+    res.status(401).send('Unauthorized')
+  }
+
+  // Protect /images path. /files and /video-files reserved for future use.
+  router.use('/images', authenticationMw)
+
+  return router
+}

--- a/packages/mirrortv/keystone.ts
+++ b/packages/mirrortv/keystone.ts
@@ -6,6 +6,7 @@ import express from 'express'
 import { createAuth } from '@keystone-6/auth'
 import { statelessSessions } from '@keystone-6/core/session'
 import { createPreviewMiniApp } from './express-mini-apps/preview/app'
+import { createImageAuthMiniApp } from './express-mini-apps/images/app'
 import Keyv from 'keyv'
 import { KeyvAdapter } from '@apollo/utils.keyvadapter'
 import { ApolloServerPluginCacheControl } from '@apollo/server/plugin/cacheControl'
@@ -110,6 +111,13 @@ export default withAuth(
 
         const jsonBodyParser = express.json({ limit: '500mb' })
         app.use(jsonBodyParser)
+
+        // Protect static image files - must run before Keystone registers storage static middleware
+        app.use(
+          createImageAuthMiniApp({
+            keystoneContext: context,
+          })
+        )
 
         if (envVar.accessControlStrategy === ACL.CMS) {
           app.use(


### PR DESCRIPTION
## Summary
- Cherry-pick mirrortv `/images/*` Keystone session auth from staging to prod
- Originated from #1205 (main), picked to staging via #1209
- 2 commits included:
  - `feat(mirrortv): protect /images/* with Keystone session auth`
  - `fix(mirrortv): add error handling to image auth middleware`

> ⚠️ Wait for staging acceptance test to pass before merging this PR to prod.

## Test plan
- [ ] Staging acceptance test passed
- [ ] Unauthenticated request to `/images/<file_id>.<ext>` returns `401 Unauthorized`
- [ ] Authenticated request (logged-in Keystone session) returns the image normally
- [ ] Keystone Admin UI image preview still works after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)