### PR TITLE
feat(mirrordaily): align Topic heroImage picker with Post

### DIFF
--- a/packages/mirrordaily/lists/Topic.ts
+++ b/packages/mirrordaily/lists/Topic.ts
@@ -125,6 +125,15 @@ const listConfigurations = list({
     heroImage: relationship({
       ref: 'Photo',
       label: '首圖',
+      ui: {
+        displayMode: 'cards',
+        cardFields: ['imageFile'],
+        inlineCreate: {
+          fields: ['name', 'imageFile', 'waterMark'],
+        },
+        inlineConnect: true,
+        views: './lists/views/sorted-relationship/index',
+      },
     }),
     heroUrl: text({
       label: '首圖連結 URL',


### PR DESCRIPTION
task：[[鏡報]CMS Topic內選首圖增加預覽圖與降序排序](https://app.asana.com/1/614399484723017/project/1217056824510799/task/1216951491105093?focus=true)
## 需求
 Topic 頁面的首圖選單比照 Post 頁面的首圖下拉選單有圖片縮圖預覽、且依上傳時間新到舊排序的功能

## 改動
`packages/mirrordaily/lists/Topic.ts` 的 `heroImage` 欄位加上與 Post.ts
相同的 UI 設定：

- `displayMode: 'cards'` + `cardFields: ['imageFile']`：選好首圖後以卡片+縮圖呈現，取代原本純文字顯示
- `views: './lists/views/sorted-relationship/index'`：套用共用元件，讓下拉選單依 id 新到舊排序，並在選項旁顯示圖片縮圖
- `inlineConnect: true`：可在下拉選單直接搜尋、連結既有 Photo
- `inlineCreate: { fields: ['name', 'imageFile', 'waterMark'] }`：可在 Topic 頁面就地新增 Photo，不用跳去 Photos list
  