### PR TITLE
feat(mirrordaily): add Post EditLog audit trail

### DIFF
--- a/packages/mirrordaily/lists/EditLog.ts
+++ b/packages/mirrordaily/lists/EditLog.ts
@@ -1,0 +1,175 @@
+import { customFields, utils } from '@mirrormedia/lilith-core'
+import { graphql, list } from '@keystone-6/core'
+import { relationship, text, timestamp, virtual } from '@keystone-6/core/fields'
+
+import { formatChangedList } from '../utils/formatChangedList'
+
+const { allowRoles, admin, moderator } = utils.accessControl
+
+type DraftContent = {
+  blocks?: { text: string }[]
+}
+
+const extractText = (val: unknown): string => {
+  if (!val || typeof val !== 'object') return ''
+  const content = val as DraftContent
+  return (
+    content.blocks
+      ?.map((b) => b.text)
+      .filter(Boolean)
+      .join(' ')
+      .substring(0, 200) ?? ''
+  )
+}
+
+const listConfigurations = list({
+  fields: {
+    name: text({
+      label: '編輯者',
+      validation: { isRequired: true },
+      ui: { itemView: { fieldMode: 'read' } },
+    }),
+
+    operation: text({
+      label: '動作',
+      validation: { isRequired: true },
+      ui: { itemView: { fieldMode: 'read' } },
+    }),
+
+    postId: text({
+      label: '文章ID',
+      ui: { itemView: { fieldMode: 'read' } },
+      isIndexed: true,
+    }),
+
+    changedList: text({
+      label: '欄位更動內容',
+      ui: {
+        displayMode: 'textarea',
+        itemView: { fieldMode: 'read' },
+      },
+      hooks: {
+        resolveInput: async ({ resolvedData, item }) => {
+          const raw = resolvedData.changedList || item?.changedList || ''
+          if (typeof raw === 'string' && raw.trim().startsWith('{')) {
+            return formatChangedList(raw)
+          }
+
+          return raw
+        },
+      },
+    }),
+
+    brief: customFields.richTextEditor({
+      label: '已更動前言',
+      ui: {
+        listView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'read' },
+      },
+      disabledButtons: [],
+      website: 'mirrordaily',
+    }),
+
+    briefPreview: virtual({
+      label: '前言預覽',
+      field: graphql.field({
+        type: graphql.String,
+        resolve(item: Record<string, unknown>): string {
+          return extractText(item.brief)
+        },
+      }),
+      ui: {
+        listView: { fieldMode: 'read' },
+        itemView: { fieldMode: 'hidden' },
+      },
+    }),
+
+    content: customFields.richTextEditor({
+      label: '已更動內文',
+      ui: {
+        listView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'read' },
+      },
+      disabledButtons: [],
+      website: 'mirrordaily',
+    }),
+
+    contentPreview: virtual({
+      label: '內文預覽',
+      field: graphql.field({
+        type: graphql.String,
+        resolve(item: Record<string, unknown>): string {
+          return extractText(item.content)
+        },
+      }),
+      ui: {
+        listView: { fieldMode: 'read' },
+        itemView: { fieldMode: 'hidden' },
+      },
+    }),
+  },
+
+  access: {
+    operation: {
+      query: allowRoles(admin, moderator),
+      create: () => false,
+      update: () => false,
+      delete: () => false,
+    },
+  },
+
+  ui: {
+    labelField: 'name',
+    listView: {
+      initialColumns: [
+        'id',
+        'name',
+        'operation',
+        'postId',
+        'briefPreview',
+        'contentPreview',
+        'createdAt',
+      ] as any,
+      initialSort: { field: 'id', direction: 'DESC' },
+      pageSize: 50,
+    },
+  },
+})
+
+const editLogList = utils.addTrackingFields(listConfigurations)
+
+// 更新者/更新時間永遠為空（紀錄不可被更新），建立者與「編輯者」重複。
+// 用與 addTrackingFields 相同的欄位定義重新宣告，只多加 listView 隱藏 ——
+// 欄位型別不變（schema 不變、免 migration），只從列表隱藏。不改共用工具。
+const hiddenInListView = { fieldMode: 'hidden' } as const
+const trackingItemView = { fieldMode: 'read' } as const
+const trackingCreateView = { fieldMode: 'hidden' } as const
+
+editLogList.fields.updatedAt = timestamp({
+  label: '更新時間',
+  ui: {
+    createView: trackingCreateView,
+    itemView: hiddenInListView,
+    listView: hiddenInListView,
+  },
+})
+editLogList.fields.createdBy = relationship({
+  label: '建立者',
+  ref: 'User',
+  ui: {
+    createView: trackingCreateView,
+    itemView: trackingItemView,
+    listView: hiddenInListView,
+  },
+})
+editLogList.fields.updatedBy = relationship({
+  label: '更新者',
+  ref: 'User',
+  ui: {
+    createView: trackingCreateView,
+    itemView: hiddenInListView,
+    listView: hiddenInListView,
+  },
+})
+
+export default editLogList

