### PR TITLE
feat(readr): add recommendedTitle field to Post

### DIFF
--- a/packages/readr/lists/Post.ts
+++ b/packages/readr/lists/Post.ts
@@ -33,6 +33,16 @@ const listConfigurations = list({
         isNullable: true,
       },
     }),
+    recommendedTitle: text({
+      label: '建議標題',
+      ui: { displayMode: 'textarea' },
+      validation: { isRequired: false },
+      db: {
+        isNullable: true,
+      },
+      isFilterable: false,
+      isOrderable: false,
+    }),
     state: select({
       label: '狀態',
       options: [

--- a/packages/readr/migrations/20260617151420_add_recommended_title/migration.sql
+++ b/packages/readr/migrations/20260617151420_add_recommended_title/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "recommendedTitle" TEXT;

--- a/packages/readr/schema.graphql
+++ b/packages/readr/schema.graphql
@@ -1239,6 +1239,7 @@ type Post {
   sortOrder: Int
   name: String
   subtitle: String
+  recommendedTitle: String
   state: String
   publishTime: DateTime
   categories(where: CategoryWhereInput! = {}, orderBy: [CategoryOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CategoryWhereUniqueInput): [Category!]
@@ -1413,6 +1414,7 @@ input PostUpdateInput {
   sortOrder: Int
   name: String
   subtitle: String
+  recommendedTitle: String
   state: String
   publishTime: DateTime
   categories: CategoryRelateToManyForUpdateInput
@@ -1515,6 +1517,7 @@ input PostCreateInput {
   sortOrder: Int
   name: String
   subtitle: String
+  recommendedTitle: String
   state: String
   publishTime: DateTime
   categories: CategoryRelateToManyForCreateInput

--- a/packages/readr/schema.prisma
+++ b/packages/readr/schema.prisma
@@ -325,6 +325,7 @@ model Post {
   sortOrder                    Int?
   name                         String            @default("")
   subtitle                     String?
+  recommendedTitle             String?
   state                        String?           @default("draft")
   publishTime                  DateTime?
   categories                   Category[]        @relation("Category_relatedPost")


### PR DESCRIPTION
## Reason
The nDX「AI文章標題」workflow (Asana [1215088025385899](https://app.asana.com/1/614399484723017/project/1199408264065173/task/1215088025385899)) generates 3 suggested headlines per article and writes them back to the Post. This adds the CMS field that receives them. The field is an editor-facing reference shown in the CMS only (not on the article front end).

## What this does
Adds `recommendedTitle`「建議標題」to the READr `Post` list:
- `text` with `ui.displayMode: 'textarea'` so it holds the multi-line `1.…\n2.…\n3.…` format
- nullable (`db.isNullable: true`), `isFilterable: false`, `isOrderable: false`

## Scope of impact
- `packages/readr/lists/Post.ts` — field definition
- `packages/readr/migrations/20260617151420_add_recommended_title/migration.sql` — `ALTER TABLE "Post" ADD COLUMN "recommendedTitle" TEXT;` (additive, nullable — no backfill, no downtime)
- `packages/readr/schema.prisma` / `schema.graphql` — regenerated artifacts

Only the READr Post list is touched; other packages/lists are unaffected.

## How to verify
The migration was generated by `keystone prisma migrate dev` (prisma 4.13.0) against a throwaway local Postgres — dev DB untouched. On deploy, `run.sh` runs `keystone prisma migrate deploy`, which applies the additive column. After deploy, the field appears on the Post edit page and is writable via `updatePost(data: { recommendedTitle })`.

## Deploy note
Merging to `ndx-demo` triggers the `lilith-readr-dev` Cloud Build → deploys to the dev CMS (`readr-cms-dev`) and applies the migration. Deploy together with the worker PR (`readr-media/readr-nodemation-lagann#16`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215088025385902