### PR TITLE
feat(mirrortv): add preview button to Post and restrict video worker to CMS mode

### DIFF
--- a/packages/mirrortv/express-mini-apps/preview/app.js
+++ b/packages/mirrortv/express-mini-apps/preview/app.js
@@ -38,7 +38,7 @@ export function createPreviewMiniApp({ previewServer, keystoneContext }) {
     target: previewServer.origin,
     changeOrigin: true,
     onProxyRes: (proxyRes) => {
-      // The response from preview nuxt server might be with Cache-Control header.
+      // The response from preview Next.js server might be with Cache-Control header.
       // However, we don't want to get cached responses for `draft` posts.
       // Therefore, we do not cache html response intentionlly by overwritting the Cache-Control header.
       proxyRes.headers['cache-control'] = 'no-store'

--- a/packages/mirrortv/keystone.ts
+++ b/packages/mirrortv/keystone.ts
@@ -126,18 +126,17 @@ export default withAuth(
               keystoneContext: context,
             })
           )
-        }
 
-        const initWorker = async () => {
-          // 啟動 Video Worker
-          try {
-            await startVideoWorker(context)
-            console.log('Video Duration Processing Worker started')
-          } catch (error) {
-            console.error('Failed to start Video Duration Worker:', error)
+          const initWorker = async () => {
+            try {
+              await startVideoWorker(context)
+              console.log('Video Duration Processing Worker started')
+            } catch (error) {
+              console.error('Failed to start Video Duration Worker:', error)
+            }
           }
+          initWorker()
         }
-        initWorker()
       },
     },
   })

--- a/packages/mirrortv/lists/Post.ts
+++ b/packages/mirrortv/lists/Post.ts
@@ -490,6 +490,23 @@ const listConfigurations = list({
         },
       }),
     }),
+
+    preview: virtual({
+      field: graphql.field({
+        type: graphql.JSON,
+        resolve(item: Record<string, unknown>): Record<string, string> {
+          return {
+            href: `${envVar.previewServer.path}/story/${item?.slug}`,
+            label: 'Preview',
+          }
+        },
+      }),
+      ui: {
+        views: './lists/views/link-button',
+        createView: { fieldMode: 'hidden' },
+        listView: { fieldMode: 'hidden' },
+      },
+    }),
   },
 
   ui: {

--- a/packages/mirrortv/schema.graphql
+++ b/packages/mirrortv/schema.graphql
@@ -1444,6 +1444,7 @@ type Post {
   lockBy: User
   lockExpireAt: DateTime
   trimmedApiData: JSON
+  preview: JSON
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User


### PR DESCRIPTION
  - Add preview virtual field to Post list so editors can preview draft posts from Admin UI
  - Restrict startVideoWorker to ACL.CMS only to avoid competing with the same BullMQ queue when running as a preview instance