### PR TITLE
fix(mirrormedia): skip auto tagging when post content is empty

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -976,19 +976,25 @@ const listConfigurations = list({
 
         // Condition 1: state transitions to published (any non-published state → published, or created directly as published)
         // only trigger if post has meaningful content (at least one block with non-empty text)
-        const contentBlocks = (item.content as any)?.blocks
+        // stateIsPublished short-circuits the block traversal when state is not published
         const hasContent =
-          Array.isArray(contentBlocks) &&
-          contentBlocks.some((b: any) => b?.text?.trim())
+          stateIsPublished &&
+          Array.isArray((item.content as any)?.blocks) &&
+          (item.content as any).blocks.some((b: any) => b?.text?.trim())
         let shouldTriggerAutoTag = firstTimePublished && hasContent
 
         // Condition 2: already published, content changed, and no related articles
-        if (!shouldTriggerAutoTag && wasAlreadyPublished && stateIsPublished) {
+        if (
+          !shouldTriggerAutoTag &&
+          wasAlreadyPublished &&
+          stateIsPublished &&
+          hasContent
+        ) {
           const contentChanged =
             resolvedData?.content !== undefined &&
             JSON.stringify(item.content) !==
               JSON.stringify(originalItem?.content)
-          if (contentChanged && hasContent) {
+          if (contentChanged) {
             try {
               const postData = await context.sudo().query.Post.findOne({
                 where: { id: String(item.id) },

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -974,8 +974,13 @@ const listConfigurations = list({
         const wasAlreadyPublished = originalItem?.state === PostStatus.Published
         const firstTimePublished = !wasAlreadyPublished && stateIsPublished
 
-        // Condition 1: first time published (draft/scheduled → published, or created directly as published)
-        let shouldTriggerAutoTag = firstTimePublished
+        // Condition 1: state transitions to published (any non-published state → published, or created directly as published)
+        // only trigger if post has meaningful content (at least one block with non-empty text)
+        const contentBlocks = (item.content as any)?.blocks
+        const hasContent =
+          Array.isArray(contentBlocks) &&
+          contentBlocks.some((b: any) => b?.text?.trim())
+        let shouldTriggerAutoTag = firstTimePublished && hasContent
 
         // Condition 2: already published, content changed, and no related articles
         if (!shouldTriggerAutoTag && wasAlreadyPublished && stateIsPublished) {
@@ -983,7 +988,7 @@ const listConfigurations = list({
             resolvedData?.content !== undefined &&
             JSON.stringify(item.content) !==
               JSON.stringify(originalItem?.content)
-          if (contentChanged) {
+          if (contentChanged && hasContent) {
             try {
               const postData = await context.sudo().query.Post.findOne({
                 where: { id: String(item.id) },


### PR DESCRIPTION
 ## Summary                                                                                           
- 在 Condition 1 與 Condition 2 加上內文非空的判斷，避免內文為空時 data service 以 metadata 產生不相關的 tag                                                              
                                        
## 原本問題
當文章在內文為空的情況下發佈，`auto_tagging` 仍會被觸發。data service 的 `get_content` 會拿到title、sections 等 metadata，`generate` 以此產生與內文無關的 tag。                                   
                                        
## Changes
`packages/mirrormedia/lists/Post.ts`                                         
  - 新增 `hasContent` 判斷：`blocks` 陣列中至少有一個 block 的 `text` 非空白                           
  - Condition 1：`firstTimePublished && hasContent`，空內文發佈不觸發          
  - Condition 2：`contentChanged && hasContent`，內文被清空時不觸發             
                                                                                                       
## Test plan                                                                                                                                                                 
  - [ ] 狀態轉 published，有內文：auto tagging 觸發                                                    
  - [ ] 狀態轉 published，無內文（null）：auto tagging 不觸發                                          
  - [ ] 狀態轉 published，blocks 全為空字串：auto tagging 不觸發                                       
  - [ ] 已發佈，內文從有改成空：auto tagging 不觸發                                                    
  - [ ] 已發佈，內文有實際變更，無 relateds：auto tagging 觸發