### PR TITLE
feat(mirrortv): add GCS image copy with Cloud Tasks fallback on upload

### DIFF
--- a/packages/mirrortv/environment-variables.ts
+++ b/packages/mirrortv/environment-variables.ts
@@ -30,6 +30,11 @@ const {
   YOUTUBE_API_KEY,
   DOMAIN_URL,
   PROMOTE_TOPIC_SERVICE_URL,
+  PROJECT_ID,
+  LOCATION,
+  COPY_QUEUE_NAME,
+  IMAGE_PROCESSOR_URL,
+  SCHEDULER_KEY,
 } = process.env
 
 enum DatabaseProvider {
@@ -100,5 +105,12 @@ export default {
   promoteTopicServiceUrl: PROMOTE_TOPIC_SERVICE_URL,
   youtube: {
     apiKey: YOUTUBE_API_KEY,
+  },
+  projectID: PROJECT_ID || 'mirror-tv-275709',
+  location: LOCATION || 'asia-east1',
+  copyQueueName: COPY_QUEUE_NAME || 'image-copy-retry-dev',
+  imageProcessor: {
+    url: IMAGE_PROCESSOR_URL || '',
+    schedulerKey: SCHEDULER_KEY || '',
   },
 }

--- a/packages/mirrortv/lists/Image.ts
+++ b/packages/mirrortv/lists/Image.ts
@@ -18,6 +18,12 @@ const gcsBucket = new Storage().bucket(envVar.gcs.bucket)
 const tasksClient = new CloudTasksClient()
 
 async function enqueueCopyTask(source: string, dest: string) {
+  if (!envVar.imageProcessor.url) {
+    console.error(
+      '[Image hook] IMAGE_PROCESSOR_URL is not configured. Skipping Cloud Tasks enqueue.'
+    )
+    return
+  }
   try {
     const parent = tasksClient.queuePath(
       envVar.projectID,

--- a/packages/mirrortv/lists/Image.ts
+++ b/packages/mirrortv/lists/Image.ts
@@ -1,3 +1,5 @@
+import { Storage } from '@google-cloud/storage'
+import { CloudTasksClient, protos } from '@google-cloud/tasks'
 import { list, graphql } from '@keystone-6/core'
 import { utils } from '@mirrormedia/lilith-core'
 import {
@@ -11,6 +13,43 @@ import {
 } from '@keystone-6/core/fields'
 import envVar from '../environment-variables'
 import { getFileURL } from '../utils/common'
+
+const gcsBucket = new Storage().bucket(envVar.gcs.bucket)
+const tasksClient = new CloudTasksClient()
+
+async function enqueueCopyTask(source: string, dest: string) {
+  try {
+    const parent = tasksClient.queuePath(
+      envVar.projectID,
+      envVar.location,
+      envVar.copyQueueName
+    )
+    const task = {
+      httpRequest: {
+        httpMethod: protos.google.cloud.tasks.v2.HttpMethod.POST,
+        url: `${envVar.imageProcessor.url}/copy_blob`,
+        headers: { 'Content-Type': 'application/json' },
+        body: Buffer.from(
+          JSON.stringify({
+            key: envVar.imageProcessor.schedulerKey,
+            bucket: envVar.gcs.bucket,
+            source,
+            dest,
+          })
+        ),
+      },
+    }
+    const [response] = await tasksClient.createTask({ parent, task })
+    console.log(
+      `[Image hook] Enqueued copy task: ${source} → ${dest}: ${response.name}`
+    )
+  } catch (error) {
+    console.error(
+      `[Image hook] CRITICAL: copy failed AND enqueue failed, manual recovery needed: ${source} → ${dest}:`,
+      error
+    )
+  }
+}
 
 const { allowRoles, admin, moderator, editor, contributor } =
   utils.accessControl
@@ -123,7 +162,6 @@ const listConfigurations = list({
           const rtn: Record<string, string> = {}
 
           resizedTargets.forEach((target) => {
-            // rtn[target] = `${baseUrl}/${fileId}-${target}${ext}`
             rtn[target] = getFileURL(
               envVar.gcs.bucket,
               baseUrl,
@@ -131,7 +169,6 @@ const listConfigurations = list({
             )
           })
 
-          // rtn['original'] = `${baseUrl}/${fileId}${ext}`
           rtn['original'] = getFileURL(
             envVar.gcs.bucket,
             baseUrl,
@@ -195,7 +232,6 @@ const listConfigurations = list({
           const rtn: Record<string, string> = {}
 
           resizedTargets.forEach((target) => {
-            // rtn[target] = `${baseUrl}/${fileId}-${target}${ext}`
             rtn[target] = getFileURL(
               envVar.gcs.bucket,
               baseUrl,
@@ -203,7 +239,6 @@ const listConfigurations = list({
             )
           })
 
-          // rtn['original'] = `${baseUrl}/${fileId}${ext}`
           rtn['original'] = getFileURL(
             envVar.gcs.bucket,
             baseUrl,
@@ -219,6 +254,43 @@ const listConfigurations = list({
   },
 
   hooks: {
+    afterOperation: async ({ operation, item, originalItem }) => {
+      if (operation === 'delete') return
+      if (!item?.file_id) return
+      if (operation === 'update' && item.file_id === originalItem?.file_id)
+        return
+
+      if (!item.file_extension) return
+      const filename = item.file_id as string
+      const ext = `.${item.file_extension}`
+      const gcsSourcePath = `images/${filename}${ext}`
+
+      const width = typeof item.file_width === 'number' ? item.file_width : 0
+      const height = typeof item.file_height === 'number' ? item.file_height : 0
+      const targets =
+        width >= height
+          ? ['w480', 'w800', 'w1600', 'w2400']
+          : ['w480', 'w800', 'w1200', 'w1600']
+
+      await Promise.all(
+        targets.map(async (target) => {
+          const gcsDestPath = `images/${filename}-${target}${ext}`
+          try {
+            await gcsBucket
+              .file(gcsSourcePath)
+              .copy(gcsBucket.file(gcsDestPath))
+            console.log(`[Image hook] Copied ${gcsSourcePath} → ${gcsDestPath}`)
+          } catch (err) {
+            console.error(
+              `[Image hook] Copy failed, enqueuing retry: ${gcsDestPath}`,
+              err
+            )
+            await enqueueCopyTask(gcsSourcePath, gcsDestPath)
+          }
+        })
+      )
+    },
+
     resolveInput: async ({ resolvedData, item }) => {
       // Get file metadata from new upload or existing record
       const fileId = resolvedData.file?.id || item?.file_id

--- a/packages/mirrortv/package.json
+++ b/packages/mirrortv/package.json
@@ -24,6 +24,7 @@
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@ffprobe-installer/ffprobe": "^2.1.2",
     "@google-cloud/storage": "^7.17.3",
+    "@google-cloud/tasks": "^6.2.1",
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.2.0",
     "@keyv/redis": "^2.7.0",


### PR DESCRIPTION
#### Summary
  
- 圖片上傳時加入 GCS copy邏輯，並以 Cloud Tasks 作為失敗時的 fall back
- 建立或更換換圖片時，`afterOperation` hook 會依照橫直圖產生對應尺寸（橫圖：`w480`、`w800`、`w1600`、`w2400` / 直圖：`w480`、`w800`、`w1200`、`w1600`）
- GCS 複製失敗，則將重試加入 Cloud Tasks 佇列（`image-copy-retry-dev`），再由 image processor 處理替換 resize 檔案
- 新增 Cloud Tasks 相關環境變數（`PROJECT_ID`、`LOCATION`、`COPY_QUEUE_NAME`、`IMAGE_PROCESSOR_URL`、`SCHEDULER_KEY`）
- 新增 `@google-cloud/tasks` package

#### Changes

- `packages/mirrortv/lists/Image.ts` — 新增 `afterOperation` hook，包含 GCS  copy 及 Cloud Tasks fallback 邏輯
- `packages/mirrortv/environment-variables.ts` — 新增 Cloud Tasks 相關環境變數
- `packages/mirrortv/package.json` — 新增 `@google-cloud/tasks ^6.2.1`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215696600976936