### PR TITLE
chore(draft-renderer): support styled-components v6 compatibility

### DIFF
--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-draft-renderer",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "react": "^18",
     "react-dom": "^18",
-    "styled-components": "^5"
+    "styled-components": "^5 || ^6"
   },
   "files": [
     "lib"
@@ -36,8 +36,8 @@
   "devDependencies": {
     "@types/body-scroll-lock": "^3.1.0",
     "@types/draft-js": "^0.11.10",
-    "@types/styled-components": "^5.1.26",
     "babel-plugin-file-loader": "^2.0.0",
-    "babel-plugin-inline-react-svg": "^2.0.1"
+    "babel-plugin-inline-react-svg": "^2.0.1",
+    "styled-components": "^6"
   }
 }

--- a/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/website/mirrormedia/block-renderers/image-block.tsx
@@ -164,8 +164,8 @@ const LightBoxWrapper = styled.div`
       width: 20px;
       margin: 0 5px 0 0;
       position: relative;
-      &:before,
-      :after {
+      &::before,
+      &::after {
         position: absolute;
         left: 8.5px;
         top: 5px;
@@ -175,10 +175,10 @@ const LightBoxWrapper = styled.div`
         width: 1.2px;
         background-color: #fff;
       }
-      &:before {
+      &::before {
         transform: rotate(45deg);
       }
-      &:after {
+      &::after {
         transform: rotate(-45deg);
       }
     }

--- a/packages/draft-renderer/src/website/mirrortv/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/website/mirrortv/block-renderers/image-block.tsx
@@ -164,8 +164,8 @@ const LightBoxWrapper = styled.div`
       width: 20px;
       margin: 0 5px 0 0;
       position: relative;
-      &:before,
-      :after {
+      &::before,
+      &::after {
         position: absolute;
         left: 8.5px;
         top: 5px;
@@ -175,10 +175,10 @@ const LightBoxWrapper = styled.div`
         width: 1.2px;
         background-color: #fff;
       }
-      &:before {
+      &::before {
         transform: rotate(45deg);
       }
-      &:after {
+      &::after {
         transform: rotate(-45deg);
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2700,6 +2700,13 @@
   resolved "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz"
   integrity sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==
 
+"@emotion/is-prop-valid@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz#e9ad47adff0b5c94c72db3669ce46de33edf28c0"
+  integrity sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==
+  dependencies:
+    "@emotion/memoize" "^0.9.0"
+
 "@emotion/is-prop-valid@^1.1.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz"
@@ -5143,14 +5150,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/hoist-non-react-statics@*":
-  version "3.3.1"
-  resolved "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz"
-  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-
 "@types/http-proxy@^1.17.8":
   version "1.17.9"
   resolved "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.9.tgz"
@@ -5411,15 +5410,6 @@
   version "2.0.3"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
-
-"@types/styled-components@^5.1.26":
-  version "5.1.26"
-  resolved "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.26.tgz"
-  integrity sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==
-  dependencies:
-    "@types/hoist-non-react-statics" "*"
-    "@types/react" "*"
-    csstype "^3.0.2"
 
 "@types/tough-cookie@*":
   version "4.0.5"
@@ -6918,6 +6908,15 @@ css-select@^5.1.0:
     domutils "^3.0.1"
     nth-check "^2.0.1"
 
+css-to-react-native@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
+  integrity sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
+
 css-to-react-native@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz"
@@ -6946,6 +6945,11 @@ csso@^4.2.0:
   integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
   dependencies:
     css-tree "^1.1.2"
+
+csstype@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
+  integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
 csstype@^3.0.2:
   version "3.1.0"
@@ -8832,7 +8836,7 @@ he@1.2.0:
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -12830,6 +12834,16 @@ styled-components@5.3.5:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
+styled-components@^6:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-6.4.2.tgz#2e92f7b8a1e49f5791c80c864eddf215dd1046c6"
+  integrity sha512-xZBhBJsMtGqb+aKcwKgaT+BtuFums9VynX2JRvXJGTx5UfZzN12rk5r4nVdhXYvRw+hE7yiYxVrOqJZaK2+Txg==
+  dependencies:
+    "@emotion/is-prop-valid" "1.4.0"
+    css-to-react-native "3.2.0"
+    csstype "3.2.3"
+    stylis "4.3.6"
+
 styled-jsx@5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz"
@@ -12846,6 +12860,11 @@ stylis@4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz"
   integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
+
+stylis@4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.6.tgz#7c7b97191cb4f195f03ecab7d52f7902ed378320"
+  integrity sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==
 
 supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
This PR introduces a v5/v6 compatibility release for `@mirrormedia/lilith-draft-renderer` to unblock the Phase 6 infrastructure upgrade (styled-components v6) in the Mirror Media Next.js (Adam) project. It expands the peer dependency range, updates development dependencies, and fixes a critical pseudo-element selector syntax issue in the image lightbox close button that is incompatible with stylis v4.

## Additions
- Added `styled-components` v6 to `devDependencies` for local development and validation.

## Removals
- Removed `@types/styled-components` from `devDependencies` as type definitions are now built-in with styled-components v6.

## Changes
- Bumped `@mirrormedia/lilith-draft-renderer` package version to `1.4.7`.
- Expanded `peerDependencies.styled-components` to `^5 || ^6` to maintain backward compatibility with existing v5 consumers while supporting v6.
- Fixed comma-separated pseudo-selectors in `src/website/mirrormedia/block-renderers/image-block.tsx` and `src/website/mirrortv/block-renderers/image-block.tsx` (changed `&:before, :after` to `&::before, &::after`), as stylis v4 no longer auto-appends `&` to naked pseudo-selectors.
- Updated `yarn.lock` to reflect dependency changes.

## Testing
- Run `make build` to ensure successful compilation.
- **Integration Testing in Adam:** Install this candidate release in the Adam project and verify the rendering of general articles, AMP articles, photography articles, wide articles, and external articles. Specifically, verify that the image block lightbox opens and its close button renders and functions correctly.

## Screenshots
- N/A

## Todos
- Publish this v5/v6-compatible release of `@mirrormedia/lilith-draft-renderer`.
- Determine whether to replace `@readr-media/share-button` locally in Adam or perform a similar compatibility release.
- Proceed with styled-components v6 upgrade in Adam (Phase 6) once peer blockers are resolved.

## Task Links
[[週刊改版] 前端_07_styled-components v6 預升級 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1215115081444107?focus=true)