### PR TITLE
fix(mirrordaily): restrict EditLog query access to admin only

### DIFF
--- a/packages/mirrordaily/lists/EditLog.ts
+++ b/packages/mirrordaily/lists/EditLog.ts
@@ -4,7 +4,7 @@ import { relationship, text, timestamp, virtual } from '@keystone-6/core/fields'
 
 import { formatChangedList } from '../utils/formatChangedList'
 
-const { allowRoles, admin, moderator } = utils.accessControl
+const { allowRoles, admin } = utils.accessControl
 
 type DraftContent = {
   blocks?: { text: string }[]
@@ -111,7 +111,7 @@ const listConfigurations = list({
 
   access: {
     operation: {
-      query: allowRoles(admin, moderator),
+      query: allowRoles(admin),
       create: () => false,
       update: () => false,
       delete: () => false,


### PR DESCRIPTION
task：[[鏡報]仿效電視或週刊於CMS增加edit log](https://app.asana.com/1/614399484723017/project/1217056824510799/task/1216281858897841?focus=true)

按編輯台需求，限制 EditLog 僅限 admin 可查閱