### PR TITLE
fix(mirrordaily): enable bold and italic buttons in post brief editor toolbar

### DIFF
--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -527,8 +527,6 @@ const listConfigurations = list({
       label: '前言',
       disabledButtons: [
         'code',
-        'bold',
-        'italic',
         'underline',
         'header-two',
         'header-three',


### PR DESCRIPTION
Task: [[鏡報]CMS Post內前言放大按鈕異常](https://app.asana.com/1/614399484723017/inbox/1211621121118901/item/1216969952453357/story/1217099758656154?focus=true)

#### Issue
Brief rich text 編輯器放大鈕異常：由於前言把 toolbar 的按鈕全部 disable，toolbar 變成空的，導致右上角的放大／縮小鈕被壓縮覆蓋因此放大後也縮不回來

#### Approach
`mirrordaily/lists/Post.ts` 的 `brief` 欄位 disabledButtons 中，移除 'bold'、'italic'，讓前言 toolbar 顯示粗體 / 斜體按鈕使toolbar 不再是空的，放大鈕即可正常運作

#### Notes: draft-editor (另一種做法)
- 前言(brief)與內文(content)用的是專案客製化的 rich text 編輯器（Draft.js base，來自 @mirrormedia/lilith-core 的 customFields.richTextEditor）
- 放大／縮小鈕是編輯器內建、獨立於 disabledButtons 之外、永遠會 render，所以無法用 disabledButtons 把它關掉
- 前言把所有功能鍵都 disable → toolbar 內容為空、高度塌陷 → 絕對定位在右上角的放大鈕失去可點空間、被編輯區蓋住、放大後也縮不回

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216969952453357