### PR TITLE
feat(mirrormedia): add EditLog to track Post create/update/delete

### DIFF
--- a/packages/mirrormedia/lists/EditLog.ts
+++ b/packages/mirrormedia/lists/EditLog.ts
@@ -13,7 +13,13 @@ type DraftContent = {
 const extractText = (val: unknown): string => {
   if (!val || typeof val !== 'object') return ''
   const content = val as DraftContent
-  return content.blocks?.find((b) => b.text)?.text ?? ''
+  return (
+    content.blocks
+      ?.map((b) => b.text)
+      .filter(Boolean)
+      .join(' ')
+      .substring(0, 200) ?? ''
+  )
 }
 
 const listConfigurations = list({

--- a/packages/mirrormedia/lists/EditLog.ts
+++ b/packages/mirrormedia/lists/EditLog.ts
@@ -1,0 +1,133 @@
+import { customFields, utils } from '@mirrormedia/lilith-core'
+import { graphql, list } from '@keystone-6/core'
+import { text, virtual } from '@keystone-6/core/fields'
+
+import { formatChangedList } from '../utils/formatChangedList'
+
+const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+type DraftContent = {
+  blocks?: { text: string }[]
+}
+
+const extractText = (val: unknown): string => {
+  if (!val || typeof val !== 'object') return ''
+  const content = val as DraftContent
+  return content.blocks?.find((b) => b.text)?.text ?? ''
+}
+
+const listConfigurations = list({
+  fields: {
+    name: text({
+      label: '編輯者',
+      validation: { isRequired: true },
+      ui: { itemView: { fieldMode: 'read' } },
+    }),
+
+    operation: text({
+      label: '動作',
+      validation: { isRequired: true },
+      ui: { itemView: { fieldMode: 'read' } },
+    }),
+
+    postSlug: text({
+      label: '文章Slug',
+      ui: { itemView: { fieldMode: 'read' } },
+      isIndexed: true,
+    }),
+
+    changedList: text({
+      label: '欄位更動內容',
+      ui: {
+        displayMode: 'textarea',
+        itemView: { fieldMode: 'edit' },
+      },
+      hooks: {
+        resolveInput: async ({ resolvedData, item }) => {
+          const raw = resolvedData.changedList || item?.changedList || ''
+          if (typeof raw === 'string' && raw.trim().startsWith('{')) {
+            return formatChangedList(raw)
+          }
+
+          return raw
+        },
+      },
+    }),
+
+    brief: customFields.richTextEditor({
+      label: '已更動前言',
+      ui: {
+        listView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'read' },
+      },
+      disabledButtons: [],
+      website: 'mirrormedia',
+    }),
+
+    briefPreview: virtual({
+      label: '前言預覽',
+      field: graphql.field({
+        type: graphql.String,
+        resolve(item: Record<string, unknown>): string {
+          return extractText(item.brief)
+        },
+      }),
+      ui: {
+        listView: { fieldMode: 'read' },
+        itemView: { fieldMode: 'hidden' },
+      },
+    }),
+
+    content: customFields.richTextEditor({
+      label: '已更動內文',
+      ui: {
+        listView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'read' },
+      },
+      disabledButtons: [],
+      website: 'mirrormedia',
+    }),
+
+    contentPreview: virtual({
+      label: '內文預覽',
+      field: graphql.field({
+        type: graphql.String,
+        resolve(item: Record<string, unknown>): string {
+          return extractText(item.content)
+        },
+      }),
+      ui: {
+        listView: { fieldMode: 'read' },
+        itemView: { fieldMode: 'hidden' },
+      },
+    }),
+  },
+
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator),
+      update: allowRoles(admin),
+      create: allowRoles(admin, moderator, editor),
+      delete: allowRoles(admin),
+    },
+  },
+
+  ui: {
+    labelField: 'name',
+    listView: {
+      initialColumns: [
+        'id',
+        'name',
+        'operation',
+        'postSlug',
+        'briefPreview',
+        'contentPreview',
+        'createdAt',
+      ] as any,
+      initialSort: { field: 'id', direction: 'DESC' },
+      pageSize: 50,
+    },
+  },
+})
+
+export default utils.addTrackingFields(listConfigurations)

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -19,7 +19,18 @@ const { allowRoles, admin, moderator, editor } = utils.accessControl
 
 // 用於在 beforeOperation 儲存 update 前的完整舊資料（含 relationship），
 // 讓 afterOperation 能以相同格式做比對，避免 Prisma raw row 與 GraphQL 格式不一致
