### PR TITLE
feat(mirrormedia): update Post auto tagging trigger to fire on first publish or content change without related articles

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -980,8 +980,9 @@ const listConfigurations = list({
         // Condition 2: already published, content changed, and no related articles
         if (!shouldTriggerAutoTag && wasAlreadyPublished && stateIsPublished) {
           const contentChanged =
+            resolvedData?.content !== undefined &&
             JSON.stringify(item.content) !==
-            JSON.stringify(originalItem?.content)
+              JSON.stringify(originalItem?.content)
           if (contentChanged) {
             try {
               const postData = await context.sudo().query.Post.findOne({

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -969,27 +969,55 @@ const listConfigurations = list({
       context,
       resolvedData,
     }) => {
-      if (
-        resolvedData &&
-        resolvedData.state &&
-        resolvedData.state === PostStatus.Published &&
-        envVar.autotagging
-      ) {
-        try {
-          // trigger auto tagging and auto relation service
-          const response = await fetch(
-            envVar.dataServiceApi + '/post_tagging_with_relation?id=' + item.id,
-            {
-              method: 'GET',
+      if (envVar.autotagging && item) {
+        const stateIsPublished = item.state === PostStatus.Published
+        const wasAlreadyPublished = originalItem?.state === PostStatus.Published
+        const firstTimePublished = !wasAlreadyPublished && stateIsPublished
+
+        // Condition 1: first time published (draft/scheduled → published, or created directly as published)
+        let shouldTriggerAutoTag = firstTimePublished
+
+        // Condition 2: already published, content changed, and no related articles
+        if (!shouldTriggerAutoTag && wasAlreadyPublished && stateIsPublished) {
+          const contentChanged =
+            JSON.stringify(item.content) !==
+            JSON.stringify(originalItem?.content)
+          if (contentChanged) {
+            try {
+              const postData = await context.sudo().query.Post.findOne({
+                where: { id: String(item.id) },
+                query: 'relateds { id }',
+              })
+              const hasNoRelateds = !postData?.relateds?.length
+              shouldTriggerAutoTag = hasNoRelateds
+            } catch (err) {
+              console.error(
+                `[AUTO-TAG-RELATION] Failed to check relateds for post ${item.id}:`,
+                err
+              )
             }
-          )
-          if (!response.ok) {
+          }
+        }
+
+        if (shouldTriggerAutoTag) {
+          try {
+            const response = await fetch(
+              envVar.dataServiceApi +
+                '/post_tagging_with_relation?id=' +
+                item.id,
+              { method: 'GET' }
+            )
+            if (!response.ok) {
+              console.error(
+                `[AUTO-TAG-RELATION] Failed: ${response.status} ${response.statusText}`
+              )
+            }
+          } catch (error) {
             console.error(
-              `[AUTO-TAG-RELATION] Failed: ${response.status} ${response.statusText}`
+              `[AUTO-TAG-RELATION] Error for post ${item.id}:`,
+              error
             )
           }
-        } catch (error) {
-          console.error(`[AUTO-TAG-RELATION] Error:`, error)
         }
       }
       if (


### PR DESCRIPTION
## Summary                                                                                                                                                                       
- 將原本的 auto tagging 觸發條件（`resolvedData.state === 'published'`）改為透過 `item` 與 `originalItem` 做前後狀態比較                                                                  
- **Condition 1**：第一次發佈時觸發 — 文章從 draft/scheduled/archived 變成 published，或 create 時直接帶 published                                                                                   
- **Condition 2**：非第一次發佈，但內文有變更且沒有相關文章（`relateds`）時觸發   
- [Asana](https://app.asana.com/1/614399484723017/project/1199408264065173/task/1214821080637151?focus=true)                
                                                                                                       
## Original Logic                                                                                         
每次存檔的 mutation payload 若有帶 state: published 就會觸發 auto-tagging                         
                                                                                
## Changes                                                                                                                                                                        
  `packages/mirrormedia/lists/Post.ts ` 觸發邏輯                                                                 
  -  Condition 1：!wasAlreadyPublished && stateIsPublished 判斷為第一次發佈                          
  -  Condition 2：已發佈且內文有變更時，查詢相關文章確認為空才觸發 tagging                                                                     
                                                                                
## Test plan                                                                                                                                                                    
  - draft → published：auto tagging 觸發                                                               
  - scheduled → published：auto tagging 觸發                                                           
  - create 直接帶 published：auto tagging 觸發                                                         
  - 已發佈，內文未變更：auto tagging 不觸發                                                            
  - 已發佈，內文有變更，有相關文章：auto tagging 不觸發                                                
  - 已發佈，內文有變更，無相關文章：auto tagging 觸發                          
  - published → archived：auto tagging 不觸發  