### PR TITLE
fix(mirrormedia): hide relatedsOne/relatedsTwo fields and remove from base query

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -43,7 +43,7 @@ const POST_BASE_QUERY = `
   engineers { id name } vocals { id name }
   heroVideo { id name } heroImage { id name } og_image { id name }
   topics { id name }
-  relatedsOne { id slug } relatedsTwo { id slug } relateds { id slug }
+  relateds { id slug }
   tags { id name } related_videos { id name }
 `
 
@@ -577,20 +577,26 @@ const listConfigurations = list({
         views: './lists/views/sorted-relationship/index',
       },
     }),
+    // TODO: 觀察無影響後刪除欄位定義、schema.prisma 欄位，並執行 migration DROP COLUMN
     relatedsOne: relationship({
       label: '相關文章（一）',
       ref: 'Post',
       many: false,
       ui: {
         views: './lists/views/related-posts-all/index',
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'hidden' },
       },
     }),
+    // TODO: 觀察無影響後刪除欄位定義、schema.prisma 欄位，並執行 migration DROP COLUMN
     relatedsTwo: relationship({
       label: '相關文章（二）',
       ref: 'Post',
       many: false,
       ui: {
         views: './lists/views/related-posts-all/index',
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'hidden' },
       },
     }),
     relateds: relationship({

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -586,6 +586,7 @@ const listConfigurations = list({
         views: './lists/views/related-posts-all/index',
         createView: { fieldMode: 'hidden' },
         itemView: { fieldMode: 'hidden' },
+        listView: { fieldMode: 'hidden' },
       },
     }),
     // TODO: 觀察無影響後刪除欄位定義、schema.prisma 欄位，並執行 migration DROP COLUMN
@@ -597,6 +598,7 @@ const listConfigurations = list({
         views: './lists/views/related-posts-all/index',
         createView: { fieldMode: 'hidden' },
         itemView: { fieldMode: 'hidden' },
+        listView: { fieldMode: 'hidden' },
       },
     }),
     relateds: relationship({


### PR DESCRIPTION
task：[[週刊CMS] 研究CMS移除相關文章（一）跟（二）可行性](https://app.asana.com/1/614399484723017/project/1211518136121527/task/1216223741459516?focus=true
)

## 變更

- 從 `POST_BASE_QUERY` 移除 `relatedsOne`、`relatedsTwo`，停止在查詢中拉取這兩個廢棄欄位的資料
- 在 Admin UI 的 create/item view 隱藏兩個欄位（`fieldMode: 'hidden'`），避免編輯者誤用
- 保留欄位定義與 scheOP COLUMNmigration（程式碼內有 TODO 標記）