-const preSaveSnapshot = new Map<string, Record<string, unknown>>()
+type SnapshotEntry = { data: Record<string, unknown>; ts: number }
+const preSaveSnapshot = new Map<string, SnapshotEntry>()
+
+// DB 操作失敗時 afterOperation 不會被呼叫，導致 snapshot 殘留
+// 每分鐘清除超過 5 分鐘的 stale entry
+const snapshotCleanupTimer = setInterval(() => {
+  const cutoff = Date.now() - 5 * 60 * 1000
+  for (const [key, val] of preSaveSnapshot) {
+    if (val.ts < cutoff) preSaveSnapshot.delete(key)
+  }
+}, 60 * 1000)
+snapshotCleanupTimer.unref()
 
 const POST_BASE_QUERY = `
   id slug title subtitle state publishedDate publishedDateString
@@ -914,7 +925,10 @@ const listConfigurations = list({
             query: buildPostQuery(includeRichText),
           })) as Record<string, unknown>
           if (snapshot) {
-            preSaveSnapshot.set(String(item.id), snapshot)
+            preSaveSnapshot.set(String(item.id), {
+              data: snapshot,
+              ts: Date.now(),
+            })
           }
         } catch (err) {
           console.error('[EditLog] beforeOperation snapshot 失敗:', err)
@@ -1069,10 +1083,8 @@ const listConfigurations = list({
                 })) as Record<string, unknown>)
               : null
 
-          // update/delete 時用 beforeOperation 儲存的 snapshot（GraphQL 格式，含 relationship）
-          // create 時 originalItem 不存在，oldItemBase 用不到
           const oldItemBase: Record<string, unknown> =
-            preSaveSnapshot.get(String(targetId)) ??
+            preSaveSnapshot.get(String(targetId))?.data ??
             (originalItem as Record<string, unknown>) ??
             {}
 
@@ -1140,8 +1152,8 @@ const listConfigurations = list({
             }
           } else {
             // create: 從 fullNewItem（GraphQL query）取得完整資料
-            // delete: afterOperation 觸發時文章已刪除，直接用 originalItem（Prisma raw row）
-            //         relationship 欄位只有 id，不會有展開的 name
+            // delete: 優先用 beforeOperation 儲存的 snapshot（GraphQL 格式，含展開的 relationship）
+            //         snapshot 失敗時退回 originalItem（Prisma raw row，relationship 欄位無展開）
             const target =
               operation === 'delete' ? oldItemBase : fullNewItem || {}
 

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -17,6 +17,28 @@ import { RawContentState } from 'draft-js'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
 
+// 用於在 beforeOperation 儲存 update 前的完整舊資料（含 relationship），
+// 讓 afterOperation 能以相同格式做比對，避免 Prisma raw row 與 GraphQL 格式不一致
+const preSaveSnapshot = new Map<string, Record<string, unknown>>()
+
+const POST_BASE_QUERY = `
+  id slug title subtitle state publishedDate publishedDateString
+  heroCaption style isMember memberFeed isFeatured isAdvertised
+  hiddenAdvertised isAdult auto_faq redirect adTrace css
+  og_title og_description extend_byline
+  sections { id name } categories { id name }
+  writers { id name } photographers { id name }
+  camera_man { id name } designers { id name }
+  engineers { id name } vocals { id name }
+  heroVideo { id name } heroImage { id name } og_image { id name }
+  topics { id name }
+  relatedsOne { id slug } relatedsTwo { id slug } relateds { id slug }
+  tags { id name } related_videos { id name }
+`
+
+const buildPostQuery = (includeRichText: boolean) =>
+  includeRichText ? POST_BASE_QUERY + ' brief content' : POST_BASE_QUERY
+
 enum UserRole {
   Admin = 'admin',
   Moderator = 'moderator',
@@ -879,8 +901,25 @@ const listConfigurations = list({
       }
       return resolvedData
     },
-    beforeOperation: async ({ operation, resolvedData }) => {
+    beforeOperation: async ({ operation, item, resolvedData, context }) => {
       /* ... */
+      if ((operation === 'update' || operation === 'delete') && item) {
+        try {
+          const includeRichText =
+            operation === 'delete' ||
+            resolvedData?.brief !== undefined ||
+            resolvedData?.content !== undefined
+          const snapshot = (await context.sudo().query.Post.findOne({
+            where: { id: String(item.id) },
+            query: buildPostQuery(includeRichText),
+          })) as Record<string, unknown>
+          if (snapshot) {
+            preSaveSnapshot.set(String(item.id), snapshot)
+          }
+        } catch (err) {
+          console.error('[EditLog] beforeOperation snapshot 失敗:', err)
+        }
+      }
       if (operation === 'create' || operation === 'update') {
         if (resolvedData.slug) {
           resolvedData.slug = resolvedData.slug.trim()
@@ -1010,12 +1049,7 @@ const listConfigurations = list({
 
           const safeParse = (data: unknown): unknown => {
             if (!data) return undefined
-            if (typeof data === 'object') return data
-            try {
-              return JSON.parse(String(data))
-            } catch (e) {
-              return undefined
-            }
+            return data
           }
           const targetId = item?.id || originalItem?.id
           if (!targetId) {
@@ -1023,31 +1057,26 @@ const listConfigurations = list({
             return
           }
 
-          const fullQuery = `
-            id slug title subtitle state publishedDate publishedDateString
-            heroCaption style isMember memberFeed isFeatured isAdvertised
-            hiddenAdvertised isAdult auto_faq redirect adTrace css
-            og_title og_description extend_byline
-            sections { id name } categories { id name }
-            writers { id name } photographers { id name }
-            camera_man { id name } designers { id name }
-            engineers { id name } vocals { id name }
-            heroVideo { id name } heroImage { id name } og_image { id name }
-            topics { id name }
-            relatedsOne { id slug } relatedsTwo { id slug } relateds { id slug }
-            tags { id name } related_videos { id name }
-            brief content
-          `
-
+          const includeRichText =
+            operation === 'create' ||
+            resolvedData?.brief !== undefined ||
+            resolvedData?.content !== undefined
           const fullNewItem =
             operation !== 'delete'
               ? ((await context.sudo().query.Post.findOne({
                   where: { id: String(targetId) },
-                  query: fullQuery,
+                  query: buildPostQuery(includeRichText),
                 })) as Record<string, unknown>)
               : null
 
-          const oldItemBase = (originalItem as Record<string, unknown>) || {}
+          // update/delete 時用 beforeOperation 儲存的 snapshot（GraphQL 格式，含 relationship）
+          // create 時 originalItem 不存在，oldItemBase 用不到
+          const oldItemBase: Record<string, unknown> =
+            preSaveSnapshot.get(String(targetId)) ??
+            (originalItem as Record<string, unknown>) ??
+            {}
+
+          preSaveSnapshot.delete(String(targetId))
 
           const blackList = [
             'id',

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -35,6 +35,7 @@ enum PostStatus {
 type Session = {
   data: {
     id: string
+    name: string
     role: UserRole
   }
 }
@@ -973,6 +974,190 @@ const listConfigurations = list({
             lockExpireAt: null,
           },
         })
+      }
+
+      if (
+        operation === 'create' ||
+        operation === 'update' ||
+        operation === 'delete'
+      ) {
+        try {
+          const editorName = context.session?.data?.name || '未知用戶'
+
+          const formatValueForLog = (val: unknown): string | null => {
+            if (val === undefined || val === null) return null
+            if (Array.isArray(val)) {
+              if (val.length === 0) return null
+              return val
+                .map((v: unknown) => {
+                  if (v && typeof v === 'object') {
+                    const obj = v as Record<string, unknown>
+                    return String(obj.name ?? obj.slug ?? obj.id ?? '')
+                  }
+                  return String(v)
+                })
+                .join(',')
+            }
+            if (typeof val === 'object') {
+              const obj = val as Record<string, unknown>
+              if (obj.name) return String(obj.name)
+              if (obj.slug) return String(obj.slug)
+              if (obj.id) return String(obj.id)
+              return JSON.stringify(val)
+            }
+            return String(val)
+          }
+
+          const safeParse = (data: unknown): unknown => {
+            if (!data) return undefined
+            if (typeof data === 'object') return data
+            try {
+              return JSON.parse(String(data))
+            } catch (e) {
+              return undefined
+            }
+          }
+          const targetId = item?.id || originalItem?.id
+          if (!targetId) {
+            console.warn('[EditLog] 無法取得目標 ID，取消紀錄')
+            return
+          }
+
+          const fullQuery = `
+            id slug title subtitle state publishedDate publishedDateString
+            heroCaption style isMember memberFeed isFeatured isAdvertised
+            hiddenAdvertised isAdult auto_faq redirect adTrace css
+            og_title og_description extend_byline
+            sections { id name } categories { id name }
+            writers { id name } photographers { id name }
+            camera_man { id name } designers { id name }
+            engineers { id name } vocals { id name }
+            heroVideo { id name } heroImage { id name } og_image { id name }
+            topics { id name }
+            relatedsOne { id slug } relatedsTwo { id slug } relateds { id slug }
+            tags { id name } related_videos { id name }
+            brief content
+          `
+
+          const fullNewItem =
+            operation !== 'delete'
+              ? ((await context.sudo().query.Post.findOne({
+                  where: { id: String(targetId) },
+                  query: fullQuery,
+                })) as Record<string, unknown>)
+              : null
+
+          const oldItemBase = (originalItem as Record<string, unknown>) || {}
+
+          const blackList = [
+            'id',
+            'apiData',
+            'apiDataBrief',
+            'updatedAt',
+            'createdAt',
+            'publishedDateString',
+            'updateTimeStamp',
+            'lockBy',
+            'lockExpireAt',
+            'manualOrderOfWriters',
+            'manualOrderOfSections',
+            'manualOrderOfCategories',
+            'manualOrderOfRelateds',
+            'manualOrderOfRelatedVideos',
+            'tags_algo',
+            'faqs_algo',
+            'from_External_relateds',
+            'groups',
+          ]
+
+          const editedData: Record<string, string | null> = {}
+          let briefObject: unknown = undefined
+          let contentObject: unknown = undefined
+
+          if (operation === 'update') {
+            const newItem = fullNewItem || {}
+            Object.keys(resolvedData || {}).forEach((key) => {
+              if (
+                blackList.includes(key) ||
+                key === 'brief' ||
+                key === 'content'
+              )
+                return
+
+              const oldValue = formatValueForLog(oldItemBase[key])
+              const newValue = formatValueForLog(newItem[key])
+
+              if (oldValue !== newValue) {
+                editedData[key] = newValue ?? 'null'
+              }
+            })
+
+            // 只在 brief/content 有實際變動時才記錄
+            if (resolvedData.brief !== undefined) {
+              const oldBrief = JSON.stringify(oldItemBase.brief ?? null)
+              const newBrief = JSON.stringify(newItem.brief ?? null)
+
+              if (oldBrief !== newBrief) {
+                briefObject = newItem.brief
+              }
+            }
+            if (resolvedData.content !== undefined) {
+              const oldContent = JSON.stringify(oldItemBase.content ?? null)
+              const newContent = JSON.stringify(newItem.content ?? null)
+
+              if (oldContent !== newContent) {
+                contentObject = newItem.content
+              }
+            }
+          } else {
+            // create: 從 fullNewItem（GraphQL query）取得完整資料
+            // delete: afterOperation 觸發時文章已刪除，直接用 originalItem（Prisma raw row）
+            //         relationship 欄位只有 id，不會有展開的 name
+            const target =
+              operation === 'delete' ? oldItemBase : fullNewItem || {}
+
+            Object.keys(target).forEach((key) => {
+              if (
+                blackList.includes(key) ||
+                key === 'brief' ||
+                key === 'content'
+              )
+                return
+              editedData[key] = formatValueForLog(target[key])
+            })
+            briefObject = target.brief
+            contentObject = target.content
+          }
+
+          if (
+            operation === 'update' &&
+            Object.keys(editedData).length === 0 &&
+            briefObject === undefined &&
+            contentObject === undefined
+          ) {
+            return
+          }
+
+          const postSlug =
+            operation === 'delete'
+              ? oldItemBase?.slug || String(targetId)
+              : fullNewItem?.slug || String(targetId)
+
+          await context.sudo().query.EditLog.createOne({
+            data: {
+              name: editorName,
+              operation: operation,
+              postSlug: String(postSlug),
+              brief: safeParse(briefObject),
+              content: safeParse(contentObject),
+              changedList: JSON.stringify(editedData),
+            },
+          })
+
+          console.log(`[EditLog] ${operation} 成功紀錄: ${postSlug}`)
+        } catch (err) {
+          console.error(`[EditLog] ${operation} 發生錯誤:`, err)
+        }
       }
     },
   },

--- a/packages/mirrormedia/lists/index.ts
+++ b/packages/mirrormedia/lists/index.ts
@@ -19,6 +19,7 @@ import Group from './Group'
 import AnnouncementScope from './AnnouncementScope'
 import Announcement from './Announcement'
 import PromoteTopic from './PromoteTopic'
+import EditLog from './EditLog'
 
 export const listDefinition = {
   AudioFile: Audio,
@@ -42,4 +43,5 @@ export const listDefinition = {
   User,
   Video,
   Group,
+  EditLog,
 }

--- a/packages/mirrormedia/migrations/20260422081108_add_edit_log/migration.sql
+++ b/packages/mirrormedia/migrations/20260422081108_add_edit_log/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "EditLog" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL DEFAULT '',
+    "operation" TEXT NOT NULL DEFAULT '',
+    "postSlug" TEXT NOT NULL DEFAULT '',
+    "changedList" TEXT NOT NULL DEFAULT '',
+    "brief" JSONB,
+    "content" JSONB,
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "EditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "EditLog_postSlug_idx" ON "EditLog"("postSlug");
+
+-- CreateIndex
+CREATE INDEX "EditLog_createdBy_idx" ON "EditLog"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "EditLog_updatedBy_idx" ON "EditLog"("updatedBy");
+
+-- AddForeignKey
+ALTER TABLE "EditLog" ADD CONSTRAINT "EditLog_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EditLog" ADD CONSTRAINT "EditLog_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/mirrormedia/schema.graphql
+++ b/packages/mirrormedia/schema.graphql
@@ -2496,6 +2496,82 @@ input GroupCreateInput {
   updatedBy: UserRelateToOneForCreateInput
 }
 
+type EditLog {
+  id: ID!
+  name: String
+  operation: String
+  postSlug: String
+  changedList: String
+  brief: JSON
+  briefPreview: String
+  content: JSON
+  contentPreview: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+input EditLogWhereUniqueInput {
+  id: ID
+}
+
+input EditLogWhereInput {
+  AND: [EditLogWhereInput!]
+  OR: [EditLogWhereInput!]
+  NOT: [EditLogWhereInput!]
+  id: IDFilter
+  name: StringFilter
+  operation: StringFilter
+  postSlug: StringFilter
+  changedList: StringFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input EditLogOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  operation: OrderDirection
+  postSlug: OrderDirection
+  changedList: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input EditLogUpdateInput {
+  name: String
+  operation: String
+  postSlug: String
+  changedList: String
+  brief: JSON
+  content: JSON
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input EditLogUpdateArgs {
+  where: EditLogWhereUniqueInput!
+  data: EditLogUpdateInput!
+}
+
+input EditLogCreateInput {
+  name: String
+  operation: String
+  postSlug: String
+  changedList: String
+  brief: JSON
+  content: JSON
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -2628,6 +2704,12 @@ type Mutation {
   updateGroups(data: [GroupUpdateArgs!]!): [Group]
   deleteGroup(where: GroupWhereUniqueInput!): Group
   deleteGroups(where: [GroupWhereUniqueInput!]!): [Group]
+  createEditLog(data: EditLogCreateInput!): EditLog
+  createEditLogs(data: [EditLogCreateInput!]!): [EditLog]
+  updateEditLog(where: EditLogWhereUniqueInput!, data: EditLogUpdateInput!): EditLog
+  updateEditLogs(data: [EditLogUpdateArgs!]!): [EditLog]
+  deleteEditLog(where: EditLogWhereUniqueInput!): EditLog
+  deleteEditLogs(where: [EditLogWhereUniqueInput!]!): [EditLog]
   endSession: Boolean!
   authenticateUserWithPassword(email: String!, password: String!): UserAuthenticationWithPasswordResult
   createInitialUser(data: CreateInitialUserInput!): UserAuthenticationWithPasswordSuccess!
@@ -2715,6 +2797,9 @@ type Query {
   groups(where: GroupWhereInput! = {}, orderBy: [GroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: GroupWhereUniqueInput): [Group!]
   group(where: GroupWhereUniqueInput!): Group
   groupsCount(where: GroupWhereInput! = {}): Int
+  editLogs(where: EditLogWhereInput! = {}, orderBy: [EditLogOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: EditLogWhereUniqueInput): [EditLog!]
+  editLog(where: EditLogWhereUniqueInput!): EditLog
+  editLogsCount(where: EditLogWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
   allPostsForRelation(where: JSON, take: Int, skip: Int, orderBy: JSON): [PostForRelation!]

--- a/packages/mirrormedia/schema.prisma
+++ b/packages/mirrormedia/schema.prisma
@@ -586,6 +586,8 @@ model User {
   from_Video_updatedBy             Video[]             @relation("Video_updatedBy")
   from_Group_createdBy             Group[]             @relation("Group_createdBy")
   from_Group_updatedBy             Group[]             @relation("Group_updatedBy")
+  from_EditLog_createdBy           EditLog[]           @relation("EditLog_createdBy")
+  from_EditLog_updatedBy           EditLog[]           @relation("EditLog_updatedBy")
 }
 
 model Video {
@@ -631,6 +633,26 @@ model Group {
   updatedBy   User?      @relation("Group_updatedBy", fields: [updatedById], references: [id])
   updatedById Int?       @map("updatedBy")
 
+  @@index([createdById])
+  @@index([updatedById])
+}
+
+model EditLog {
+  id          Int       @id @default(autoincrement())
+  name        String    @default("")
+  operation   String    @default("")
+  postSlug    String    @default("")
+  changedList String    @default("")
+  brief       Json?
+  content     Json?
+  createdAt   DateTime?
+  updatedAt   DateTime?
+  createdBy   User?     @relation("EditLog_createdBy", fields: [createdById], references: [id])
+  createdById Int?      @map("createdBy")
+  updatedBy   User?     @relation("EditLog_updatedBy", fields: [updatedById], references: [id])
+  updatedById Int?      @map("updatedBy")
+
+  @@index([postSlug])
   @@index([createdById])
   @@index([updatedById])
 }

--- a/packages/mirrormedia/utils/formatChangedList.ts
+++ b/packages/mirrormedia/utils/formatChangedList.ts
@@ -1,0 +1,24 @@
+/**
+ * 將 JSON 字串轉成多行 key:value 文字列表，並去掉第一個 key（id）
+ *
+ * @param changedList - JSON 字串
+ * @returns 格式化後的多行字串
+ */
+export const formatChangedList = (changedList: string): string => {
+  let changedListObj: Record<string, unknown>
+
+  try {
+    changedListObj = JSON.parse(changedList)
+  } catch (err) {
+    return changedList
+  }
+
+  const result = Object.keys(changedListObj)
+    .filter((key) => key !== 'id')
+    .map((key) => {
+      const value = changedListObj[key]
+      return `${key}:${String(value)}`
+    })
+
+  return result.join('\n')
+}


### PR DESCRIPTION
  - Add EditLog list with name, operation, postSlug, changedList, brief, content fields
  - Add afterOperation hook in Post to record editor, changed fields, and content snapshots
  - Add formatChangedList utility to convert JSON diff to readable key:value text
  - Add briefPreview/contentPreview virtual fields for list view display