### PR TITLE
feat(mirrortv): add manualOrderOfCategories to External list

### DIFF
--- a/packages/mirrortv/lists/External.ts
+++ b/packages/mirrortv/lists/External.ts
@@ -7,6 +7,7 @@ import {
   select,
   timestamp,
   virtual,
+  json,
 } from '@keystone-6/core/fields'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
@@ -173,6 +174,19 @@ const listConfigurations = list({
       label: '分類',
       ref: 'Category',
       many: true,
+      ui: {
+        labelField: 'name',
+        displayMode: 'select',
+        views: './lists/views/post/categories/index',
+      },
+    }),
+    manualOrderOfCategories: json({
+      isFilterable: false,
+      label: '分類手動排序結果',
+      ui: {
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'hidden' },
+      },
     }),
 
     source: text({
@@ -260,4 +274,14 @@ if (envVar.invalidateCDNCacheServerURL) {
   }
 }
 
-export default extendedListConfigurations
+export default utils.addManualOrderRelationshipFields(
+  [
+    {
+      fieldName: 'manualOrderOfCategories',
+      targetFieldName: 'categories',
+      targetListName: 'Category',
+      targetListLabelField: 'name',
+    },
+  ],
+  extendedListConfigurations
+)

--- a/packages/mirrortv/migrations/20260514101840_add_external_manual_order_of_categories/migration.sql
+++ b/packages/mirrortv/migrations/20260514101840_add_external_manual_order_of_categories/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "External" ADD COLUMN     "manualOrderOfCategories" JSONB;

--- a/packages/mirrortv/schema.graphql
+++ b/packages/mirrortv/schema.graphql
@@ -1050,11 +1050,13 @@ type External {
   tagsCount(where: TagWhereInput! = {}): Int
   categories(where: CategoryWhereInput! = {}, orderBy: [CategoryOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CategoryWhereUniqueInput): [Category!]
   categoriesCount(where: CategoryWhereInput! = {}): Int
+  manualOrderOfCategories: JSON
   source: String
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User
   updatedBy: User
+  categoriesInInputOrder: [Category]
 }
 
 input ExternalWhereUniqueInput {
@@ -1120,6 +1122,7 @@ input ExternalUpdateInput {
   content: JSON
   tags: TagRelateToManyForUpdateInput
   categories: CategoryRelateToManyForUpdateInput
+  manualOrderOfCategories: JSON
   source: String
   createdAt: DateTime
   updatedAt: DateTime
@@ -1154,6 +1157,7 @@ input ExternalCreateInput {
   content: JSON
   tags: TagRelateToManyForCreateInput
   categories: CategoryRelateToManyForCreateInput
+  manualOrderOfCategories: JSON
   source: String
   createdAt: DateTime
   updatedAt: DateTime

--- a/packages/mirrortv/schema.prisma
+++ b/packages/mirrortv/schema.prisma
@@ -257,6 +257,7 @@ model External {
   content                          Json?
   tags                             Tag[]          @relation("External_tags")
   categories                       Category[]     @relation("External_categories")
+  manualOrderOfCategories          Json?
   source                           String         @default("")
   createdAt                        DateTime?
   updatedAt                        DateTime?


### PR DESCRIPTION
## Summary                                  
- 鏡報 RSS入稿由原本只分類到「鏡報」，為增加電視各 category 的稿量擴充為可根據文章分類 mapping 到電視指定分類。                        
- CMS 新增 `External` list 的 `manualOrderOfCategories`  欄位，支援多個分類的排序。
- TASK:   [Asana](https://app.asana.com/1/614399484723017/project/1214559748867622/task/1214626823755972?focus=true)
                                                                                                       
## Changes                                                            
- `lists/External.ts` — 新增 `manualOrderOfCategories` JSON 欄位，export 改用`addManualOrderRelationshipFields` wrapper
- `schema.graphql` / `schema.prisma` — 對應 schema 更新
- `migrations/20260514101840_add_external_manual_order_of_categories` — DB migration                 
   
## Test plan                                                                                         
- [ ] 確認 migration 執行無誤                              
- [ ] 確認 External 文章可同時帶多個分類（鏡報 + 電視指定分類）                                      
- [ ] 確認分類可手動排序