### PR TITLE
fix(mirrormedia): label unauthenticated EditLog entries as '系統自動'

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -1035,7 +1035,7 @@ const listConfigurations = list({
         operation === 'delete'
       ) {
         try {
-          const editorName = context.session?.data?.name || '未知用戶'
+          const editorName = context.session?.data?.name || '系統自動'
 
           const formatValueForLog = (val: unknown): string | null => {
             if (val === undefined || val === null) return null


### PR DESCRIPTION
Replace '未知用戶' with '系統自動' so that operations triggered by Cloud Scheduler (scheduled publishing, algorithm relateds update) are clearly identified as system actions rather than unknown users, preserving the audit trail without misleading reviewers.
                                                    
Note: EditLog is an audit aid, not a security control. Unauthenticated mutations succeed in gql access-control mode regardless — '系統自動' entries help narrow the scope of post-incident investigation but do not detect or prevent endpoint exposure.                                         
  
                                              
                                             
  