### PR TITLE
feat(readr): add recommendedPoll field to Post

### DIFF
--- a/packages/readr/lists/Post.ts
+++ b/packages/readr/lists/Post.ts
@@ -43,6 +43,16 @@ const listConfigurations = list({
       isFilterable: false,
       isOrderable: false,
     }),
+    recommendedPoll: text({
+      label: '建議投票',
+      ui: { displayMode: 'textarea' },
+      validation: { isRequired: false },
+      db: {
+        isNullable: true,
+      },
+      isFilterable: false,
+      isOrderable: false,
+    }),
     state: select({
       label: '狀態',
       options: [

--- a/packages/readr/migrations/20260707131633_add_recommended_poll/migration.sql
+++ b/packages/readr/migrations/20260707131633_add_recommended_poll/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "recommendedPoll" TEXT;

--- a/packages/readr/schema.graphql
+++ b/packages/readr/schema.graphql
@@ -1240,6 +1240,7 @@ type Post {
   name: String
   subtitle: String
   recommendedTitle: String
+  recommendedPoll: String
   state: String
   publishTime: DateTime
   categories(where: CategoryWhereInput! = {}, orderBy: [CategoryOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CategoryWhereUniqueInput): [Category!]
@@ -1415,6 +1416,7 @@ input PostUpdateInput {
   name: String
   subtitle: String
   recommendedTitle: String
+  recommendedPoll: String
   state: String
   publishTime: DateTime
   categories: CategoryRelateToManyForUpdateInput
@@ -1518,6 +1520,7 @@ input PostCreateInput {
   name: String
   subtitle: String
   recommendedTitle: String
+  recommendedPoll: String
   state: String
   publishTime: DateTime
   categories: CategoryRelateToManyForCreateInput

--- a/packages/readr/schema.prisma
+++ b/packages/readr/schema.prisma
@@ -326,6 +326,7 @@ model Post {
   name                         String            @default("")
   subtitle                     String?
   recommendedTitle             String?
+  recommendedPoll              String?
   state                        String?           @default("draft")
   publishTime                  DateTime?
   categories                   Category[]        @relation("Category_relatedPost")


### PR DESCRIPTION
## Reason
Adds the「建議投票」CMS Post field (`recommendedPoll`) required by the nDX「AI投票建議」workflow (Asana [1215524824018545](https://app.asana.com/1/614399484723017/project/1212235362791829/task/1215524824018545)). The worker's `aiPoll` node generates a suggested poll (1 topic + N options) and writes it back to this field via `cmsOutput`; without the field the write-back has no target.

Companion PRs: worker `aiPoll` executor (`readr-nodemation-lagann`) and App UI wiring (`readr-nodemation`).

## Scope
- `packages/readr/lists/Post.ts`: new `recommendedPoll` field — `text({ ui: { displayMode: 'textarea' }, validation: { isRequired: false }, db: { isNullable: true }, isFilterable: false, isOrderable: false })` — config-identical to the existing `recommendedTitle` field, placed next to it.
- Prisma migration `migrations/20260707131633_add_recommended_poll/migration.sql` (`ALTER TABLE "Post" ADD COLUMN "recommendedPoll" TEXT;`).
- Regenerated artifacts: `schema.prisma` (`recommendedPoll String?`) and `schema.graphql` (`recommendedPoll: String` in `Post`, `PostCreateInput`, `PostUpdateInput`).

Impact: additive, nullable column — no data migration, no effect on existing content. CMS-editor-only field (hidden from the public article page, like `recommendedTitle`).

## How to verify
- The migration is byte-identical in shape to the proven `20260617151420_add_recommended_title` migration (only the column name differs); it auto-applies via `keystone prisma migrate deploy` (`packages/readr/run.sh`) on deploy.
- After deploy: `PostUpdateInput.recommendedPoll: String` accepts the worker's write-back, and the field renders as a textarea labeled「建議投票」in the Admin UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
