### PR TITLE
feat(mirrordaily): allow editor role to change own password only

### DIFF
--- a/packages/mirrordaily/lists/User.ts
+++ b/packages/mirrordaily/lists/User.ts
@@ -9,8 +9,31 @@ import {
   relationship,
 } from '@keystone-6/core/fields'
 
-const { allowRolesForUsers, allowAllRoles, admin, moderator } =
+const { allowRolesForUsers, allowAllRoles, admin, moderator, editor } =
   utils.accessControl
+
+// Editors may change ONLY their own password (security: external reporter accounts
+// must move off the shared password). Everything else stays admin-only.
+//
+// Centralized "default-deny" design (fail-safe for fields added later):
+//   - operation.update: widened to admin + editor. We keep allowRolesForUsers (not
+//     allowAllRoles) so gql/preview deployments stay denied without a session and
+//     the first-user bootstrap bypass is preserved.
+//   - filter.update: row scope — non-admins can only target their own record.
+//   - ui.itemView.defaultFieldMode: every field is read-only for non-admins; only
+//     the password field opts back into edit mode for admin/editor.
+//   - hooks.validateInput: column scope — a non-admin update may only change the
+//     password; touching any other field is rejected (no privilege escalation).
+type FieldMode = 'edit' | 'read'
+type SessionArg = { session?: { data?: { role?: string } } }
+
+const itemViewDefaultFieldMode = ({ session }: SessionArg): FieldMode =>
+  session?.data?.role === 'admin' ? 'edit' : 'read'
+
+const passwordFieldMode = ({ session }: SessionArg): FieldMode => {
+  const role = session?.data?.role
+  return role === 'admin' || role === 'editor' ? 'edit' : 'read'
+}
 
 const listConfigurations = list({
   fields: {
@@ -27,6 +50,11 @@ const listConfigurations = list({
     password: password({
       label: '密碼',
       validation: { isRequired: true },
+      ui: {
+        itemView: {
+          fieldMode: passwordFieldMode,
+        },
+      },
     }),
     role: select({
       label: '角色權限',
@@ -79,28 +107,63 @@ const listConfigurations = list({
       initialSort: { field: 'id', direction: 'DESC' },
       pageSize: 50,
     },
+    itemView: {
+      defaultFieldMode: itemViewDefaultFieldMode,
+    },
   },
   access: {
     operation: {
       query: allowAllRoles(),
-      update: allowRolesForUsers(admin),
+      update: allowRolesForUsers(admin, editor),
       create: allowRolesForUsers(admin),
       delete: allowRolesForUsers(admin),
     },
     filter: {
       query: async (auth) => {
         if (admin(auth) || moderator(auth)) return true
-        else {
-          return {
-            id: {
-              equals: auth.session.data.id,
-            },
-          }
-        }
+        const userId = auth.session?.data?.id
+        if (!userId) return false
+        return { id: { equals: userId } }
+      },
+      // Non-admins (in practice an editor) can only target their own record.
+      update: async (auth) => {
+        if (admin(auth)) return true
+        const userId = auth.session?.data?.id
+        if (!userId) return false
+        return { id: { equals: userId } }
       },
     },
   },
-  hooks: {},
+  hooks: {
+    // Column-level guard. Admins may edit everything; any other role (in practice an
+    // editor already scoped to their own record by filter.update) may only change the
+    // password. Runs on every update mutation, so it cannot be bypassed via GraphQL.
+    validateInput: async ({
+      operation,
+      resolvedData,
+      context,
+      addValidationError,
+    }) => {
+      if (operation !== 'update') return
+      if (context.session?.data?.role === 'admin') return
+
+      // Reject any non-password field that is present in this update. Presence is
+      // enough — don't diff against the stored value: relationship fields arrive as
+      // Prisma nested-write objects (e.g. { disconnect: true }) while the item holds a
+      // scalar FK, so a value comparison would be meaningless.
+      const changed = resolvedData as Record<string, unknown>
+      const changedFields = Object.keys(changed).filter(
+        (field) => field !== 'password' && changed[field] !== undefined
+      )
+      if (changedFields.length > 0) {
+        addValidationError(
+          `你只能修改自己的密碼，不可變更其他欄位（${changedFields.join(
+            '、'
+          )}）。`
+        )
+      }
+    },
+  },
 })
 
 export default listConfigurations


### PR DESCRIPTION
## What

Lets the `editor` role change the password on their **own** User record in the mirrordaily CMS. Every other field stays read-only for non-admins; admins keep full access. Ports the access-control approach already used in `mirrormedia`.

## How (4-layer default-deny)

- **operation.update** — widened to `admin + editor` (kept `allowRolesForUsers`, so gql/preview stay denied without a session and the first-user bootstrap is preserved)
- **filter.update** — non-admins are scoped to their own record
- **ui.itemView fieldMode** — password editable for admin/editor; all other fields read-only for non-admins
- **hooks.validateInput** — a non-admin update may only touch `password`; any other changed field is rejected (blocks privilege escalation even via raw GraphQL)

No DB migration — access control + field modes only, no schema change.

## Verification (local runtime)

Ran mirrordaily locally against the GraphQL API + admin meta:

- editor changes own password → succeeds; old password stops working, new one logs in
- editor changes own name / role → rejected by validateInput
- editor targets another user, or creates / deletes users → denied
- admin still edits every field (regression)
- adminMeta fieldMode: editor sees `password: edit`, all other fields `read`; admin sees all `edit`

## Ref

Asana: https://app.asana.com/1/614399484723017/project/1212235362791829/task/1215475968564401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