--- a/packages/mirrordaily/lists/Post.ts
+++ b/packages/mirrordaily/lists/Post.ts
@@ -19,6 +19,42 @@ import { computeLockExpireAt } from '../utils/post-lock'
 
 const { allowRoles, admin, moderator, editor } = utils.accessControl
 
+// 用於在 beforeOperation 儲存 update 前的完整舊資料（含 relationship），
+// 讓 afterOperation 能以相同格式做比對，避免 Prisma raw row 與 GraphQL 格式不一致
+type SnapshotEntry = { data: Record<string, unknown>; ts: number }
+const preSaveSnapshot = new Map<string, SnapshotEntry>()
+
+// DB 操作失敗時 afterOperation 不會被呼叫，導致 snapshot 殘留
+// 每分鐘清除超過 5 分鐘的 stale entry
+const snapshotCleanupTimer = setInterval(() => {
+  const cutoff = Date.now() - 5 * 60 * 1000
+  for (const [key, val] of preSaveSnapshot) {
+    if (val.ts < cutoff) preSaveSnapshot.delete(key)
+  }
+}, 60 * 1000)
+snapshotCleanupTimer.unref()
+
+// EditLog 用：擷取 Post 完整資料的 GraphQL query
+const POST_BASE_QUERY = `
+  id title subtitle state publishedDate publishedDateString
+  heroCaption style isMember isFeatured isAdvertised
+  hiddenAdvertised isAdult redirect adTrace css
+  og_title og_description extend_byline
+  sections { id name } categories { id name }
+  writers { id name } photographers { id name }
+  camera_man { id name } designers { id name }
+  engineers { id name } vocals { id name }
+  heroVideo { id name } heroImage { id name }
+  defaultHeroImage { id name } og_image { id name }
+  topics { id name }
+  relateds { id } relatedsOne { id } relatedsTwo { id } relatedsThree { id }
+  tags { id name } related_videos { id name }
+  Warning { id content } Warnings { id content }
+`
+
+const buildPostQuery = (includeRichText: boolean) =>
+  includeRichText ? POST_BASE_QUERY + ' brief content' : POST_BASE_QUERY
+
 enum PostStatus {
   Published = State.Published,
   Draft = State.Draft,
@@ -1121,7 +1157,28 @@ const listConfigurations = list({
       }
       return resolvedData
     },
-    beforeOperation: async ({ operation, resolvedData }) => {
+    beforeOperation: async ({ operation, item, resolvedData, context }) => {
+      // EditLog：update/delete 前抓完整快照，供 afterOperation 比對
+      if ((operation === 'update' || operation === 'delete') && item) {
+        try {
+          const includeRichText =
+            operation === 'delete' ||
+            resolvedData?.brief !== undefined ||
+            resolvedData?.content !== undefined
+          const snapshot = (await context.sudo().query.Post.findOne({
+            where: { id: String(item.id) },
+            query: buildPostQuery(includeRichText),
+          })) as Record<string, unknown>
+          if (snapshot) {
+            preSaveSnapshot.set(String(item.id), {
+              data: snapshot,
+              ts: Date.now(),
+            })
+          }
+        } catch (err) {
+          console.error('[EditLog] beforeOperation snapshot 失敗:', err)
+        }
+      }
       /* ... */
       if (operation === 'create' || operation === 'update') {
         // if (resolvedData.slug) {
@@ -1147,7 +1204,13 @@ const listConfigurations = list({
       }
       return
     },
-    afterOperation: async ({ operation, item, context, resolvedData }) => {
+    afterOperation: async ({
+      operation,
+      item,
+      originalItem,
+      context,
+      resolvedData,
+    }) => {
       // 更新 Topic 的 updatedAt
       if (operation === 'update' || operation === 'create') {
         if (resolvedData?.topics) {
@@ -1260,6 +1323,178 @@ const listConfigurations = list({
         //    lockExpireAt: null,
         //  },
         //})
+      }
+      if (
+        operation === 'create' ||
+        operation === 'update' ||
+        operation === 'delete'
+      ) {
+        try {
+          const editorName = context.session?.data?.name || '系統自動'
+
+          const formatValueForLog = (val: unknown): string | null => {
+            if (val === undefined || val === null) return null
+            if (Array.isArray(val)) {
+              if (val.length === 0) return null
+              return val
+                .map((v: unknown) => {
+                  if (v && typeof v === 'object') {
+                    const obj = v as Record<string, unknown>
+                    return String(obj.name ?? obj.content ?? obj.id ?? '')
+                  }
+                  return String(v)
+                })
+                .join(',')
+            }
+            if (typeof val === 'object') {
+              const obj = val as Record<string, unknown>
+              if (obj.name) return String(obj.name)
+              if (obj.content) return String(obj.content)
+              if (obj.id) return String(obj.id)
+              return JSON.stringify(val)
+            }
+            return String(val)
+          }
+
+          const safeParse = (data: unknown): unknown => {
+            if (!data) return undefined
+            return data
+          }
+
+          const targetId = item?.id || originalItem?.id
+          if (!targetId) {
+            console.warn('[EditLog] 無法取得目標 ID，取消紀錄')
+            return
+          }
+
+          const includeRichText =
+            operation === 'create' ||
+            resolvedData?.brief !== undefined ||
+            resolvedData?.content !== undefined
+          const fullNewItem =
+            operation !== 'delete'
+              ? ((await context.sudo().query.Post.findOne({
+                  where: { id: String(targetId) },
+                  query: buildPostQuery(includeRichText),
+                })) as Record<string, unknown>)
+              : null
+
+          if (operation !== 'delete' && !fullNewItem) {
+            console.warn('[EditLog] 取不到變動後資料，取消紀錄:', targetId)
+            preSaveSnapshot.delete(String(targetId))
+            return
+          }
+
+          const oldItemBase: Record<string, unknown> =
+            preSaveSnapshot.get(String(targetId))?.data ??
+            (originalItem as Record<string, unknown>) ??
+            {}
+
+          preSaveSnapshot.delete(String(targetId))
+
+          const blackList = [
+            'id',
+            'apiData',
+            'apiDataBrief',
+            'updatedAt',
+            'createdAt',
+            'publishedDateString',
+            'updateTimeStamp',
+            'lockBy',
+            'lockExpireAt',
+            'lockStatus',
+            'slug',
+            'pv',
+            'manualOrderOfWriters',
+            'manualOrderOfSections',
+            'manualOrderOfCategories',
+            'manualOrderOfRelateds',
+            'manualOrderOfRelatedVideos',
+            'tags_algo',
+            'from_External_relateds',
+            'groups',
+          ]
+
+          const editedData: Record<string, string | null> = {}
+          let briefObject: unknown = undefined
+          let contentObject: unknown = undefined
+
+          if (operation === 'update') {
+            const newItem = fullNewItem || {}
+            Object.keys(resolvedData || {}).forEach((key) => {
+              if (
+                blackList.includes(key) ||
+                key === 'brief' ||
+                key === 'content'
+              )
+                return
+
+              const oldValue = formatValueForLog(oldItemBase[key])
+              const newValue = formatValueForLog(newItem[key])
+
+              if (oldValue !== newValue) {
+                // 與 create/delete 一致，清空欄位存真正的 null（非字串 'null'）
+                editedData[key] = newValue
+              }
+            })
+
+            if (resolvedData.brief !== undefined) {
+              const oldBrief = JSON.stringify(oldItemBase.brief ?? null)
+              const newBrief = JSON.stringify(newItem.brief ?? null)
+              if (oldBrief !== newBrief) {
+                briefObject = newItem.brief
+              }
+            }
+            if (resolvedData.content !== undefined) {
+              const oldContent = JSON.stringify(oldItemBase.content ?? null)
+              const newContent = JSON.stringify(newItem.content ?? null)
+              if (oldContent !== newContent) {
+                contentObject = newItem.content
+              }
+            }
+          } else {
+            // create: 從 fullNewItem（GraphQL query）取得完整資料
+            // delete: 優先用 beforeOperation 儲存的 snapshot，失敗退回 originalItem
+            const target =
+              operation === 'delete' ? oldItemBase : fullNewItem || {}
+
+            Object.keys(target).forEach((key) => {
+              if (
+                blackList.includes(key) ||
+                key === 'brief' ||
+                key === 'content'
+              )
+                return
+              editedData[key] = formatValueForLog(target[key])
+            })
+            briefObject = target.brief
+            contentObject = target.content
+          }
+
+          if (
+            operation === 'update' &&
+            Object.keys(editedData).length === 0 &&
+            briefObject === undefined &&
+            contentObject === undefined
+          ) {
+            return
+          }
+
+          await context.sudo().query.EditLog.createOne({
+            data: {
+              name: editorName,
+              operation: operation,
+              postId: String(targetId),
+              brief: safeParse(briefObject),
+              content: safeParse(contentObject),
+              changedList: JSON.stringify(editedData),
+            },
+          })
+
+          console.log(`[EditLog] ${operation} 成功紀錄: ${targetId}`)
+        } catch (err) {
+          console.error(`[EditLog] ${operation} 發生錯誤:`, err)
+        }
       }
     },
   },

--- a/packages/mirrordaily/lists/index.ts
+++ b/packages/mirrordaily/lists/index.ts
@@ -5,6 +5,7 @@ import Audio from './Audio'
 import Contact from './Contact'
 import Video from './Video'
 import EditorChoice from './EditorChoice'
+import EditLog from './EditLog'
 import User from './User'
 import Section from './Section'
 import Image from './Image'
@@ -42,4 +43,5 @@ export const listDefinition = {
   Warning,
   PopularTag,
   Hot: HotNews,
+  EditLog,
 }

--- a/packages/mirrordaily/migrations/20260805025049_add_editlog/migration.sql
+++ b/packages/mirrordaily/migrations/20260805025049_add_editlog/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "EditLog" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL DEFAULT '',
+    "operation" TEXT NOT NULL DEFAULT '',
+    "postId" TEXT NOT NULL DEFAULT '',
+    "changedList" TEXT NOT NULL DEFAULT '',
+    "brief" JSONB,
+    "content" JSONB,
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+    "createdBy" INTEGER,
+    "updatedBy" INTEGER,
+
+    CONSTRAINT "EditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "EditLog_postId_idx" ON "EditLog"("postId");
+
+-- CreateIndex
+CREATE INDEX "EditLog_createdBy_idx" ON "EditLog"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "EditLog_updatedBy_idx" ON "EditLog"("updatedBy");
+
+-- AddForeignKey
+ALTER TABLE "EditLog" ADD CONSTRAINT "EditLog_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EditLog" ADD CONSTRAINT "EditLog_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/mirrordaily/schema.graphql
+++ b/packages/mirrordaily/schema.graphql
@@ -2566,6 +2566,82 @@ input HotCreateInput {
   updatedBy: UserRelateToOneForCreateInput
 }
 
+type EditLog {
+  id: ID!
+  name: String
+  operation: String
+  postId: String
+  changedList: String
+  brief: JSON
+  briefPreview: String
+  content: JSON
+  contentPreview: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: User
+  updatedBy: User
+}
+
+input EditLogWhereUniqueInput {
+  id: ID
+}
+
+input EditLogWhereInput {
+  AND: [EditLogWhereInput!]
+  OR: [EditLogWhereInput!]
+  NOT: [EditLogWhereInput!]
+  id: IDFilter
+  name: StringFilter
+  operation: StringFilter
+  postId: StringFilter
+  changedList: StringFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  createdBy: UserWhereInput
+  updatedBy: UserWhereInput
+}
+
+input EditLogOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  operation: OrderDirection
+  postId: OrderDirection
+  changedList: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input EditLogUpdateInput {
+  name: String
+  operation: String
+  postId: String
+  changedList: String
+  brief: JSON
+  content: JSON
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForUpdateInput
+  updatedBy: UserRelateToOneForUpdateInput
+}
+
+input EditLogUpdateArgs {
+  where: EditLogWhereUniqueInput!
+  data: EditLogUpdateInput!
+}
+
+input EditLogCreateInput {
+  name: String
+  operation: String
+  postId: String
+  changedList: String
+  brief: JSON
+  content: JSON
+  createdAt: DateTime
+  updatedAt: DateTime
+  createdBy: UserRelateToOneForCreateInput
+  updatedBy: UserRelateToOneForCreateInput
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -2698,6 +2774,12 @@ type Mutation {
   updateHots(data: [HotUpdateArgs!]!): [Hot]
   deleteHot(where: HotWhereUniqueInput!): Hot
   deleteHots(where: [HotWhereUniqueInput!]!): [Hot]
+  createEditLog(data: EditLogCreateInput!): EditLog
+  createEditLogs(data: [EditLogCreateInput!]!): [EditLog]
+  updateEditLog(where: EditLogWhereUniqueInput!, data: EditLogUpdateInput!): EditLog
+  updateEditLogs(data: [EditLogUpdateArgs!]!): [EditLog]
+  deleteEditLog(where: EditLogWhereUniqueInput!): EditLog
+  deleteEditLogs(where: [EditLogWhereUniqueInput!]!): [EditLog]
   endSession: Boolean!
   authenticateUserWithPassword(email: String!, password: String!): UserAuthenticationWithPasswordResult
   createInitialUser(data: CreateInitialUserInput!): UserAuthenticationWithPasswordSuccess!
@@ -2785,6 +2867,9 @@ type Query {
   hots(where: HotWhereInput! = {}, orderBy: [HotOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: HotWhereUniqueInput): [Hot!]
   hot(where: HotWhereUniqueInput!): Hot
   hotsCount(where: HotWhereInput! = {}): Int
+  editLogs(where: EditLogWhereInput! = {}, orderBy: [EditLogOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: EditLogWhereUniqueInput): [EditLog!]
+  editLog(where: EditLogWhereUniqueInput!): EditLog
+  editLogsCount(where: EditLogWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
   trafficDashboardEnabled: Boolean!

--- a/packages/mirrordaily/schema.prisma
+++ b/packages/mirrordaily/schema.prisma
@@ -536,6 +536,8 @@ model User {
   from_PopularTag_updatedBy   PopularTag[]   @relation("PopularTag_updatedBy")
   from_Hot_createdBy          Hot[]          @relation("Hot_createdBy")
   from_Hot_updatedBy          Hot[]          @relation("Hot_updatedBy")
+  from_EditLog_createdBy      EditLog[]      @relation("EditLog_createdBy")
+  from_EditLog_updatedBy      EditLog[]      @relation("EditLog_updatedBy")
 
   @@index([authorId])
 }
@@ -677,6 +679,26 @@ model Hot {
   @@index([hotexternalId])
   @@index([state])
   @@index([heroImageId])
+  @@index([createdById])
+  @@index([updatedById])
+}
+
+model EditLog {
+  id          Int       @id @default(autoincrement())
+  name        String    @default("")
+  operation   String    @default("")
+  postId      String    @default("")
+  changedList String    @default("")
+  brief       Json?
+  content     Json?
+  createdAt   DateTime?
+  updatedAt   DateTime?
+  createdBy   User?     @relation("EditLog_createdBy", fields: [createdById], references: [id])
+  createdById Int?      @map("createdBy")
+  updatedBy   User?     @relation("EditLog_updatedBy", fields: [updatedById], references: [id])
+  updatedById Int?      @map("updatedBy")
+
+  @@index([postId])
   @@index([createdById])
   @@index([updatedById])
 }

--- a/packages/mirrordaily/utils/formatChangedList.ts
+++ b/packages/mirrordaily/utils/formatChangedList.ts
@@ -1,0 +1,24 @@
+/**
+ * 將 JSON 字串轉成多行 key:value 文字列表，並去掉第一個 key（id）
+ *
+ * @param changedList - JSON 字串
+ * @returns 格式化後的多行字串
+ */
+export const formatChangedList = (changedList: string): string => {
+  let changedListObj: Record<string, unknown>
+
+  try {
+    changedListObj = JSON.parse(changedList)
+  } catch (err) {
+    return changedList
+  }
+
+  const result = Object.keys(changedListObj)
+    .filter((key) => key !== 'id')
+    .map((key) => {
+      const value = changedListObj[key]
+      return `${key}:${String(value)}`
+    })
+
+  return result.join('\n')
+}


### PR DESCRIPTION
task：[[鏡報]仿效電視或週刊於CMS增加edit log](https://app.asana.com/1/614399484723017/project/1217056824510799/task/1216281858897841?focus=true)


## 概述

為 mirrordaily 新增文章的「編輯紀錄（EditLog）」功能，比照 mirrormedia 既有實作。
每當 Post 被新增／修改／刪除，自動記錄一筆紀錄，包含編輯者、動作、變動的欄位內容，以及變動後的前言（brief）與內文（content）。

## 變更內容

- **新增 `lists/EditLog.ts`** — 唯讀稽核 list
  - `create/update/delete` 權限全關，寫入僅透過 hook 的 `context.sudo()`
  - 以 **postId** 辨識文章（mirrordaily 的 slug 已廢棄）
  - 追蹤欄位的「更新者／更新時間／建立者」從列表隱藏（更新者/更新時間單筆頁也隱藏）
- **新增 `utils/formatChangedList.ts`** — JSON → 多行可讀文字（沿用 mirrormedia）
- **修改 `lists/Post.ts`** — `beforeOperation` 存快照 + `afterOperation` 比對差異寫 EditLog
  - **不影響**既有的 topic sync / autotagging / lock 邏輯
  - update 只記變動欄位、無變動不記錄
- **修改 `lists/index.ts`** — 註冊 EditLog
- **`schema.prisma` / `schema.graphql` / migration** — Keystone 自動生成
