### PR TITLE
feat: add traffic dashboard toggle

### DIFF
--- a/packages/mirrordaily/admin/components/CustomNavigation.tsx
+++ b/packages/mirrordaily/admin/components/CustomNavigation.tsx
@@ -16,6 +16,12 @@ const USER_ROLE_QUERY = gql`
   }
 `
 
+const TRAFFIC_DASHBOARD_ENABLED_QUERY = gql`
+  query TrafficDashboardEnabled {
+    trafficDashboardEnabled
+  }
+`
+
 export function CustomNavigation({
   lists,
   authenticatedItem,
@@ -35,10 +41,18 @@ export function CustomNavigation({
   })
   const isAdmin = data?.user?.role === 'admin'
 
+  const { data: trafficDashboardData } = useQuery(
+    TRAFFIC_DASHBOARD_ENABLED_QUERY
+  )
+  const isTrafficDashboardEnabled =
+    trafficDashboardData?.trafficDashboardEnabled === true
+
   return (
     <NavigationContainer authenticatedItem={authenticatedItem}>
       <NavItem href="/">Dashboard</NavItem>
-      {isAdmin && <NavItem href="/dashboard">PV Dashboard</NavItem>}
+      {isAdmin && isTrafficDashboardEnabled && (
+        <NavItem href="/dashboard">PV Dashboard</NavItem>
+      )}
       {/* creat post shortcut */}
       <NavItem key="create-post-shortcut" href="/custom-post-creation">
         Create Post <PlusIcon size="smallish" color="blue" />

--- a/packages/mirrordaily/environment-variables.ts
+++ b/packages/mirrordaily/environment-variables.ts
@@ -7,6 +7,7 @@ const {
   PREVIEW_SERVER_PATH,
   DASHBOARD_SERVER_ORIGIN,
   DASHBOARD_SERVER_PATH,
+  TRAFFIC_DASHBOARD_ENABLED,
   DATABASE_PROVIDER,
   DATABASE_URL,
   SESSION_SECRET,
@@ -54,6 +55,7 @@ export default {
       'https://traffic-analytics-web-dev-151209114015.asia-east1.run.app',
     path: DASHBOARD_SERVER_PATH || '/dashboard',
   },
+  trafficDashboardEnabled: TRAFFIC_DASHBOARD_ENABLED !== 'false',
   database: {
     provider:
       DATABASE_PROVIDER === 'sqlite'

--- a/packages/mirrordaily/environment-variables.ts
+++ b/packages/mirrordaily/environment-variables.ts
@@ -55,7 +55,7 @@ export default {
       'https://traffic-analytics-web-dev-151209114015.asia-east1.run.app',
     path: DASHBOARD_SERVER_PATH || '/dashboard',
   },
-  trafficDashboardEnabled: TRAFFIC_DASHBOARD_ENABLED !== 'false',
+  trafficDashboardEnabled: TRAFFIC_DASHBOARD_ENABLED?.toLowerCase() !== 'false',
   database: {
     provider:
       DATABASE_PROVIDER === 'sqlite'

--- a/packages/mirrordaily/keystone.ts
+++ b/packages/mirrordaily/keystone.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config'
-import { config } from '@keystone-6/core'
+import { config, graphql } from '@keystone-6/core'
 import { listDefinition as lists } from './lists'
 import envVar from './environment-variables'
 import express from 'express'
@@ -68,6 +68,14 @@ export default withAuth(
     graphql: graphqlConfig,
     lists,
     session,
+    extendGraphqlSchema: graphql.extend(() => ({
+      query: {
+        trafficDashboardEnabled: graphql.field({
+          type: graphql.nonNull(graphql.Boolean),
+          resolve: () => envVar.trafficDashboardEnabled,
+        }),
+      },
+    })),
     storage: {
       files: {
         kind: 'local',

--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -819,7 +819,12 @@ const listConfigurations = list({
       },
       ui: {
         createView: { fieldMode: 'hidden' },
-        itemView: { fieldMode: 'read' },
+        itemView: {
+          fieldMode: envVar.trafficDashboardEnabled ? 'read' : 'hidden',
+        },
+        listView: {
+          fieldMode: envVar.trafficDashboardEnabled ? 'read' : 'hidden',
+        },
       },
     }),
     preview: virtual({


### PR DESCRIPTION
## Description

The traffic dashboard project is kept in dev for now. This PR adds a feature toggle to hide its admin UI entries (PV Dashboard nav item and Post.pv field) while leaving the /dashboard proxy route and the pv column / GraphQL field intact, so the feature can be turned back on without code changes.

When TRAFFIC_DASHBOARD_ENABLED=false:
- PV Dashboard nav item is hidden (even for admin)
- Post.pv field is hidden in both list view and item view (DB / GraphQL access unchanged)

Toggle is resolved at runtime via GraphQL, so a Cloud Run env update + revision redeploy is enough — no image rebuild required.

## ENV

- [new] TRAFFIC_DASHBOARD_ENABLED — false to hide; unset or any other value keeps current behavior