### PR TITLE
fix(mirrordaily): post lock release problem

### DIFF
--- a/packages/mirrordaily/environment-variables.ts
+++ b/packages/mirrordaily/environment-variables.ts
@@ -94,7 +94,7 @@ export default {
     storagePath: VIDEOS_STORAGE_PATH || 'public/video-files',
   },
   lockDuration:
-    (typeof LOCK_DURATION === 'string' && parseInt(LOCK_DURATION)) || 30,
+    (typeof LOCK_DURATION === 'string' && parseInt(LOCK_DURATION)) || 10,
   cache: {
     isEnabled: IS_CACHE_ENABLED === 'true',
     identifier: CACHE_IDENTIFIER ?? 'weekly-cms',

--- a/packages/mirrordaily/express-mini-apps/post-lock.ts
+++ b/packages/mirrordaily/express-mini-apps/post-lock.ts
@@ -1,0 +1,121 @@
+import express from 'express'
+import type { KeystoneContext } from '@keystone-6/core/types'
+import envVar from '../environment-variables'
+import { UserRole } from '../type'
+import { computeLockExpireAt } from '../utils/post-lock'
+
+type PostLockMiniAppOptions = {
+  keystoneContext: KeystoneContext
+}
+
+// Coerce an untrusted request body value into a positive integer post id.
+// Returns null for missing / non-numeric / array / object inputs so callers
+// never pass NaN or a coerced value into Prisma.
+function parsePostId(value: unknown): number | null {
+  if (typeof value !== 'number' && typeof value !== 'string') return null
+  const id = Number(value)
+  if (!Number.isInteger(id) || id <= 0) return null
+  return id
+}
+
+export function createPostLockMiniApp({
+  keystoneContext,
+}: PostLockMiniAppOptions) {
+  const router = express.Router()
+
+  // POST /api/post-lock/heartbeat
+  // Extend lockExpireAt = now + LOCK_DURATION
+  router.post('/api/post-lock/heartbeat', async (req, res) => {
+    try {
+      const context = await keystoneContext.withRequest(req, res)
+      const userId = context.session?.data?.id
+
+      if (!userId) {
+        return res.status(401).json({ success: false, message: 'Unauthorized' })
+      }
+
+      const postId = parsePostId(req.body?.postId)
+      if (postId === null) {
+        return res
+          .status(400)
+          .json({ success: false, message: 'postId is required' })
+      }
+
+      const newLockExpireAt = computeLockExpireAt(envVar.lockDuration)
+
+      // Only the current lock holder can refresh the lock
+      const result = await context.prisma.Post.updateMany({
+        where: {
+          id: postId,
+          lockById: Number(userId),
+        },
+        data: {
+          lockExpireAt: newLockExpireAt,
+        },
+      })
+
+      if (result.count === 1) {
+        return res.json({ success: true, lockExpireAt: newLockExpireAt })
+      }
+
+      return res
+        .status(409)
+        .json({ success: false, message: 'Lock not held by current user' })
+    } catch (error) {
+      console.error('[PostLock] Heartbeat error:', error)
+      return res
+        .status(500)
+        .json({ success: false, message: 'Internal server error' })
+    }
+  })
+
+  // POST /api/post-lock/release
+  // Release the lock: lockBy = null, lockExpireAt = null
+  router.post('/api/post-lock/release', async (req, res) => {
+    try {
+      const context = await keystoneContext.withRequest(req, res)
+      const userId = context.session?.data?.id
+      const userRole = context.session?.data?.role
+
+      if (!userId) {
+        return res.status(401).json({ success: false, message: 'Unauthorized' })
+      }
+
+      const postId = parsePostId(req.body?.postId)
+      if (postId === null) {
+        return res
+          .status(400)
+          .json({ success: false, message: 'postId is required' })
+      }
+
+      // Admin can release any lock; others can only release their own
+      const whereCondition =
+        userRole === UserRole.Admin
+          ? { id: postId }
+          : { id: postId, lockById: Number(userId) }
+
+      const result = await context.prisma.Post.updateMany({
+        where: whereCondition,
+        data: {
+          lockById: null,
+          lockExpireAt: null,
+        },
+      })
+
+      if (result.count === 1) {
+        return res.json({ success: true })
+      }
+
+      return res
+        .status(409)
+        .json({ success: false, message: 'Lock not held by current user' })
+    } catch (error) {
+      console.error('[PostLock] Release error:', error)
+      return res
+        .status(500)
+        .json({ success: false, message: 'Internal server error' })
+    }
+  })
+
+  return router
+}

--- a/packages/mirrordaily/keystone.ts
+++ b/packages/mirrordaily/keystone.ts
@@ -7,6 +7,7 @@ import { createAuth } from '@keystone-6/auth'
 import { statelessSessions } from '@keystone-6/core/session'
 import { createPreviewMiniApp } from './express-mini-apps/preview/app'
 import { createDashboardMiniApp } from './express-mini-apps/dashboard/app'
+import { createPostLockMiniApp } from './express-mini-apps/post-lock'
 import Keyv from 'keyv'
 import { KeyvAdapter } from '@apollo/utils.keyvadapter'
 import { ApolloServerPluginCacheControl } from '@apollo/server/plugin/cacheControl'
@@ -123,6 +124,13 @@ export default withAuth(
           res.set('X-Robots-Tag', 'noindex, nofollow, noimageindex')
           next()
         })
