### PR TITLE
fix(mirrormedia): skip lockby validation for cron

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -863,7 +863,11 @@ const listConfigurations = list({
       if (envVar.accessControlStrategy === 'gql') {
         return
       }
-      if (context.session?.data?.role !== UserRole.Admin) {
+      // system operations (cron, sudo) have no session; editor conflict check doesn't apply
+      if (!context.session) {
+        return
+      }
+      if (context.session.data?.role !== UserRole.Admin) {
         if (operation === 'update') {
           const { lockBy } = await context.prisma.Post.findUnique({
             where: { id: Number(item.id) },

--- a/packages/mirrormedia/lists/User.ts
+++ b/packages/mirrormedia/lists/User.ts
@@ -81,12 +81,9 @@ const listConfigurations = list({
     filter: {
       query: async (auth) => {
         if (admin(auth) || moderator(auth)) return true
-        if (!auth.session) return false
-        return {
-          id: {
-            equals: auth.session.data.id,
-          },
-        }
+        const userId = auth.session?.data?.id
+        if (!userId) return false
+        return { id: { equals: userId } }
       },
     },
   },

--- a/packages/mirrormedia/lists/User.ts
+++ b/packages/mirrormedia/lists/User.ts
@@ -81,12 +81,11 @@ const listConfigurations = list({
     filter: {
       query: async (auth) => {
         if (admin(auth) || moderator(auth)) return true
-        else {
-          return {
-            id: {
-              equals: auth.session.data.id,
-            },
-          }
+        if (!auth.session) return false
+        return {
+          id: {
+            equals: auth.session.data.id,
+          },
         }
       },
     },


### PR DESCRIPTION
## Description

1. Skip Post edit-lock check when no session (for cronjobs)

## Extra

1. Guard `auth.session` in User filter (anonymous query bug found while debugging above)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214730116936394