### PR TITLE
feat(mirrormedia): allow editor accounts to change their own password

### DIFF
--- a/packages/mirrormedia/lists/User.ts
+++ b/packages/mirrormedia/lists/User.ts
@@ -3,8 +3,31 @@ import { utils } from '@mirrormedia/lilith-core'
 
 import { text, password, select, checkbox } from '@keystone-6/core/fields'
 
-const { allowRolesForUsers, allowAllRoles, admin, moderator } =
+const { allowRolesForUsers, allowAllRoles, admin, moderator, editor } =
   utils.accessControl
+
+// Editors may change ONLY their own password (security: external reporter accounts
+// must move off the shared password). Everything else stays admin-only.
+//
+// Centralized "default-deny" design (fail-safe for fields added later):
+//   - operation.update: widened to admin + editor. We keep allowRolesForUsers (not
+//     allowAllRoles) so gql/preview deployments stay denied without a session and
+//     the first-user bootstrap bypass is preserved.
+//   - filter.update: row scope — non-admins can only target their own record.
+//   - ui.itemView.defaultFieldMode: every field is read-only for non-admins; only
+//     the password field opts back into edit mode for admin/editor.
+//   - hooks.validateInput: column scope — a non-admin update may only change the
+//     password; touching any other field is rejected (no privilege escalation).
+type FieldMode = 'edit' | 'read'
+type SessionArg = { session?: { data?: { role?: string } } }
+
+const itemViewDefaultFieldMode = ({ session }: SessionArg): FieldMode =>
+  session?.data?.role === 'admin' ? 'edit' : 'read'
+
+const passwordFieldMode = ({ session }: SessionArg): FieldMode => {
+  const role = session?.data?.role
+  return role === 'admin' || role === 'editor' ? 'edit' : 'read'
+}
 
 const listConfigurations = list({
   fields: {
@@ -21,6 +44,11 @@ const listConfigurations = list({
     password: password({
       label: '密碼',
       validation: { isRequired: true },
+      ui: {
+        itemView: {
+          fieldMode: passwordFieldMode,
+        },
+      },
     }),
     role: select({
       label: '角色權限',
@@ -70,11 +98,14 @@ const listConfigurations = list({
       initialSort: { field: 'id', direction: 'DESC' },
       pageSize: 50,
     },
+    itemView: {
+      defaultFieldMode: itemViewDefaultFieldMode,
+    },
   },
   access: {
     operation: {
       query: allowAllRoles(),
-      update: allowRolesForUsers(admin),
+      update: allowRolesForUsers(admin, editor),
       create: allowRolesForUsers(admin),
       delete: allowRolesForUsers(admin),
     },
@@ -85,9 +116,46 @@ const listConfigurations = list({
         if (!userId) return false
         return { id: { equals: userId } }
       },
+      // Non-admins (in practice an editor) can only target their own record.
+      update: async (auth) => {
+        if (admin(auth)) return true
+        const userId = auth.session?.data?.id
+        if (!userId) return false
+        return { id: { equals: userId } }
+      },
     },
   },
-  hooks: {},
+  hooks: {
+    // Column-level guard. Admins may edit everything; any other role (in practice an
+    // editor already scoped to their own record by filter.update) may only change the
+    // password. Runs on every update mutation, so it cannot be bypassed via GraphQL.
+    validateInput: async ({
+      operation,
+      item,
+      resolvedData,
+      context,
+      addValidationError,
+    }) => {
+      if (operation !== 'update') return
+      if (context.session?.data?.role === 'admin') return
+
+      const changed = resolvedData as Record<string, unknown>
+      const previous = (item ?? {}) as Record<string, unknown>
+      const changedFields = Object.keys(changed).filter(
+        (field) =>
+          field !== 'password' &&
+          changed[field] !== undefined &&
+          changed[field] !== previous[field]
+      )
+      if (changedFields.length > 0) {
+        addValidationError(
+          `你只能修改自己的密碼，不可變更其他欄位（${changedFields.join(
+            '、'
+          )}）。`
+        )
+      }
+    },
+  },
 })
 
 export default listConfigurations


### PR DESCRIPTION
## What

Allow `editor` accounts to change their own password in the 鏡週刊 CMS (`packages/mirrormedia`). Previously only `admin` could update the `User` list, so editors hit `Access denied: You cannot update that User` when editing their own account.

Asana: https://app.asana.com/1/614399484723017/project/1212235362791829/task/1214694956420490

## How

Centralized "default-deny" design in `lists/User.ts`:

- **operation.update** → `admin + editor` (kept `allowRolesForUsers`, not `allowAllRoles`, so `gql`/`preview` deployments stay denied without a session and the first-user bootstrap bypass is preserved)
- **filter.update** → non-admins can only target their own record (row scope)
- **ui.itemView.defaultFieldMode** → every field is read-only for non-admins; the password field opts back into edit for admin/editor (UI)
- **validateInput hook** → a non-admin update may only change the password; any other field change is rejected (column scope — fail-safe for fields added later)

Net effect: an editor can change only their own password; `role`/`email`/etc. stay admin-only, so no privilege escalation and no editing of other users. Admin behavior is unchanged. No DB migration (access-control + UI config only).

## Verification

- `tsc --strict` on `User.ts`: 0 errors
- ESLint: clean

Manual (recommended before merge), via `keystone dev`:
1. As an editor: open own User → only 密碼 editable, rest read-only; change password → saves.
2. As an editor: attempt to change role / another user → rejected (hook / filter).
3. As an admin: full edit of any user still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
