### PR TITLE
feat(mirrordaily): update EditorChoice list default columns

### DIFF
--- a/packages/mirrordaily/lists/EditorChoice.ts
+++ b/packages/mirrordaily/lists/EditorChoice.ts
@@ -69,7 +69,14 @@ const listConfigurations = list({
   ui: {
     labelField: 'id',
     listView: {
-      initialColumns: ['id', 'order', 'choices'],
+      initialColumns: [
+        'id',
+        'order',
+        'choices',
+        'state',
+        'updatedAt',
+        'updatedBy',
+      ],
       initialSort: { field: 'id', direction: 'DESC' },
       pageSize: 50,
     },


### PR DESCRIPTION
Task: [[鏡報] CMS Editor Choices 列表頁預設欄位與順序調整](https://app.asana.com/1/614399484723017/inbox/1211621121118901/item/1216951491105097/story/1217117669830880?focus=true)

#### Changes
- 調整 EditorChoice list 在列表頁的預設顯示欄位（ui.listView.initialColumns），讓編輯開列表時直接看到常用欄位
- 預設欄位（依序）： id → 排序(order) → 精選文章(choices) → 狀態(state) → 更新時間(updatedAt) → 更新者(updatedBy)
註：多保留 id 給 sort 使用

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216951491105097