### PR TITLE
feat(mirrormedia): extend event name max length from 10 to 25 characters

### DIFF
--- a/packages/mirrormedia/admin/components/editor-step.tsx
+++ b/packages/mirrormedia/admin/components/editor-step.tsx
@@ -176,11 +176,11 @@ export default function EditorStep() {
             id="event-name-input"
             type="text"
             value={eventName}
-            maxLength={10}
-            placeholder="最多 10 個字"
+            maxLength={25}
+            placeholder="最多 25 個字"
             onChange={(e) => dispatch(setEventName(e.target.value))}
           />
-          <EventNameHint>{eventName.trim().length}/10</EventNameHint>
+          <EventNameHint>{eventName.trim().length}/25</EventNameHint>
         </EventNameWrapper>
         <ControlGroup>
           <HiddenInput ref={inputRef} />


### PR DESCRIPTION
#### Summary
- Extend the event name input field max length from 10 to 25 characters
- Update placeholder text and character counter to reflect the new limit
  
#### Change
- `packages/mirrormedia/admin/components/editor-step.tsx`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215694881602915