### PR TITLE
feat(mirrordaily): update post updateTimeStamp default to false

### DIFF
--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -841,7 +841,7 @@ const listConfigurations = list({
     updateTimeStamp: checkbox({
       label: '下次存檔時自動更改成「現在時間」',
       isFilterable: false,
-      defaultValue: true,
+      defaultValue: false,
     }),
     pv: integer({
       label: 'Page View',

--- a/packages/mirrordaily/migrations/20260710042247_update_post_savetime_default/migration.sql
+++ b/packages/mirrordaily/migrations/20260710042247_update_post_savetime_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ALTER COLUMN "updateTimeStamp" SET DEFAULT false;

--- a/packages/mirrordaily/schema.graphql
+++ b/packages/mirrordaily/schema.graphql
@@ -1154,6 +1154,7 @@ type Post {
   id: ID!
   lockBy: User
   lockExpireAt: DateTime
+  lockStatus: String
   slug: String
   title: String
   subtitle: String

--- a/packages/mirrordaily/schema.prisma
+++ b/packages/mirrordaily/schema.prisma
@@ -313,7 +313,7 @@ model Post {
   manualOrderOfRelatedVideos Json?
   state                      String?        @default("draft")
   publishedDate              DateTime       @default(now())
-  updateTimeStamp            Boolean        @default(true)
+  updateTimeStamp            Boolean        @default(false)
   pv                         Int?           @default(0)
   isFeatured                 Boolean        @default(false)
   isAdvertised               Boolean        @default(false)


### PR DESCRIPTION
#### Summary
[鏡報] CMS 新增文章時，「下次存檔時自動更改成『現在時間』」checkbox 預設改為不勾選
TASK: [Asana](https://app.asana.com/1/614399484723017/project/1216190579632682/task/1216097029573216?focus=true)

#### Changes
- `Post.ts` — `updateTimeStamp` defaultValue: `true` → `false`
- `schema.prisma` — 同步更新 DB default 值
- `schema.graphql` — 補回 `lockStatus` 欄位（因先前 revert PR #1258 導致與 Post.ts 不同步）
- migration: `update_post_savetime_default`