+
+        // Post lock heartbeat & release endpoints (available in all modes)
+        app.use(
+          createPostLockMiniApp({
+            keystoneContext: context,
+          })
+        )
 
         if (envVar.accessControlStrategy === ACL.CMS) {
           // Serve robots.txt only in CMS domain to block all crawlers.

--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -15,6 +15,7 @@ import envVar from '../environment-variables'
 // @ts-ignore draft-js does not have typescript definition
 import { RawContentState } from 'draft-js'
 import { ACL, UserRole, State, type Session } from '../type'
+import { computeLockExpireAt } from '../utils/post-lock'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
 
@@ -112,6 +113,87 @@ type MaybeItemFunction<T extends FieldMode, ListTypeInfo> =
   | T
   | ((args: ListTypeInfo) => Promise<T>)
 
+// Atomically (re)acquire the post lock for the current Editor/Moderator.
+// Returns true if the user now holds the lock. Idempotent for the holder, so it
+// is safe to call from multiple field-mode resolvers on the same request.
+const tryAcquireLock = async ({
+  currentUserId,
+  currentUserRole,
+  context,
+  itemId,
+}: {
+  currentUserId: number
+  currentUserRole: UserRole | undefined
+  context: KeystoneContext
+  itemId: number
+}): Promise<boolean> => {
+  // Editor can only edit posts they created
+  if (currentUserRole === UserRole.Editor) {
+    const postCreator = await context.prisma.Post.findUnique({
+      where: { id: itemId },
+      select: { createdBy: { select: { id: true } } },
+    })
+    if (
+      postCreator?.createdBy &&
+      Number(postCreator.createdBy.id) !== currentUserId
+    ) {
+      return false
+    }
+  }
+
+  const newLockExpireAt = computeLockExpireAt(envVar.lockDuration)
+
+  // Atomic lock acquisition: succeed only if unlocked, locked by self, or expired
+  const result = await context.prisma.Post.updateMany({
+    where: {
+      id: itemId,
+      OR: [
+        { lockById: null },
+        { lockById: currentUserId },
+        { lockExpireAt: { lt: new Date() } },
+      ],
+    },
+    data: {
+      lockById: currentUserId,
+      lockExpireAt: newLockExpireAt,
+    },
+  })
+
+  return result.count === 1
+}
+
+// itemView fieldMode resolvers run once per field, so a bare tryAcquireLock
+// would issue one updateMany per field on every item-page load. Memoize the
+// acquisition per request (keyed on the request object, which Keystone scopes
+// the context to) so the whole page resolves with a single acquisition.
+const lockAcquisitionByRequest = new WeakMap<
+  object,
+  Map<string, Promise<boolean>>
+>()
+
+const tryAcquireLockOnce = (args: {
+  currentUserId: number
+  currentUserRole: UserRole | undefined
+  context: KeystoneContext
+  itemId: number
+}): Promise<boolean> => {
+  const requestKey = (args.context.req ?? args.context) as object
+  let cache = lockAcquisitionByRequest.get(requestKey)
+  if (!cache) {
+    cache = new Map()
+    lockAcquisitionByRequest.set(requestKey, cache)
+  }
+  const key = `${args.currentUserId}:${args.itemId}`
+  let pending = cache.get(key)
+  if (!pending) {
+    pending = tryAcquireLock(args)
+    cache.set(key, pending)
+  }
+  return pending
+}
+
+// Field editability: Editor/Moderator may edit only while holding the lock,
+// otherwise read-only. Other roles (e.g. Admin) bypass the lock and may edit.
 const itemViewFunction: MaybeItemFunction<FieldMode, ListTypeInfo> = async ({
   session,
   context,
@@ -121,97 +203,38 @@ const itemViewFunction: MaybeItemFunction<FieldMode, ListTypeInfo> = async ({
   const currentUserRole = session?.data?.role
 
   // @ts-ignore next line
-  //if ([UserRole.Moderator, UserRole.Editor].includes(currentUserRole)) {
   if ([UserRole.Editor, UserRole.Moderator].includes(currentUserRole)) {
-    const { lockBy, lockExpireAt, createdBy } =
-      await context.prisma.Post.findUnique({
-        where: { id: Number(item?.id) },
-        select: {
-          lockBy: {
-            select: {
-              id: true,
-            },
-          },
-          lockExpireAt: true,
-          createdBy: {
-            select: {
-              id: true,
-            },
-          },
-        },
-      })
-
-    const newLockExpireAt = new Date(
-      new Date().setMinutes(new Date().getMinutes() + envVar.lockDuration, 0, 0)
-    ).toISOString()
-
-    if (!lockBy) {
-      if (createdBy) {
-        if (
-          Number(createdBy?.id) !== currentUserId &&
-          currentUserRole === UserRole.Editor
-        ) {
-          return 'read'
-        }
-      }
-
-      const updatedPost = await context.prisma.Post.update({
-        where: { id: Number(item?.id) },
-        data: {
-          lockBy: {
-            connect: {
-              id: currentUserId,
-            },
-          },
-          lockExpireAt: newLockExpireAt,
-        },
-        select: {
-          lockBy: {
-            select: {
-              id: true,
-            },
-          },
-        },
-      })
-
-      return Number(updatedPost.lockBy?.id) === Number(session?.data?.id)
-        ? 'edit'
-        : 'read'
-    } else if (Number(lockBy?.id) == Number(session?.data?.id)) {
-      return 'edit'
-    } else if (new Date(lockExpireAt).valueOf() < Date.now()) {
-      // 過期的自動讓出，讓出對象為 Moderator 或者文章建立者
-      if (
-        currentUserRole === UserRole.Moderator ||
-        currentUserId === Number(createdBy?.id)
-      ) {
-        const updatedPost = await context.prisma.Post.update({
-          where: { id: Number(item?.id) },
-          data: {
-            lockBy: {
-              connect: {
-                id: currentUserId,
-              },
-            },
-            lockExpireAt: newLockExpireAt,
-          },
-          select: {
-            lockBy: {
-              select: {
-                id: true,
-              },
-            },
-          },
-        })
-
-        return Number(updatedPost.lockBy?.id) === Number(session?.data?.id)
-          ? 'edit'
-          : 'read'
-      }
-    }
-    return 'hidden'
+    const held = await tryAcquireLockOnce({
+      currentUserId,
+      currentUserRole,
+      context,
+      itemId: Number(item?.id),
+    })
+    return held ? 'edit' : 'read'
   }
   return 'edit'
+}
+
+// Heartbeat / release widget visibility: only the lock holder should run the
+// heartbeat, so non-holders and lock-bypassing roles (Admin) get 'hidden'.
+const lockStatusItemViewFunction: MaybeItemFunction<
+  FieldMode,
+  ListTypeInfo
+> = async ({ session, context, item }) => {
+  const currentUserId = Number(session?.data?.id)
+  const currentUserRole = session?.data?.role
+
+  // @ts-ignore next line
+  if ([UserRole.Editor, UserRole.Moderator].includes(currentUserRole)) {
+    const held = await tryAcquireLockOnce({
+      currentUserId,
+      currentUserRole,
+      context,
+      itemId: Number(item?.id),
+    })
+    return held ? 'edit' : 'hidden'
+  }
+  return 'hidden'
 }
 
 const lockByItemViewFunction: MaybeItemFunction<
@@ -282,6 +305,18 @@ const listConfigurations = list({
         createView: { fieldMode: 'hidden' },
         itemView: { fieldMode: 'hidden' },
         listView: { fieldMode: 'hidden' },
+      },
+    }),
+    lockStatus: virtual({
+      field: graphql.field({
+        type: graphql.String,
+        resolve: () => '',
+      }),
+      ui: {
+        createView: { fieldMode: 'hidden' },
+        listView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: lockStatusItemViewFunction },
+        views: './lists/views/post-lock-status/index',
       },
     }),
     // TODO: slug field is deprecated, should be removed in the future
@@ -1062,11 +1097,11 @@ const listConfigurations = list({
       addValidationError,
     }) => {
       if (envVar.accessControlStrategy === ACL.CMS) {
-        // Lock check (existing logic, unchanged)
-        if (
-          context.session?.data?.role !== UserRole.Admin &&
-          context.session?.data?.role !== UserRole.Moderator
-        ) {
+        // Moderators are lock-bound in the editor UI (itemViewFunction), so
+        // they must also be lock-bound on save — otherwise a Moderator whose
+        // lock expired could silently overwrite the current holder's changes.
+        // Only Admin bypasses the lock.
+        if (context.session?.data?.role !== UserRole.Admin) {
           if (operation === 'update') {
             const { lockBy, lockExpireAt } =
               await context.prisma.Post.findUnique({

--- a/packages/mirrordaily/lists/views/post-lock-status/index.tsx
+++ b/packages/mirrordaily/lists/views/post-lock-status/index.tsx
@@ -1,0 +1,246 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { jsx } from '@keystone-ui/core'
+import { FieldContainer } from '@keystone-ui/fields'
+import {
+  type FieldController,
+  type FieldControllerConfig,
+  type FieldProps,
+} from '@keystone-6/core/types'
+import { useEffect, useRef, useCallback, useState } from 'react'
+import { useRouter } from '@keystone-6/core/admin-ui/router'
+
+const HEARTBEAT_INTERVAL = 3 * 60 * 1000 // 3 minutes
+// With a 3-minute interval, 3 consecutive failures ≈ 9 minutes without a
+// successful refresh — right before the (default 10-minute) lock expires.
+const MAX_CONSECUTIVE_FAILURES = 3
+
+type LockWarning = 'lock-taken' | 'session-expired' | 'heartbeat-failing'
+
+const WARNING_MESSAGES: Record<LockWarning, string> = {
+  'lock-taken': '鎖定已失效，其他人可能已接管編輯。請重新整理頁面。',
+  'session-expired': '登入已過期，無法繼續為文章保持鎖定。請重新登入。',
+  'heartbeat-failing':
+    '持續無法連線伺服器更新鎖定，鎖定可能已過期，其他人可能接管編輯。',
+}
+
+function PostLockHeartbeatUI({ postId }: { postId: string }) {
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const mountedRef = useRef(true)
+  const lockLostRef = useRef(false)
+  const failureCountRef = useRef(0)
+  const [warning, setWarning] = useState<LockWarning | null>(null)
+  const [releasing, setReleasing] = useState(false)
+  const [releaseError, setReleaseError] = useState(false)
+  const router = useRouter()
+
+  const stopHeartbeat = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }, [])
+
+  // Stop polling for good and surface a warning. Tracked via a ref so the
+  // effect below doesn't have to re-run (which would restart polling).
+  const giveUpHeartbeat = useCallback(
+    (reason: LockWarning) => {
+      lockLostRef.current = true
+      stopHeartbeat()
+      if (mountedRef.current) setWarning(reason)
+    },
+    [stopHeartbeat]
+  )
+
+  const sendHeartbeat = useCallback(async () => {
+    try {
+      const res = await fetch('/api/post-lock/heartbeat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ postId: Number(postId) }),
+      })
+      if (res.ok) {
+        failureCountRef.current = 0
+        return
+      }
+      // Only these statuses are definitive: 409 means the lock is no longer
+      // held by this user; 401 means the session is gone and no future
+      // heartbeat can succeed. Anything else (5xx during a deploy, gateway
+      // errors) is transient — the lock is still ours server-side.
+      if (res.status === 409) return giveUpHeartbeat('lock-taken')
+      if (res.status === 401) return giveUpHeartbeat('session-expired')
+    } catch {
+      // Network error — transient, same as 5xx
+    }
+    failureCountRef.current += 1
+    if (failureCountRef.current >= MAX_CONSECUTIVE_FAILURES) {
+      // The lock may have expired server-side by now; stop pretending we
+      // still hold it.
+      giveUpHeartbeat('heartbeat-failing')
+    }
+  }, [postId, giveUpHeartbeat])
+
+  const sendRelease = useCallback(() => {
+    const data = JSON.stringify({ postId: Number(postId) })
+    navigator.sendBeacon(
+      '/api/post-lock/release',
+      new Blob([data], { type: 'application/json' })
+    )
+  }, [postId])
+
+  const startHeartbeat = useCallback(() => {
+    if (intervalRef.current || lockLostRef.current) return
+    intervalRef.current = setInterval(sendHeartbeat, HEARTBEAT_INTERVAL)
+  }, [sendHeartbeat])
+
+  useEffect(() => {
+    mountedRef.current = true
+    startHeartbeat()
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        stopHeartbeat()
+      } else {
+        sendHeartbeat().then(() => {
+          if (mountedRef.current && !document.hidden && !lockLostRef.current) {
+            startHeartbeat()
+          }
+        })
+      }
+    }
+
+    const handleBeforeUnload = () => {
+      sendRelease()
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('beforeunload', handleBeforeUnload)
+
+    return () => {
+      mountedRef.current = false
+      stopHeartbeat()
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      // The Keystone admin is an SPA: leaving the editor through the sidebar
+      // is client-side navigation, which unmounts this component without ever
+      // firing beforeunload. Release here too, or the lock would stay held
+      // until lockExpireAt. Skip when the lock is already gone — releasing
+      // would just 409.
+      if (!lockLostRef.current) sendRelease()
+    }
+  }, [startHeartbeat, stopHeartbeat, sendHeartbeat, sendRelease])
+
+  const handleRelease = useCallback(async () => {
+    setReleasing(true)
+    setReleaseError(false)
+    try {
+      const res = await fetch('/api/post-lock/release', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ postId: Number(postId) }),
+      })
+      // 409 means the lock is no longer held by this user (e.g. an Admin
+      // already cleared it). The user's intent — leaving the editor without
+      // holding the lock — is satisfied either way, so navigate away cleanly
+      // and only treat genuine failures (5xx / network) as errors.
+      if (res.ok || res.status === 409) {
+        // Mark the lock as gone so the unmount cleanup triggered by
+        // router.push doesn't beacon a second (guaranteed-409) release.
+        lockLostRef.current = true
+        stopHeartbeat()
+        router.push('/posts')
+        return
+      }
+      setReleaseError(true)
+    } catch {
+      setReleaseError(true)
+    } finally {
+      if (mountedRef.current) setReleasing(false)
+    }
+  }, [postId, stopHeartbeat, router])
+
+  if (warning) {
+    return (
+      <FieldContainer>
+        <div
+          css={{
+            padding: '12px 16px',
+            backgroundColor: '#fef2f2',
+            border: '1px solid #fecaca',
+            borderRadius: 8,
+            color: '#991b1b',
+            fontSize: 14,
+          }}
+        >
+          {WARNING_MESSAGES[warning]}
+        </div>
+      </FieldContainer>
+    )
+  }
+
+  return (
+    <FieldContainer>
+      <button
+        onClick={handleRelease}
+        type="button"
+        disabled={releasing}
+        css={{
+          padding: '8px 16px',
+          backgroundColor: '#f3f4f6',
+          border: '1px solid #d1d5db',
+          borderRadius: 6,
+          cursor: releasing ? 'not-allowed' : 'pointer',
+          fontSize: 14,
+          opacity: releasing ? 0.6 : 1,
+          ':hover': {
+            backgroundColor: releasing ? '#f3f4f6' : '#e5e7eb',
+          },
+        }}
+      >
+        {releasing ? '釋放中…' : '完成編輯（釋放鎖定）'}
+      </button>
+      {releaseError && (
+        <div
+          css={{
+            marginTop: 8,
+            fontSize: 13,
+            color: '#991b1b',
+          }}
+        >
+          釋放鎖定失敗，請稍後再試。
+        </div>
+      )}
+    </FieldContainer>
+  )
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const Field = (props: FieldProps<typeof controller>) => {
+  const router = useRouter()
+  const { id } = router.query
+
+  if (typeof id !== 'string' || isNaN(Number(id))) return null
+
+  return <PostLockHeartbeatUI postId={id} />
+}
+
+type LockStatusController = FieldController<null>
+
+export const controller = (
+  config: FieldControllerConfig
+): LockStatusController => {
+  return {
+    path: config.path,
+    label: config.label,
+    description: config.description,
+    graphqlSelection: `${config.path}`,
+    defaultValue: null,
+    deserialize() {
+      return null
+    },
+    serialize() {
+      return {}
+    },
+  }
+}

--- a/packages/mirrordaily/utils/post-lock.ts
+++ b/packages/mirrordaily/utils/post-lock.ts
@@ -1,0 +1,7 @@
+// Lock expiry timestamp `durationMinutes` from now. Computed from a single
+// Date.now() so the duration is exact — deriving it from two separate Date
+// instances (the previous pattern) could roll the expiry past an extra hour
+// when the wall clock crossed a minute boundary between the two reads.
+export function computeLockExpireAt(durationMinutes: number): string {
+  return new Date(Date.now() + durationMinutes * 60_000).toISOString()
+}


### PR DESCRIPTION
## Description

Fix the long-standing "post stays locked after the previous editor walks away" pain in the mirrordaily admin.

The current lock is a `findUnique` + `update`, which has a race: two users opening the same post can both see `lockBy === null` and both write the lock — the loser still enters edit mode but their work gets blocked at save time. There is also no active release, so a 30-minute lock blocks everyone (typically the video team waiting on the writer) until it expires.