### PR TITLE
feat(mirrormedia): add event name field to multi images upload

### DIFF
--- a/packages/mirrormedia/admin/components/editor-step.tsx
+++ b/packages/mirrormedia/admin/components/editor-step.tsx
@@ -180,7 +180,7 @@ export default function EditorStep() {
             placeholder="最多 10 個字"
             onChange={(e) => dispatch(setEventName(e.target.value))}
           />
-          <EventNameHint>({eventName.length}/10)</EventNameHint>
+          <EventNameHint>{eventName.trim().length}/10</EventNameHint>
         </EventNameWrapper>
         <ControlGroup>
           <HiddenInput ref={inputRef} />

--- a/packages/mirrormedia/admin/components/editor-step.tsx
+++ b/packages/mirrormedia/admin/components/editor-step.tsx
@@ -5,6 +5,7 @@ import {
   selectSelectedFilename,
   selectShouldSetWatermarkToAll,
   selectUidsOfFile,
+  selectEventName,
 } from '../redux/features/multi-images/selector'
 import { isEqual } from 'lodash-es'
 import Button from './button'
@@ -14,6 +15,7 @@ import HiddenInput from './hidden-input'
 import {
   removeSelectedItems,
   setShouldSetWatermarkToAll,
+  setEventName,
 } from '../redux/features/multi-images/slice'
 import SubmissionButtonAndModal from './submission-button-and-modal'
 import Modal from './modal'
@@ -89,6 +91,44 @@ const ListGroup = styled.div`
   padding-right: 62px;
 `
 
+const EventNameWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  column-gap: 12px;
+  margin-top: 24px;
+  margin-left: 69px;
+  margin-right: 69px;
+
+  @media (max-width: 575px) {
+    flex-wrap: wrap;
+    row-gap: 8px;
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+`
+
+const EventNameLabel = styled.label`
+  font-size: 16px;
+  font-weight: 700;
+  white-space: nowrap;
+`
+
+const EventNameInput = styled.input`
+  padding: 6px 10px;
+  border: 1px solid #000;
+  font-size: 16px;
+  width: 220px;
+
+  @media (max-width: 575px) {
+    width: 100%;
+  }
+`
+
+const EventNameHint = styled.span`
+  font-size: 12px;
+  color: #888;
+`
+
 const AlertBody = styled.div`
   display: flex;
   width: 100%;
@@ -117,6 +157,7 @@ export default function EditorStep() {
   const shouldSetWatermarkToAll = useAppSelector(selectShouldSetWatermarkToAll)
   const hasItemSelected = useAppSelector(selectHasItemSelected)
   const filenames = useAppSelector(selectSelectedFilename)
+  const eventName = useAppSelector(selectEventName)
   const inputRef = useRef<HTMLInputElement>(null)
   const checkInputRef = useRef<HTMLInputElement>(null)
   const checkMediaInputRef = useRef<HTMLInputElement>(null)
@@ -127,6 +168,20 @@ export default function EditorStep() {
   return (
     <Body>
       <Container>
+        <EventNameWrapper>
+          <EventNameLabel htmlFor="event-name-input">
+            活動或事件名稱
+          </EventNameLabel>
+          <EventNameInput
+            id="event-name-input"
+            type="text"
+            value={eventName}
+            maxLength={10}
+            placeholder="最多 10 個字"
+            onChange={(e) => dispatch(setEventName(e.target.value))}
+          />
+          <EventNameHint>({eventName.length}/10)</EventNameHint>
+        </EventNameWrapper>
         <ControlGroup>
           <HiddenInput ref={inputRef} />
           <Button clickFn={() => inputRef.current?.click()}>Add images</Button>

--- a/packages/mirrormedia/admin/components/submission-button-and-modal.tsx
+++ b/packages/mirrormedia/admin/components/submission-button-and-modal.tsx
@@ -3,7 +3,10 @@ import { convertStringToFile } from '../utils'
 import { gql, useMutation } from '@keystone-6/core/admin-ui/apollo'
 import Button from './button'
 import { useAppSelector } from '../redux/hooks'
-import { selectFiles } from '../redux/features/multi-images/selector'
+import {
+  selectFiles,
+  selectEventName,
+} from '../redux/features/multi-images/selector'
 import { isEqual } from 'lodash-es'
 import { useDispatch } from 'react-redux'
 import { resetAllState } from '../redux/features/multi-images/slice'
@@ -48,6 +51,7 @@ export default function SubmissionButtonAndModal({
 }: SubmissionButtonAndModalProps) {
   const dispatch = useDispatch()
   const files = useAppSelector(selectFiles, isEqual)
+  const eventName = useAppSelector(selectEventName)
 
   const [addPhotos, { data, loading, error, reset }] = useMutation(gql`
     mutation AddPhotos($data: [PhotoCreateInput!]!) {
@@ -76,15 +80,18 @@ export default function SubmissionButtonAndModal({
       })
       .map((result) => result.value)
 
+    const trimmedEventName = eventName.trim()
+
     addPhotos({
       variables: {
         data: data.map((d) => ({
-          name: d.name,
+          name: trimmedEventName ? `${trimmedEventName}-${d.name}` : d.name,
           imageFile: {
             upload: d.file,
           },
           waterMark: d.shouldSetWatermark,
           watermarkType: waterMarkType || 'mirrormedia',
+          ...(trimmedEventName && { topicKeywords: trimmedEventName }),
         })),
       },
     })

--- a/packages/mirrormedia/admin/redux/features/multi-images/selector.ts
+++ b/packages/mirrormedia/admin/redux/features/multi-images/selector.ts
@@ -21,3 +21,5 @@ export const selectSelectedFilename = (state: RootState) =>
   (state.multiImages.files.filter((file) => file.isSelected) ?? []).map(
     (file) => file.originalName
   )
+
+export const selectEventName = (state: RootState) => state.multiImages.eventName

--- a/packages/mirrormedia/admin/redux/features/multi-images/slice.ts
+++ b/packages/mirrormedia/admin/redux/features/multi-images/slice.ts
@@ -20,11 +20,13 @@ type ImageFileData = {
 type MutilImageState = {
   files: ImageFileData[]
   shouldSetWatermarkToAll: boolean
+  eventName: string
 }
 
 const initialState: MutilImageState = {
   files: [],
   shouldSetWatermarkToAll: true,
+  eventName: '',
 }
 
 type RawImageFileData = Pick<ImageFileData, 'uid' | 'name' | 'blobURL' | 'type'>
@@ -119,6 +121,9 @@ export const multiImagesSlice = createSlice({
     removeSelectedItems: (state) => {
       state.files = state.files.filter((file) => file.isSelected === false)
     },
+    setEventName: (state, action: PayloadAction<string>) => {
+      state.eventName = action.payload
+    },
     resetAllState: () => initialState,
   },
   extraReducers: (builder) => {
@@ -149,6 +154,7 @@ export const {
   setShouldSetWatermarkToAll,
   setIsSelected,
   removeSelectedItems,
+  setEventName,
   resetAllState,
 } = multiImagesSlice.actions
 


### PR DESCRIPTION
#### Description
新增「活動或事件名稱」欄位於 Multi Images 上傳頁面
  
#### Features
- 上傳頁面新增文字輸入欄位，最多 10 個字
- 填入特徵碼後，上傳的圖片檔名會自動加上前綴
- 特徵碼同時寫入圖片的 `topicKeywords` 欄位
- 未填寫時維持原有檔名

#### Changes
- `admin/redux/features/multi-images/slice.ts` — 新增 `eventName` state 與 `setEventName` reducer
- `admin/redux/features/multi-images/selector.ts` — 新增 `selectEventName` selector
- `admin/components/editor-step.tsx` — 新增活動名稱輸入 UI（含 RWD）
- `admin/components/submission-button-and-modal.tsx` — 送出時將 `eventName` 寫入檔名前綴與`topicKeywords`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214921542222196