### PR TITLE
feat(mirrormedia): add CDN cache invalidation on external state change

### DIFF
--- a/packages/mirrormedia/lists/External.ts
+++ b/packages/mirrormedia/lists/External.ts
@@ -255,4 +255,54 @@ const listConfigurations = list({
   },
 })
 
-export default utils.addTrackingFields(listConfigurations)
+const extendedListConfigurations = utils.addTrackingFields(listConfigurations)
+
+if (envVar.invalidateCDNCacheServerURL) {
+  const originalAfterOperation =
+    extendedListConfigurations.hooks?.afterOperation
+
+  extendedListConfigurations.hooks = {
+    ...extendedListConfigurations.hooks,
+    afterOperation: async (params) => {
+      if (typeof originalAfterOperation === 'function') {
+        await originalAfterOperation(params)
+      }
+
+      const { operation, item, originalItem } = params
+      const isDelete = operation === 'delete'
+      const isUpdate = operation === 'update'
+      const isStateChanged = item?.state !== originalItem?.state
+
+      if (isDelete || (isUpdate && isStateChanged)) {
+        const slug = item?.slug || originalItem?.slug
+        if (slug) {
+          try {
+            const res = await fetch(
+              `${envVar.invalidateCDNCacheServerURL}/external`,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ slug }),
+              }
+            )
+            if (!res.ok) {
+              const errorText = await res.text()
+              console.error(
+                `[External CDN Cache] Failed to refresh external ${slug}. Status: ${res.status}, Error: ${errorText}`
+              )
+            } else {
+              console.log(`[External CDN Cache] Refreshing external: ${slug}`)
+            }
+          } catch (error) {
+            console.error(
+              `[External CDN Cache] Failed to refresh external ${slug}:`,
+              error
+            )
+          }
+        }
+      }
+    },
+  }
+}
+
+export default extendedListConfigurations

--- a/packages/mirrormedia/lists/External.ts
+++ b/packages/mirrormedia/lists/External.ts
@@ -264,43 +264,50 @@ if (envVar.invalidateCDNCacheServerURL) {
   extendedListConfigurations.hooks = {
     ...extendedListConfigurations.hooks,
     afterOperation: async (params) => {
+      const { operation, item, originalItem } = params
+      const tasks: Promise<unknown>[] = []
+
       if (typeof originalAfterOperation === 'function') {
-        await originalAfterOperation(params)
+        tasks.push(originalAfterOperation(params))
       }
 
-      const { operation, item, originalItem } = params
-      const isDelete = operation === 'delete'
-      const isUpdate = operation === 'update'
       const isStateChanged = item?.state !== originalItem?.state
 
-      if (isDelete || (isUpdate && isStateChanged)) {
+      if (
+        operation === 'delete' ||
+        (operation === 'update' && isStateChanged)
+      ) {
         const slug = item?.slug || originalItem?.slug
         if (slug) {
-          try {
-            const res = await fetch(
-              `${envVar.invalidateCDNCacheServerURL}/external`,
-              {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ slug }),
-              }
-            )
-            if (!res.ok) {
-              const errorText = await res.text()
-              console.error(
-                `[External CDN Cache] Failed to refresh external ${slug}. Status: ${res.status}, Error: ${errorText}`
-              )
-            } else {
-              console.log(`[External CDN Cache] Refreshing external: ${slug}`)
-            }
-          } catch (error) {
-            console.error(
-              `[External CDN Cache] Failed to refresh external ${slug}:`,
-              error
-            )
-          }
+          tasks.push(
+            fetch(`${envVar.invalidateCDNCacheServerURL}/external`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ slug }),
+            })
+              .then(async (res) => {
+                if (!res.ok) {
+                  const errorText = await res.text()
+                  console.error(
+                    `[External CDN Cache] Failed to refresh external ${slug}. Status: ${res.status}, Error: ${errorText}`
+                  )
+                } else {
+                  console.log(
+                    `[External CDN Cache] Refreshing external: ${slug}`
+                  )
+                }
+              })
+              .catch((error) => {
+                console.error(
+                  `[External CDN Cache] Failed to refresh external ${slug}:`,
+                  error
+                )
+              })
+          )
         }
       }
+
+      await Promise.allSettled(tasks)
     },
   }
 }


### PR DESCRIPTION
#### Summary
  - Add CDN cache invalidation hook to External list in mirrormedia
  - Triggers on state change (update) or delete operation
  - Calls `{INVALID_CDN_CACHE_SERVER_URL}/external` with the post slug
                                              
#### Note                                                                                              
Local testing is not possible because `invalidate-cdn-cache` has `ingress=internal` and only accepts requests from Cloud Run services within the same GCP project. 