### PR TITLE
feat(mirrordaily): add GCS image copy with Cloud Tasks fallback on upload

### DIFF
--- a/packages/mirrordaily/environment-variables.ts
+++ b/packages/mirrordaily/environment-variables.ts
@@ -32,6 +32,11 @@ const {
   YOUTUBE_API_KEY,
   TOPIC_SERVICE_URL,
   PROMOTE_TOPIC_SERVICE_URL,
+  PROJECT_ID,
+  LOCATION,
+  COPY_QUEUE_NAME,
+  IMAGE_PROCESSOR_URL,
+  SCHEDULER_KEY,
 } = process.env
 
 enum DatabaseProvider {
@@ -106,5 +111,12 @@ export default {
   invalidateCDNCacheServerURL: INVALID_CDN_CACHE_SERVER_URL,
   youtube: {
     apiKey: YOUTUBE_API_KEY,
+  },
+  projectID: PROJECT_ID || 'mirrordaily',
+  location: LOCATION || 'asia-east1',
+  copyQueueName: COPY_QUEUE_NAME || 'image-copy-retry-dev',
+  imageProcessor: {
+    url: IMAGE_PROCESSOR_URL || '',
+    schedulerKey: SCHEDULER_KEY || '',
   },
 }

--- a/packages/mirrordaily/environment-variables.ts
+++ b/packages/mirrordaily/environment-variables.ts
@@ -37,6 +37,7 @@ const {
   COPY_QUEUE_NAME,
   IMAGE_PROCESSOR_URL,
   SCHEDULER_KEY,
+  IMAGE_COPY_ON_UPLOAD_ENABLED,
 } = process.env
 
 enum DatabaseProvider {
@@ -119,4 +120,5 @@ export default {
     url: IMAGE_PROCESSOR_URL || '',
     schedulerKey: SCHEDULER_KEY || '',
   },
+  imageCopyOnUploadEnabled: IMAGE_COPY_ON_UPLOAD_ENABLED === 'true',
 }

--- a/packages/mirrordaily/lists/Image.ts
+++ b/packages/mirrordaily/lists/Image.ts
@@ -1,8 +1,53 @@
+import { Storage } from '@google-cloud/storage'
+import { CloudTasksClient, protos } from '@google-cloud/tasks'
 import envVar from '../environment-variables'
 import { utils } from '@mirrormedia/lilith-core'
 import { list, graphql } from '@keystone-6/core'
 import { image, text, virtual, checkbox } from '@keystone-6/core/fields'
 import { getFileURL } from '../utils/common'
+
+const gcsBucket = new Storage().bucket(envVar.gcs.bucket)
+const tasksClient = new CloudTasksClient()
+
+async function enqueueCopyTask(source: string, dest: string) {
+  if (!envVar.imageProcessor.url) {
+    console.error(
+      '[Image hook] IMAGE_PROCESSOR_URL is not configured. Skipping Cloud Tasks enqueue.'
+    )
+    return
+  }
+  try {
+    const parent = tasksClient.queuePath(
+      envVar.projectID,
+      envVar.location,
+      envVar.copyQueueName
+    )
+    const task = {
+      httpRequest: {
+        httpMethod: protos.google.cloud.tasks.v2.HttpMethod.POST,
+        url: `${envVar.imageProcessor.url}/copy_blob`,
+        headers: { 'Content-Type': 'application/json' },
+        body: Buffer.from(
+          JSON.stringify({
+            key: envVar.imageProcessor.schedulerKey,
+            bucket: envVar.gcs.bucket,
+            source,
+            dest,
+          })
+        ),
+      },
+    }
+    const [response] = await tasksClient.createTask({ parent, task })
+    console.log(
+      `[Image hook] Enqueued copy task: ${source} → ${dest}: ${response.name}`
+    )
+  } catch (error) {
+    console.error(
+      `[Image hook] CRITICAL: copy failed AND enqueue failed, manual recovery needed: ${source} → ${dest}:`,
+      error
+    )
+  }
+}
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
 
@@ -197,6 +242,50 @@ const listConfigurations = list({
       label: '版權',
     }),
   },
+  hooks: {
+    afterOperation: async ({ operation, item, originalItem }) => {
+      if (operation === 'delete') return
+      if (!item?.imageFile_id) return
+      if (
+        operation === 'update' &&
+        item.imageFile_id === originalItem?.imageFile_id
+      )
+        return
+
+      if (!item.imageFile_extension) return
+      const filename = item.imageFile_id as string
+      const ext = `.${item.imageFile_extension}`
+      const gcsSourcePath = `images/${filename}${ext}`
+
+      const width =
+        typeof item.imageFile_width === 'number' ? item.imageFile_width : 0
+      const height =
+        typeof item.imageFile_height === 'number' ? item.imageFile_height : 0
+      const targets =
+        width >= height
+          ? ['w480', 'w800', 'w1600', 'w2400']
+          : ['w480', 'w800', 'w1200', 'w1600']
+
+      await Promise.all(
+        targets.map(async (target) => {
+          const gcsDestPath = `images/${filename}-${target}${ext}`
+          try {
+            await gcsBucket
+              .file(gcsSourcePath)
+              .copy(gcsBucket.file(gcsDestPath))
+            console.log(`[Image hook] Copied ${gcsSourcePath} → ${gcsDestPath}`)
+          } catch (err) {
+            console.error(
+              `[Image hook] Copy failed, enqueuing retry: ${gcsDestPath}`,
+              err
+            )
+            await enqueueCopyTask(gcsSourcePath, gcsDestPath)
+          }
+        })
+      )
+    },
+  },
+
   ui: {
     labelField: 'name',
     listView: {

--- a/packages/mirrordaily/lists/Image.ts
+++ b/packages/mirrordaily/lists/Image.ts
@@ -244,6 +244,7 @@ const listConfigurations = list({
   },
   hooks: {
     afterOperation: async ({ operation, item, originalItem }) => {
+      if (!envVar.imageCopyOnUploadEnabled) return
       if (operation === 'delete') return
       if (!item?.imageFile_id) return
       if (

--- a/packages/mirrordaily/package.json
+++ b/packages/mirrordaily/package.json
@@ -21,6 +21,8 @@
     "@apollo/utils.keyvadapter": "^3.0.0",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "11.11.0",
+    "@google-cloud/storage": "^7.17.3",
+    "@google-cloud/tasks": "^6.2.1",
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.2.0",
     "@keyv/redis": "^2.7.0",


### PR DESCRIPTION
#### Summary
- 圖片上傳時加入 GCS copy邏輯，並以 Cloud Tasks 作為失敗時的 fall back
- 建立或更換換圖片時，afterOperation hook 會依照橫直圖產生對應尺寸（橫圖：w480、w800、w1600、w2400 / 直圖：w480、w800、w1200、w1600）
- GCS 複製失敗，則將重試加入 Cloud Tasks 佇列（image-copy-retry-dev），再由 image processor 處理替換 resize 檔案
- 新增 Cloud Tasks 相關環境變數（PROJECT_ID、LOCATION、COPY_QUEUE_NAME、IMAGE_PROCESSOR_URL、SCHEDULER_KEY）
- 新增 `@google-cloud/storage`、`@google-cloud/tasks` 套件

#### Changes
- `packages/mirrordaily/lists/Image.ts` — 新增 `afterOperation` hook，包含 GCS copy 及 Cloud Tasks fallback
- `packages/mirrordaily/environment-variables.ts` — 新增 Cloud Tasks 相關環境變數
- `packages/mirrordaily/package.json` — 新增 `@google-cloud/storage^7.17.3`、`@google-cloud/tasks ^6.2.1`