### PR TITLE
fix(mirrormedia): remove auto_faq from EditLog POST_BASE_QUERY

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -35,7 +35,7 @@ snapshotCleanupTimer.unref()
 const POST_BASE_QUERY = `
   id slug title subtitle state publishedDate publishedDateString
   heroCaption style isMember memberFeed isFeatured isAdvertised
-  hiddenAdvertised isAdult auto_faq redirect adTrace css
+  hiddenAdvertised isAdult redirect adTrace css
   og_title og_description extend_byline
   sections { id name } categories { id name }
   writers { id name } photographers { id name }


### PR DESCRIPTION
auto_faq 欄位目前僅存在 staging，prod schema 尚未包含此欄位。            
EditLog 的 POST_BASE_QUERY 查詢該欄位會在 prod 觸發 GraphQLError: Cannot query field "auto_faq" on type "Post"，導致 create/update/beforeOperation snapshot 全部失敗。                      
先將該欄位從 EditLog 查詢中移除，待 auto_faq 確定上線後再評估是否納入追蹤。                            
  