### PR TITLE
feat(mirrormedia): copy original image to resized targets via afterOperation hook

### DIFF
--- a/packages/mirrormedia/environment-variables.ts
+++ b/packages/mirrormedia/environment-variables.ts
@@ -27,6 +27,9 @@ const {
   PROJECT_ID,
   LOCATION,
   PROMOTE_TOPIC_SERVICE_URL,
+  COPY_QUEUE_NAME,
+  IMAGE_PROCESSOR_URL,
+  SCHEDULER_KEY,
 } = process.env
 
 enum DatabaseProvider {
@@ -90,5 +93,10 @@ export default {
   queueName: QUEUE_NAME || 'external-tagging-dev',
   projectID: PROJECT_ID || 'mirrormedia',
   location: LOCATION || 'asia-east1',
+  copyQueueName: COPY_QUEUE_NAME || 'image-copy-retry-dev',
+  imageProcessor: {
+    url: IMAGE_PROCESSOR_URL || '',
+    schedulerKey: SCHEDULER_KEY || '',
+  },
   promoteTopicServiceUrl: PROMOTE_TOPIC_SERVICE_URL,
 }

--- a/packages/mirrormedia/lists/Image.ts
+++ b/packages/mirrormedia/lists/Image.ts
@@ -1,10 +1,20 @@
+import { Storage } from '@google-cloud/storage'
 import envVar from '../environment-variables'
 import { utils } from '@mirrormedia/lilith-core'
 import { list, graphql } from '@keystone-6/core'
-import { file, image, text, select, virtual, checkbox } from '@keystone-6/core/fields'
+import {
+  file,
+  image,
+  text,
+  select,
+  virtual,
+  checkbox,
+} from '@keystone-6/core/fields'
 import { getFileURL } from '../utils/common'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
+
+const gcsBucket = new Storage().bucket(envVar.gcs.bucket)
 
 const listConfigurations = list({
   db: {
@@ -237,6 +247,46 @@ const listConfigurations = list({
       initialColumns: ['id', 'name', 'imageFile'],
       initialSort: { field: 'id', direction: 'DESC' },
       pageSize: 50,
+    },
+  },
+
+  hooks: {
+    afterOperation: async ({ operation, item, originalItem }) => {
+      if (operation === 'delete') return
+      if (!item?.imageFile_id) return
+      // update 只有換圖才重新複製
+      if (
+        operation === 'update' &&
+        item.imageFile_id === originalItem?.imageFile_id
+      )
+        return
+
+      const filename = item.imageFile_id as string
+      const ext = item.imageFile_extension ? `.${item.imageFile_extension}` : ''
+      const gcsSourcePath = `images/${filename}${ext}`
+
+      const width =
+        typeof item.imageFile_width === 'number' ? item.imageFile_width : 0
+      const height =
+        typeof item.imageFile_height === 'number' ? item.imageFile_height : 0
+      const targets =
+        width >= height
+          ? ['w480', 'w800', 'w1600', 'w2400']
+          : ['w480', 'w800', 'w1200', 'w1600']
+
+      await Promise.all(
+        targets.map(async (target) => {
+          const gcsDestPath = `images/${filename}-${target}${ext}`
+          try {
+            await gcsBucket
+              .file(gcsSourcePath)
+              .copy(gcsBucket.file(gcsDestPath))
+            console.log(`[Image hook] Copied ${gcsSourcePath} → ${gcsDestPath}`)
+          } catch (err) {
+            console.error(`[Image hook] Failed to copy to ${gcsDestPath}:`, err)
+          }
+        })
+      )
     },
   },
 

--- a/packages/mirrormedia/lists/Image.ts
+++ b/packages/mirrormedia/lists/Image.ts
@@ -1,4 +1,5 @@
 import { Storage } from '@google-cloud/storage'
+import { CloudTasksClient, protos } from '@google-cloud/tasks'
 import envVar from '../environment-variables'
 import { utils } from '@mirrormedia/lilith-core'
 import { list, graphql } from '@keystone-6/core'
@@ -15,6 +16,41 @@ import { getFileURL } from '../utils/common'
 const { allowRoles, admin, moderator, editor } = utils.accessControl
 
 const gcsBucket = new Storage().bucket(envVar.gcs.bucket)
+const tasksClient = new CloudTasksClient()
+
+async function enqueueCopyTask(source: string, dest: string) {
+  try {
+    const parent = tasksClient.queuePath(
+      envVar.projectID,
+      envVar.location,
+      envVar.copyQueueName
+    )
+    const task = {
+      httpRequest: {
+        httpMethod: protos.google.cloud.tasks.v2.HttpMethod.POST,
+        url: `${envVar.imageProcessor.url}/copy_blob`,
+        headers: { 'Content-Type': 'application/json' },
+        body: Buffer.from(
+          JSON.stringify({
+            key: envVar.imageProcessor.schedulerKey,
+            bucket: envVar.gcs.bucket,
+            source,
+            dest,
+          })
+        ),
+      },
+    }
+    const [response] = await tasksClient.createTask({ parent, task })
+    console.log(
+      `[Image hook] Enqueued copy task: ${source} → ${dest}: ${response.name}`
+    )
+  } catch (error) {
+    console.error(
+      `[Image hook] CRITICAL: copy failed AND enqueue failed, manual recovery needed: ${source} → ${dest}:`,
+      error
+    )
+  }
+}
 
 const listConfigurations = list({
   db: {
@@ -283,7 +319,11 @@ const listConfigurations = list({
               .copy(gcsBucket.file(gcsDestPath))
             console.log(`[Image hook] Copied ${gcsSourcePath} → ${gcsDestPath}`)
           } catch (err) {
-            console.error(`[Image hook] Failed to copy to ${gcsDestPath}:`, err)
+            console.error(
+              `[Image hook] Copy failed, enqueuing retry: ${gcsDestPath}`,
+              err
+            )
+            await enqueueCopyTask(gcsSourcePath, gcsDestPath)
           }
         })
       )

--- a/packages/mirrormedia/package.json
+++ b/packages/mirrormedia/package.json
@@ -21,6 +21,7 @@
     "@apollo/utils.keyvadapter": "^3.0.0",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "11.11.0",
+    "@google-cloud/storage": "^7.19.0",
     "@google-cloud/tasks": "^6.2.1",
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.2.0",


### PR DESCRIPTION
#### Summary                                                                                                                                                                                                           
  - Add afterOperation hook to Image list that automatically copies the original uploaded image to resized target paths on GCS (-w480, -w800, -w1600/-w1200, -w2400) after create/update                             
  - Each copied file triggers a GCS OBJECT_FINALIZE event, which the image-processor service picks up to perform the actual resize and watermark operations                                                        
  - Skip re-copy on update if imageFile_id hasn't changed (same image, only metadata updated)
                                                                                                            
 #### How it works                                                                                                                                                                                   
  Upload image (CMS)                                                                  
    → Keystone saves images/{id}.jpg to GCS + DB stores width/height                                        
    → afterOperation hook fires                                                                             
    → Copies original to images/{id}-w480.jpg, -w800.jpg, etc. (same content)                               
    → Each copy triggers OBJECT_FINALIZE → image-processor resizes in place                                 
                                                                                      
  #### Notes                                                                                                                                        
  - Target sizes follow orientation: landscape → w480/w800/w1600/w2400, portrait → w480/w800/w1200/w1600 