### PR TITLE
feat(mirrortv): add IMAGE_COPY_ON_UPLOAD_ENABLED feature toggle for GCS image copy hook

### DIFF
--- a/packages/mirrortv/environment-variables.ts
+++ b/packages/mirrortv/environment-variables.ts
@@ -35,6 +35,7 @@ const {
   COPY_QUEUE_NAME,
   IMAGE_PROCESSOR_URL,
   SCHEDULER_KEY,
+  IMAGE_COPY_ON_UPLOAD_ENABLED,
 } = process.env
 
 enum DatabaseProvider {
@@ -113,4 +114,5 @@ export default {
     url: IMAGE_PROCESSOR_URL || '',
     schedulerKey: SCHEDULER_KEY || '',
   },
+  imageCopyOnUploadEnabled: IMAGE_COPY_ON_UPLOAD_ENABLED === 'true',
 }

--- a/packages/mirrortv/lists/Image.ts
+++ b/packages/mirrortv/lists/Image.ts
@@ -261,6 +261,7 @@ const listConfigurations = list({
 
   hooks: {
     afterOperation: async ({ operation, item, originalItem }) => {
+      if (!envVar.imageCopyOnUploadEnabled) return
       if (operation === 'delete') return
       if (!item?.file_id) return
       if (operation === 'update' && item.file_id === originalItem?.file_id)


### PR DESCRIPTION
#### Summary
- Add `IMAGE_COPY_ON_UPLOAD_ENABLED` feature toggle to gate the GCS image copy and Cloud Tasks fallback hook in the Image list
- Default is `false` (disabled), so existing behavior is preserved until the flag is explicitly enabled