### PR TITLE
fix(mirrordaily): replace wrong PromoteTopic migration with correct prod version prod version

### DIFF
--- a/packages/mirrordaily/migrations/20260202035237_add_is_promoted_to_topic/migration.sql
+++ b/packages/mirrordaily/migrations/20260202035237_add_is_promoted_to_topic/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "Topic" ADD COLUMN     "isPromoted" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/mirrordaily/migrations/20260305053257_add_promote_topic_v2/migration.sql
+++ b/packages/mirrordaily/migrations/20260305053257_add_promote_topic_v2/migration.sql
@@ -1,11 +1,6 @@
-/*
-  Warnings:
-
-  - You are about to drop the column `isPromoted` on the `Topic` table. All the data in the column will be lost.
-
-*/
 -- AlterTable
-ALTER TABLE "Topic" DROP COLUMN "isPromoted";
+ALTER TABLE "Video" ALTER COLUMN "fileDuration" SET DEFAULT '',
+ALTER COLUMN "youtubeDuration" SET DEFAULT '';
 
 -- CreateTable
 CREATE TABLE "PromoteTopic" (


### PR DESCRIPTION
 ## 修復說明
補回 PromoteTopic migration，以 prod DB 為準，整理成一份乾淨的 migration。
註：原鏡報需求為增加 isPromoted checkbox，後需求調整為新增新的list，因此dev migration file 會多建立跟刪除該column

### 變更內容
  - 刪除 `20260202035237_add_is_promoted_to_topic`（ADD isPromoted checkbox，未部署到 staging/prod）
  - 刪除 `20260209085012_add_promote_topic_list`（DROP isPromoted checkbox + 錯誤版本的 PromoteTopic）
  - 新增 `20260305053257_add_promote_topic_v2`（與 staging/prod DB 一致的正確版本）

### Main(dev) DB 需要手動執行 ---> 還沒執行以下指令先待 code review 確認無誤後再執行
main(dev)DB 先執行以下 SQL，再進行 merge：

 ```
 DELETE FROM _prisma_migrations WHERE migration_name IN (
    '20260202035237_add_is_promoted_to_topic',
    '20260209085012_add_promote_topic_list'
  );
```

```
  INSERT INTO _prisma_migrations
    (id, checksum, finished_at, migration_name, logs, rolled_back_at, started_at, applied_steps_count)
  VALUES (
    gen_random_uuid(),
    '40c19e005ac1eef35ff9046f563ca561e2ffd8edd54363dc85ea9797e60b9fa9',
    NOW(),
    '20260305053257_add_promote_topic_v2',
    NULL, NULL, NOW(), 1
  );
```