### PR TITLE
feat(mirrordaily): implement new review workflow

### DIFF
--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -21,7 +21,9 @@ const { allowRoles, admin, moderator, editor } = utils.accessControl
 enum PostStatus {
   Published = State.Published,
   Draft = State.Draft,
+  Pending = 'pending',
   Scheduled = State.Scheduled,
+  Rejected = 'rejected',
   Archived = State.Archived,
   Invisible = State.Invisible,
 }
@@ -788,13 +790,16 @@ const listConfigurations = list({
       label: '狀態',
       options: [
         { label: '草稿', value: PostStatus.Draft },
+        { label: '待審核', value: PostStatus.Pending },
         { label: '已發布', value: PostStatus.Published },
         { label: '預約發佈', value: PostStatus.Scheduled },
+        { label: '退回修改', value: PostStatus.Rejected },
         { label: '下線', value: PostStatus.Archived },
         { label: '前台不可見', value: PostStatus.Invisible },
       ],
       defaultValue: PostStatus.Draft,
       isIndexed: true,
+      isFilterable: true,
     }),
     publishedDate: timestamp({
       isIndexed: true,
@@ -949,6 +954,31 @@ const listConfigurations = list({
         listView: { fieldMode: 'hidden' },
       },
     }),
+    // Review fields
+    reviewedBy: relationship({
+      ref: 'User',
+      label: '審核人',
+      ui: {
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'read' },
+        listView: { fieldMode: 'read' },
+      },
+    }),
+    reviewedAt: timestamp({
+      label: '審核時間',
+      ui: {
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'read' },
+        listView: { fieldMode: 'hidden' },
+      },
+    }),
+    reviewNote: text({
+      label: '審核備註',
+      ui: {
+        displayMode: 'textarea',
+        createView: { fieldMode: 'hidden' },
+      },
+    }),
     trimmedApiData: virtual({
       label: '擷取apiData中的前五段內容',
       isFilterable: false,
@@ -1024,8 +1054,15 @@ const listConfigurations = list({
     },
   },
   hooks: {
-    validateInput: async ({ operation, item, context, addValidationError }) => {
+    validateInput: async ({
+      operation,
+      item,
+      context,
+      resolvedData,
+      addValidationError,
+    }) => {
       if (envVar.accessControlStrategy === ACL.CMS) {
+        // Lock check (existing logic, unchanged)
         if (
           context.session?.data?.role !== UserRole.Admin &&
           context.session?.data?.role !== UserRole.Moderator
@@ -1053,13 +1090,72 @@ const listConfigurations = list({
             }
           }
         }
+
+        // Review workflow: state transition validation
+        if (operation === 'update' && resolvedData.state !== undefined) {
+          const oldState = item?.state
+          const newState = resolvedData.state
+          const currentUserRole = context.session?.data?.role
+
+          // Admin has no restrictions
+          if (currentUserRole !== UserRole.Admin) {
+            // Editor / Moderator cannot move directly to Published or Scheduled
+            if (
+              [PostStatus.Published, PostStatus.Scheduled].includes(newState) &&
+              oldState !== PostStatus.Published &&
+              oldState !== PostStatus.Scheduled
+            ) {
+              addValidationError(
+                '文章需經 Admin 審核才能發布，請先提交審核（設為「待審核」）。'
+              )
+            }
+          }
+        }
       }
     },
-    resolveInput: async ({ operation, resolvedData }) => {
+    resolveInput: async ({ operation, resolvedData, item, context }) => {
       const { publishedDate, content, brief, updateTimeStamp } = resolvedData
       if (operation === 'create') {
         resolvedData.publishedDate = new Date(publishedDate.setSeconds(0, 0))
         resolvedData.updatedAt = new Date()
+      }
+
+      // Review workflow: auto-fill review metadata
+      if (operation === 'update' && resolvedData.state !== undefined) {
+        const oldState = item?.state
+        const newState = resolvedData.state
+
+        // Admin approves: Pending → Published / Scheduled
+        if (
+          oldState === PostStatus.Pending &&
+          [PostStatus.Published, PostStatus.Scheduled].includes(newState)
+        ) {
+          resolvedData.reviewedBy = {
+            connect: { id: Number(context.session?.data?.id) },
+          }
+          resolvedData.reviewedAt = new Date()
+        }
+
+        // Admin rejects: Pending → Rejected
+        if (
+          oldState === PostStatus.Pending &&
+          newState === PostStatus.Rejected
+        ) {
+          resolvedData.reviewedBy = {
+            connect: { id: Number(context.session?.data?.id) },
+          }
+          resolvedData.reviewedAt = new Date()
+        }
+
+        // Resubmit: Rejected → Pending (clear previous review metadata)
+        if (
+          oldState === PostStatus.Rejected &&
+          newState === PostStatus.Pending
+        ) {
+          resolvedData.reviewedBy = { disconnect: true }
+          resolvedData.reviewedAt = null
+          resolvedData.reviewNote = ''
+        }
       }
       if (content) {
         resolvedData.apiData = customFields.draftConverter

--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -1129,26 +1129,19 @@ const listConfigurations = list({
       if (operation === 'update' && resolvedData.state !== undefined) {
         const oldState = item?.state
         const newState = resolvedData.state
+        const reviewerId = context.session?.data?.id
 
-        // Admin approves: Pending → Published / Scheduled
+        // Admin reviews (approve / reject): Pending → Published / Scheduled / Rejected
         if (
           oldState === PostStatus.Pending &&
-          [PostStatus.Published, PostStatus.Scheduled].includes(newState)
+          [
+            PostStatus.Published,
+            PostStatus.Scheduled,
+            PostStatus.Rejected,
+          ].includes(newState) &&
+          reviewerId
         ) {
-          resolvedData.reviewedBy = {
-            connect: { id: Number(context.session?.data?.id) },
-          }
-          resolvedData.reviewedAt = new Date()
-        }
-
-        // Admin rejects: Pending → Rejected
-        if (
-          oldState === PostStatus.Pending &&
-          newState === PostStatus.Rejected
-        ) {
-          resolvedData.reviewedBy = {
-            connect: { id: Number(context.session?.data?.id) },
-          }
+          resolvedData.reviewedBy = { connect: { id: Number(reviewerId) } }
           resolvedData.reviewedAt = new Date()
         }
 

--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -1092,7 +1092,12 @@ const listConfigurations = list({
         }
 
         // Review workflow: state transition validation
-        if (operation === 'update' && resolvedData.state !== undefined) {
+        // Skip when there's no session (system / cron / sudo operations)
+        if (
+          operation === 'update' &&
+          resolvedData.state !== undefined &&
+          context.session
+        ) {
           const oldState = item?.state
           const newState = resolvedData.state
           const currentUserRole = context.session?.data?.role

--- a/packages/mirrordaily/migrations/20260527085548_add_post_review_fields/migration.sql
+++ b/packages/mirrordaily/migrations/20260527085548_add_post_review_fields/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "reviewNote" TEXT DEFAULT '',
+ADD COLUMN     "reviewedAt" TIMESTAMP(3),
+ADD COLUMN     "reviewedBy" INTEGER;
+
+-- CreateIndex
+CREATE INDEX "Post_reviewedBy_idx" ON "Post"("reviewedBy");
+
+-- AddForeignKey
+ALTER TABLE "Post" ADD CONSTRAINT "Post_reviewedBy_fkey" FOREIGN KEY ("reviewedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/mirrordaily/schema.graphql
+++ b/packages/mirrordaily/schema.graphql
@@ -1220,6 +1220,9 @@ type Post {
   apiDataBrief: JSON
   apiData: JSON
   publishedDateString: String
+  reviewedBy: User
+  reviewedAt: DateTime
+  reviewNote: String
   trimmedApiData: JSON
   createdAt: DateTime
   updatedAt: DateTime
@@ -1276,6 +1279,9 @@ input PostWhereInput {
   adTrace: StringFilter
   css: StringFilter
   publishedDateString: StringFilter
+  reviewedBy: UserWhereInput
+  reviewedAt: DateTimeNullableFilter
+  reviewNote: StringFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
@@ -1317,6 +1323,8 @@ input PostOrderByInput {
   adTrace: OrderDirection
   css: OrderDirection
   publishedDateString: OrderDirection
+  reviewedAt: OrderDirection
+  reviewNote: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
@@ -1378,6 +1386,9 @@ input PostUpdateInput {
   apiDataBrief: JSON
   apiData: JSON
   publishedDateString: String
+  reviewedBy: UserRelateToOneForUpdateInput
+  reviewedAt: DateTime
+  reviewNote: String
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
@@ -1479,6 +1490,9 @@ input PostCreateInput {
   apiDataBrief: JSON
   apiData: JSON
   publishedDateString: String
+  reviewedBy: UserRelateToOneForCreateInput
+  reviewedAt: DateTime
+  reviewNote: String
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput
@@ -2780,6 +2794,7 @@ type Query {
   hotsCount(where: HotWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
+  trafficDashboardEnabled: Boolean!
 }
 
 union AuthenticatedItem = User

--- a/packages/mirrordaily/schema.prisma
+++ b/packages/mirrordaily/schema.prisma
@@ -327,16 +327,16 @@ model Post {
   apiDataBrief               Json?
   apiData                    Json?
   publishedDateString        String         @default("")
+  reviewedBy                 User?          @relation("Post_reviewedBy", fields: [reviewedById], references: [id])
+  reviewedById               Int?           @map("reviewedBy")
+  reviewedAt                 DateTime?
+  reviewNote                 String         @default("")
   createdAt                  DateTime?
   updatedAt                  DateTime?
   createdBy                  User?          @relation("Post_createdBy", fields: [createdById], references: [id])
   createdById                Int?           @map("createdBy")
   updatedBy                  User?          @relation("Post_updatedBy", fields: [updatedById], references: [id])
   updatedById                Int?           @map("updatedBy")
-  reviewedBy                 User?          @relation("Post_reviewedBy", fields: [reviewedById], references: [id])
-  reviewedById               Int?           @map("reviewedBy")
-  reviewedAt                 DateTime?
-  reviewNote                 String?        @default("")
   from_EditorChoice_choices  EditorChoice[] @relation("EditorChoice_choices")
   from_Post_relateds         Post[]         @relation("Post_relateds")
   from_Post_relatedsOne      Post[]         @relation("Post_relatedsOne")
@@ -359,9 +359,9 @@ model Post {
   @@index([publishedDate])
   @@index([pv])
   @@index([WarningId])
+  @@index([reviewedById])
   @@index([createdById])
   @@index([updatedById])
-  @@index([reviewedById])
 }
 
 model PromoteTopic {
@@ -518,9 +518,9 @@ model User {
   from_Photo_createdBy        Photo[]        @relation("Photo_createdBy")
   from_Photo_updatedBy        Photo[]        @relation("Photo_updatedBy")
   from_Post_lockBy            Post[]         @relation("Post_lockBy")
+  from_Post_reviewedBy        Post[]         @relation("Post_reviewedBy")
   from_Post_createdBy         Post[]         @relation("Post_createdBy")
   from_Post_updatedBy         Post[]         @relation("Post_updatedBy")
-  from_Post_reviewedBy        Post[]         @relation("Post_reviewedBy")
   from_PromoteTopic_createdBy PromoteTopic[] @relation("PromoteTopic_createdBy")
   from_PromoteTopic_updatedBy PromoteTopic[] @relation("PromoteTopic_updatedBy")
   from_Section_createdBy      Section[]      @relation("Section_createdBy")

--- a/packages/mirrordaily/schema.prisma
+++ b/packages/mirrordaily/schema.prisma
@@ -333,6 +333,10 @@ model Post {
   createdById                Int?           @map("createdBy")
   updatedBy                  User?          @relation("Post_updatedBy", fields: [updatedById], references: [id])
   updatedById                Int?           @map("updatedBy")
+  reviewedBy                 User?          @relation("Post_reviewedBy", fields: [reviewedById], references: [id])
+  reviewedById               Int?           @map("reviewedBy")
+  reviewedAt                 DateTime?
+  reviewNote                 String?        @default("")
   from_EditorChoice_choices  EditorChoice[] @relation("EditorChoice_choices")
   from_Post_relateds         Post[]         @relation("Post_relateds")
   from_Post_relatedsOne      Post[]         @relation("Post_relatedsOne")
@@ -357,6 +361,7 @@ model Post {
   @@index([WarningId])
   @@index([createdById])
   @@index([updatedById])
+  @@index([reviewedById])
 }
 
 model PromoteTopic {
@@ -515,6 +520,7 @@ model User {
   from_Post_lockBy            Post[]         @relation("Post_lockBy")
   from_Post_createdBy         Post[]         @relation("Post_createdBy")
   from_Post_updatedBy         Post[]         @relation("Post_updatedBy")
+  from_Post_reviewedBy        Post[]         @relation("Post_reviewedBy")
   from_PromoteTopic_createdBy PromoteTopic[] @relation("PromoteTopic_createdBy")
   from_PromoteTopic_updatedBy PromoteTopic[] @relation("PromoteTopic_updatedBy")
   from_Section_createdBy      Section[]      @relation("Section_createdBy")


### PR DESCRIPTION
## Description

Add an Admin review step for mirrordaily Posts. Editor and Moderator can no longer publish directly — they submit to `pending`, and an Admin either approves (→ `published` / `scheduled`) or rejects (→ `rejected`, with optional note). Resubmitting a rejected post clears the previous review metadata. Admins remain unrestricted.