### PR TITLE
feat(mirrordaily): add watermark type selector to multi images upload

### DIFF
--- a/packages/mirrordaily/admin/components/multi-images/editor-step.tsx
+++ b/packages/mirrordaily/admin/components/multi-images/editor-step.tsx
@@ -129,7 +129,10 @@ export default function EditorStep() {
               ref={checkInputRef}
               type="checkbox"
               checked={shouldSetWatermarkToAll}
-              onClick={() => dispatch(setShouldSetWatermarkToAll())}
+              onClick={(e) => {
+                e.stopPropagation()
+                dispatch(setShouldSetWatermarkToAll())
+              }}
             />
             watermark
           </Button>
@@ -138,7 +141,10 @@ export default function EditorStep() {
               ref={checkMediaInputRef}
               type="checkbox"
               checked={waterMarkType === 'mirrormedia'}
-              onClick={() => setWaterMarkType('mirrormedia')}
+              onClick={(e) => {
+                e.stopPropagation()
+                setWaterMarkType('mirrormedia')
+              }}
             />
             週刊
           </Button>
@@ -147,7 +153,10 @@ export default function EditorStep() {
               ref={checkDailyInputRef}
               type="checkbox"
               checked={waterMarkType === 'mirrordaily'}
-              onClick={() => setWaterMarkType('mirrordaily')}
+              onClick={(e) => {
+                e.stopPropagation()
+                setWaterMarkType('mirrordaily')
+              }}
             />
             鏡報
           </Button>

--- a/packages/mirrordaily/admin/components/multi-images/editor-step.tsx
+++ b/packages/mirrordaily/admin/components/multi-images/editor-step.tsx
@@ -113,7 +113,10 @@ export default function EditorStep() {
   const filenames = useAppSelector(selectSelectedFilename)
   const inputRef = useRef<HTMLInputElement>(null)
   const checkInputRef = useRef<HTMLInputElement>(null)
+  const checkMediaInputRef = useRef<HTMLInputElement>(null)
+  const checkDailyInputRef = useRef<HTMLInputElement>(null)
   const [shouldShowAlert, setShouldShowAlert] = useState(false)
+  const [waterMarkType, setWaterMarkType] = useState('mirrordaily')
 
   return (
     <Body>
@@ -129,6 +132,24 @@ export default function EditorStep() {
               onClick={() => dispatch(setShouldSetWatermarkToAll())}
             />
             watermark
+          </Button>
+          <Button clickFn={() => checkMediaInputRef.current?.click()}>
+            <WatermarkIcon
+              ref={checkMediaInputRef}
+              type="checkbox"
+              checked={waterMarkType === 'mirrormedia'}
+              onClick={() => setWaterMarkType('mirrormedia')}
+            />
+            週刊
+          </Button>
+          <Button clickFn={() => checkDailyInputRef.current?.click()}>
+            <WatermarkIcon
+              ref={checkDailyInputRef}
+              type="checkbox"
+              checked={waterMarkType === 'mirrordaily'}
+              onClick={() => setWaterMarkType('mirrordaily')}
+            />
+            鏡報
           </Button>
           <Button
             color={'#FB1818'}
@@ -174,7 +195,7 @@ export default function EditorStep() {
             <Item key={uid} uid={uid} />
           ))}
         </ListGroup>
-        <SubmissionButtonAndModal />
+        <SubmissionButtonAndModal waterMarkType={waterMarkType} />
       </Container>
     </Body>
   )

--- a/packages/mirrordaily/admin/components/multi-images/submission-button-and-modal.tsx
+++ b/packages/mirrordaily/admin/components/multi-images/submission-button-and-modal.tsx
@@ -39,7 +39,13 @@ const ErrorWrapper = styled.p`
   font-size: 20px;
 `
 
-export default function SubmissionButtonAndModal() {
+type SubmissionButtonAndModalProps = {
+  waterMarkType?: string
+}
+
+export default function SubmissionButtonAndModal({
+  waterMarkType = 'mirrordaily',
+}: SubmissionButtonAndModalProps) {
   const dispatch = useDispatch()
   const files = useAppSelector(selectFiles, isEqual)
 
@@ -78,6 +84,7 @@ export default function SubmissionButtonAndModal() {
             upload: d.file,
           },
           waterMark: d.shouldSetWatermark,
+          watermarkType: waterMarkType || 'mirrordaily',
         })),
       },
     })

--- a/packages/mirrordaily/lists/Image.ts
+++ b/packages/mirrordaily/lists/Image.ts
@@ -3,7 +3,7 @@ import { CloudTasksClient, protos } from '@google-cloud/tasks'
 import envVar from '../environment-variables'
 import { utils } from '@mirrormedia/lilith-core'
 import { list, graphql } from '@keystone-6/core'
