### PR TITLE
fix(mirrormedia): add originalItem to Post afterOperation destructure

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -943,7 +943,13 @@ const listConfigurations = list({
       }
       return
     },
-    afterOperation: async ({ operation, item, context, resolvedData }) => {
+    afterOperation: async ({
+      operation,
+      item,
+      originalItem,
+      context,
+      resolvedData,
+    }) => {
       if (
         resolvedData &&
         resolvedData.state &&


### PR DESCRIPTION
EditLog logic references originalItem as a fallback, but the prod afterOperation signature was missing it, causing "ReferenceError: originalItem is not defined" on create/update/delete. Align the destructure with main so the upcoming auto_faq merge stays conflict-free