-import { image, text, virtual, checkbox } from '@keystone-6/core/fields'
+import { image, text, virtual, checkbox, select } from '@keystone-6/core/fields'
 import { getFileURL } from '../utils/common'
 
 const gcsBucket = new Storage().bucket(envVar.gcs.bucket)
@@ -68,8 +68,31 @@ const listConfigurations = list({
       label: '浮水印',
       defaultValue: false,
       ui: {
-        itemView: { fieldMode: 'read' },
+        itemView: { fieldMode: 'hidden' },
       },
+    }),
+    watermarkType: select({
+      label: '',
+      options: [
+        { label: '鏡週刊', value: 'mirrormedia' },
+        { label: '鏡報', value: 'mirrordaily' },
+      ],
+      defaultValue: 'mirrordaily',
+      isIndexed: false,
+    }),
+    waterMarkDescription: virtual({
+      label: '浮水印',
+      ui: {
+        createView: { fieldMode: 'hidden' },
+      },
+      field: graphql.field({
+        type: graphql.String,
+        resolve(item: Record<string, unknown>) {
+          return item.waterMark
+            ? '此圖片已含有浮水印，嵌入文章時會自動顯示，如需修改，請刪除後重新上傳'
+            : '此圖片不含有浮水印，如需修改，請刪除後重新上傳'
+        },
+      }),
     }),
     defaultImage: checkbox({
       label: '預設圖',

--- a/packages/mirrordaily/migrations/20260624023132_add_watermark_type_to_image/migration.sql
+++ b/packages/mirrordaily/migrations/20260624023132_add_watermark_type_to_image/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Image" ADD COLUMN     "watermarkType" TEXT DEFAULT 'mirrordaily';

--- a/packages/mirrordaily/schema.graphql
+++ b/packages/mirrordaily/schema.graphql
@@ -1033,6 +1033,8 @@ type Photo {
   name: String
   imageFile: ImageFieldOutput
   waterMark: Boolean
+  watermarkType: String
+  waterMarkDescription: String
   defaultImage: Boolean
   resized: ResizedImages
   resizedWebp: ResizedWebPImages
@@ -1089,6 +1091,7 @@ input PhotoWhereInput {
   id: IDFilter
   name: StringFilter
   waterMark: BooleanFilter
+  watermarkType: StringNullableFilter
   defaultImage: BooleanFilter
   topicKeywords: StringFilter
   copyRight: BooleanFilter
@@ -1102,6 +1105,7 @@ input PhotoOrderByInput {
   id: OrderDirection
   name: OrderDirection
   waterMark: OrderDirection
+  watermarkType: OrderDirection
   defaultImage: OrderDirection
   topicKeywords: OrderDirection
   copyRight: OrderDirection
@@ -1113,6 +1117,7 @@ input PhotoUpdateInput {
   name: String
   imageFile: ImageFieldInput
   waterMark: Boolean
+  watermarkType: String
   defaultImage: Boolean
   topicKeywords: String
   copyRight: Boolean
@@ -1135,6 +1140,7 @@ input PhotoCreateInput {
   name: String
   imageFile: ImageFieldInput
   waterMark: Boolean
+  watermarkType: String
   defaultImage: Boolean
   topicKeywords: String
   copyRight: Boolean
@@ -2780,6 +2786,7 @@ type Query {
   hotsCount(where: HotWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
+  trafficDashboardEnabled: Boolean!
 }
 
 union AuthenticatedItem = User

--- a/packages/mirrordaily/schema.prisma
+++ b/packages/mirrordaily/schema.prisma
@@ -230,6 +230,7 @@ model Photo {
   imageFile_height            Int?
   imageFile_id                String?
   waterMark                   Boolean        @default(false)
+  watermarkType               String?        @default("mirrordaily")
   defaultImage                Boolean        @default(false)
   topicKeywords               String         @default("")
   copyRight                   Boolean        @default(false)


### PR DESCRIPTION
#### Summary
- 鏡報 multi images 上傳原本只有浮水印 on/off，且僅使用鏡報 logo。本次修改加入「週刊 / 鏡報」類型選擇同步對齊週刊做法
- Task: [Asana](https://app.asana.com/1/614399484723017/project/1215753750830181/task/1215613562490896?focus=true)

#### Changes
- `lists/Image.ts`: 新增 `watermarkType` 欄位(default `mirrordaily`) 和浮水印說明文字
- migration: `Image` 表新增 `watermarkType` 欄位
- multi images UI: 加入「週刊 / 鏡報」選擇，並寫入 mutation

[待補] Cloud Run `image-processor-[dev/staging/prod]`新增環境變數:
| 變數 | 值 |
|------|-----|
| `WATERMARK_OPTION` | `watermarkType` |