### PR TITLE
feat(readr): restore Keystone MCP mini app on lilith-core 3.1.0-beta.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-core",
-  "version": "3.0.11-beta.10",
+  "version": "3.1.0-beta.1",
   "description": "",
   "main": "lib/index.js",
   "types": "@types/index.d.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ import { createLoginLoggingPlugin } from './utils/login-logging'
 import { draftConverter } from '@mirrormedia/lilith-draft-editor'
 import { richTextEditor } from './custom-fields/rich-text-editor'
 import { selectWithColor } from './custom-fields/select-with-color'
+import * as mcp from './mcp'
 
 export const admin = {
   ListSearchMobileFix,
@@ -27,8 +28,12 @@ export const utils = {
   createLoginLoggingPlugin,
 }
 
+export { mcp }
+export * from './mcp'
+
 export default {
   admin,
   customFields,
   utils,
+  mcp,
 }

--- a/packages/core/src/mcp/express.ts
+++ b/packages/core/src/mcp/express.ts
@@ -1,0 +1,151 @@
+import { ExpressHandler, McpServerOptions, McpTextContent } from './types'
+
+type JsonRpcRequest = {
+  jsonrpc?: unknown
+  id?: string | number | null
+  method?: unknown
+  params?: unknown
+}
+
+const JSON_RPC_VERSION = '2.0'
+const MCP_PROTOCOL_VERSION = '2025-03-26'
+
+function sendResult(
+  response: Parameters<ExpressHandler>[1],
+  id: JsonRpcRequest['id'],
+  result: unknown
+) {
+  return response.json({ jsonrpc: JSON_RPC_VERSION, id: id ?? null, result })
+}
+
+function sendError(
+  response: Parameters<ExpressHandler>[1],
+  id: JsonRpcRequest['id'],
+  code: number,
+  message: string
+) {
+  return response.status(code === -32601 ? 404 : 400).json({
+    jsonrpc: JSON_RPC_VERSION,
+    id: id ?? null,
+    error: { code, message },
+  })
+}
+
+function isJsonRpcRequest(value: unknown): value is JsonRpcRequest {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Creates a Streamable HTTP-compatible MCP endpoint for an application's
+ * existing Express server.  Authentication is deliberately delegated to the
+ * Keystone context provided by the consuming package.
+ */
+export function createMcpExpressHandler<Context>(
+  options: McpServerOptions<Context>
+): ExpressHandler {
+  const tools = new Map(options.tools.map((tool) => [tool.name, tool]))
+
+  return async (request, response, next) => {
+    try {
+      if (
+        !isJsonRpcRequest(request.body) ||
+        request.body.jsonrpc !== JSON_RPC_VERSION
+      ) {
+        return sendError(response, null, -32600, 'Invalid JSON-RPC request')
+      }
+
+      const rpcRequest = request.body
+      const context = await options.context.withRequest(request, response)
+      if (!(await options.isAuthorized(context, request))) {
+        return response.status(401).json({
+          jsonrpc: JSON_RPC_VERSION,
+          id: rpcRequest.id ?? null,
+          error: { code: -32001, message: 'Authentication required' },
+        })
+      }
+
+      if (rpcRequest.method === 'initialize') {
+        return sendResult(response, rpcRequest.id, {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: { name: options.name, version: options.version },
+        })
+      }
+
+      // MCP clients send this notification after initialize. Notifications do
+      // not receive a JSON-RPC response.
+      if (rpcRequest.method === 'notifications/initialized') {
+        return response.status(202).end()
+      }
+
+      if (rpcRequest.method === 'tools/list') {
+        return sendResult(response, rpcRequest.id, {
+          tools: options.tools.map(({ name, description, inputSchema }) => ({
+            name,
+            description,
+            inputSchema: inputSchema || { type: 'object', properties: {} },
+          })),
+        })
+      }
+
+      if (rpcRequest.method === 'tools/call') {
+        const params = rpcRequest.params
+        if (
+          typeof params !== 'object' ||
+          params === null ||
+          Array.isArray(params)
+        ) {
+          return sendError(
+            response,
+            rpcRequest.id,
+            -32602,
+            'tools/call requires an object params value'
+          )
+        }
+        const { name, arguments: args = {} } = params as {
+          name?: unknown
+          arguments?: unknown
+        }
+        if (typeof name !== 'string' || !tools.has(name)) {
+          return sendError(response, rpcRequest.id, -32602, 'Unknown tool')
+        }
+        if (typeof args !== 'object' || args === null || Array.isArray(args)) {
+          return sendError(
+            response,
+            rpcRequest.id,
+            -32602,
+            'Tool arguments must be an object'
+          )
+        }
+
+        try {
+          const content = await tools
+            .get(name)!
+            .execute(args as Record<string, unknown>, context)
+          return sendResult(response, rpcRequest.id, { content })
+        } catch {
+          // Tool failures are a successful MCP protocol response. This keeps
+          // the transport usable while avoiding accidental disclosure of an
+          // application/database error to the client.
+          return sendResult(response, rpcRequest.id, {
+            content: textContent('The tool could not complete the request.'),
+            isError: true,
+          })
+        }
+      }
+
+      return sendError(
+        response,
+        rpcRequest.id,
+        -32601,
+        `Unsupported method: ${String(rpcRequest.method)}`
+      )
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+export function textContent(text: string): McpTextContent[] {
+  return [{ type: 'text', text }]
+}

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -1,0 +1,8 @@
+export { createMcpExpressHandler, textContent } from './express'
+export type {
+  McpAuthorization,
+  McpServerOptions,
+  McpTextContent,
+  McpTool,
+  RequestContextFactory,
+} from './types'

--- a/packages/core/src/mcp/types.ts
+++ b/packages/core/src/mcp/types.ts
@@ -1,0 +1,66 @@
+/**
+ * The small subset of the Express API used by the MCP adapter.  Keeping this
+ * structural means `lilith-core` does not make every Keystone package depend
+ * on Express just to define MCP tools.
+ */
+export type ExpressRequest = {
+  body?: unknown
+  headers: Record<string, string | string[] | undefined>
+}
+
+export type ExpressResponse = {
+  status: (status: number) => ExpressResponse
+  json: (body: unknown) => unknown
+  end: () => unknown
+}
+
+export type ExpressNext = (error?: unknown) => void
+
+export type ExpressHandler = (
+  request: ExpressRequest,
+  response: ExpressResponse,
+  next: ExpressNext
+) => unknown
+
+export type RequestContextFactory<Context> = {
+  // Keystone's generated context accepts its own concrete Request/Response
+  // types. Method parameters are intentionally bivariant, preserving
+  // compatibility without imposing Express as a dependency of lilith-core.
+  withRequest(
+    request: ExpressRequest,
+    response: ExpressResponse
+  ): Promise<Context>
+}
+
+export type McpTextContent = {
+  type: 'text'
+  text: string
+}
+
+export type McpTool<Context> = {
+  name: string
+  description: string
+  /** JSON Schema accepted by MCP clients. Defaults to an empty object. */
+  inputSchema?: Record<string, unknown>
+  execute: (
+    args: Record<string, unknown>,
+    context: Context
+  ) => Promise<McpTextContent[]> | McpTextContent[]
+}
+
+export type McpAuthorization<Context> = (
+  context: Context,
+  request: ExpressRequest
+) => boolean | Promise<boolean>
+
+export type McpServerOptions<Context> = {
+  name: string
+  version: string
+  context: RequestContextFactory<Context>
+  tools: McpTool<Context>[]
+  /**
+   * Called for every request, after Keystone has restored its package-local
+   * session. This lets each package keep its own authentication model.
+   */
+  isAuthorized: McpAuthorization<Context>
+}

--- a/packages/readr/README.md
+++ b/packages/readr/README.md
@@ -55,6 +55,13 @@ DATABASE_URL=postgres://anotherAccount:anotherPasswd@localhost:5433/anotherDatab
 ### GraphQL playground
 起 lilith-readr CMS 服務後，我們可以透過 [http://localhost:3000/api/graphql](http://localhost:3000/api/graphql) 來使用 GraphQL playground。
 
+### MCP endpoint
+
+READr 也在同一個 Keystone/Express process 提供 MCP Streamable HTTP endpoint：`POST /mcp`。
+它不使用另一組 API key；每個 MCP request 都會由 Keystone 還原既有的 session，因此權限和 Admin UI 相同，且各 list 的 access control 仍由 `context.query` 強制執行。
+
+目前 READr tools 包含 `list_recent_posts`、`get_post`、`get_posts`、`search_posts` 和 `filter_posts`。`filter_posts` 的 category 即 CMS 中的文章 section，可依 category、writer、state、style 組合篩選。要讓其他 package 啟用 MCP，請在它們的 `extendExpressApp` 掛上 `createMcpExpressHandler`，並提供該 package 的 `commonContext`、tools，以及以本身 session 判斷的 `isAuthorized`。
+
 ### Start GraphQL API server only
 我們也可以單獨把 lilith-readr 當作 GraphQL API server 使用。
 透過傳入 `IS_UI_DISABLED` 環境變數，我們可以把 CMS WEB UI 的部分關閉，只留下 GraphQL endpoint `/api/graphql`。

--- a/packages/readr/keystone.ts
+++ b/packages/readr/keystone.ts
@@ -6,6 +6,8 @@ import envVar from './environment-variables'
 import express, { Request, Response, NextFunction } from 'express'
 import { createAuth } from '@keystone-6/auth'
 import { statelessSessions } from '@keystone-6/core/session'
+import { createMcpExpressHandler } from '@mirrormedia/lilith-core'
+import { isReadrMcpAuthorized, readrMcpTools } from './mcp'
 
 const { withAuth } = createAuth({
   listKey: 'User',
@@ -59,15 +61,28 @@ export default withAuth(
       },
     },
     server: {
-	  healthCheck: {
-	    path: '/health_check',
-	    data: { status: 'healthy' },
-	  },
+      healthCheck: {
+        path: '/health_check',
+        data: { status: 'healthy' },
+      },
       extendExpressApp: (app, commonContext) => {
         // This middleware is available in Express v4.16.0 onwards
         // Set to 50mb because DraftJS Editor playload could be really large
         const jsonBodyParser = express.json({ limit: '50mb' })
         app.use(jsonBodyParser)
+
+        // MCP shares this Express process and restores the package's existing
+        // Keystone session for every request; no separate credentials exist.
+        app.post(
+          '/mcp',
+          createMcpExpressHandler({
+            name: 'lilith-readr',
+            version: '0.1.0',
+            context: commonContext,
+            tools: readrMcpTools,
+            isAuthorized: isReadrMcpAuthorized,
+          })
+        )
 
         // Check if the request is sent by an authenticated user
         const authenticationMw = async (

--- a/packages/readr/mcp.ts
+++ b/packages/readr/mcp.ts
@@ -1,0 +1,229 @@
+import { McpTool, textContent } from '@mirrormedia/lilith-core'
+
+type ReadrMcpContext = {
+  session?: { data?: { role?: string } }
+  query: {
+    Post: {
+      findMany: (args: Record<string, unknown>) => Promise<unknown>
+    }
+  }
+}
+
+const POST_SUMMARY_QUERY = `id name slug state publishTime subtitle
+   categories { id slug title } writers { id name }`
+const POST_DETAIL_QUERY = `
+  id slug sortOrder name subtitle state publishTime
+  categories { id slug title } writers { id name name_en title }
+  photographers { id name } cameraOperators { id name } designers { id name }
+  engineers { id name } dataAnalysts { id name } otherByline
+  heroCaption heroImageSize style summary content actionList citation
+  readringTime wordCount readingTime tags { id name }
+  ogTitle ogDescription isFeatured css summaryApiData apiData actionlistApiData
+  citationApiData
+  createdAt updatedAt
+`
+
+function getLimit(value: unknown, defaultLimit = 20) {
+  const requestedLimit = typeof value === 'number' ? value : defaultLimit
+  return Math.max(1, Math.min(100, Math.floor(requestedLimit)))
+}
+
+function getString(value: unknown, name: string, required = false) {
+  if (typeof value === 'string' && value.trim()) return value.trim()
+  if (required) throw new Error(`${name} is required`)
+  return undefined
+}
+
+function result(posts: unknown) {
+  return textContent(JSON.stringify(posts, null, 2))
+}
+
+function singleResult(posts: unknown) {
+  return result(Array.isArray(posts) ? posts[0] || null : posts)
+}
+
+export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
+  {
+    name: 'list_recent_posts',
+    description: 'List recent READr posts that the signed-in user may view.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+      },
+      additionalProperties: false,
+    },
+    async execute(args, context) {
+      return result(
+        await context.query.Post.findMany({
+          take: getLimit(args.limit),
+          orderBy: { publishTime: 'desc' },
+          query: POST_SUMMARY_QUERY,
+        })
+      )
+    },
+  },
+  {
+    name: 'get_post',
+    description:
+      'Get the complete READr article by its Keystone post ID or slug.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        slug: { type: 'string' },
+      },
+      anyOf: [{ required: ['id'] }, { required: ['slug'] }],
+      additionalProperties: false,
+    },
+    async execute(args, context) {
+      const id = getString(args.id, 'id')
+      const slug = getString(args.slug, 'slug')
+      if ((id && slug) || (!id && !slug)) {
+        throw new Error('Provide exactly one of id or slug')
+      }
+
+      return singleResult(
+        await context.query.Post.findMany({
+          take: 1,
+          where: id ? { id: { equals: id } } : { slug: { equals: slug } },
+          query: POST_DETAIL_QUERY,
+        })
+      )
+    },
+  },
+  {
+    name: 'get_posts',
+    description:
+      'Get complete details for up to 100 READr posts by their Keystone IDs.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ids: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 100,
+          items: { type: 'string' },
+        },
+      },
+      required: ['ids'],
+      additionalProperties: false,
+    },
+    async execute(args, context) {
+      if (
+        !Array.isArray(args.ids) ||
+        !args.ids.every((id) => typeof id === 'string')
+      ) {
+        throw new Error('ids must be an array of post IDs')
+      }
+      const ids = args.ids.slice(0, 100)
+      if (ids.length === 0) throw new Error('ids must not be empty')
+
+      return result(
+        await context.query.Post.findMany({
+          take: ids.length,
+          where: { id: { in: ids } },
+          query: POST_DETAIL_QUERY,
+        })
+      )
+    },
+  },
+  {
+    name: 'search_posts',
+    description: 'Search READr post titles, subtitles, and slugs.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', minLength: 1 },
+        limit: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
+    async execute(args, context) {
+      const searchTerm = getString(args.query, 'query', true)
+      return result(
+        await context.query.Post.findMany({
+          take: getLimit(args.limit),
+          orderBy: { publishTime: 'desc' },
+          where: {
+            OR: [
+              { name: { contains: searchTerm, mode: 'insensitive' } },
+              { subtitle: { contains: searchTerm, mode: 'insensitive' } },
+              { slug: { contains: searchTerm, mode: 'insensitive' } },
+            ],
+          },
+          query: POST_SUMMARY_QUERY,
+        })
+      )
+    },
+  },
+  {
+    name: 'filter_posts',
+    description:
+      'Filter READr posts by category (section), writer, state, or style.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        categoryId: { type: 'string', description: 'Keystone Category ID' },
+        categorySlug: { type: 'string' },
+        writerId: { type: 'string', description: 'Keystone Author ID' },
+        writerName: { type: 'string' },
+        state: { type: 'string' },
+        style: { type: 'string' },
+        limit: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+      },
+      additionalProperties: false,
+    },
+    async execute(args, context) {
+      const conditions: Record<string, unknown>[] = []
+      const categoryId = getString(args.categoryId, 'categoryId')
+      const categorySlug = getString(args.categorySlug, 'categorySlug')
+      const writerId = getString(args.writerId, 'writerId')
+      const writerName = getString(args.writerName, 'writerName')
+      const state = getString(args.state, 'state')
+      const style = getString(args.style, 'style')
+
+      if (categoryId) {
+        conditions.push({
+          categories: { some: { id: { equals: categoryId } } },
+        })
+      }
+      if (categorySlug) {
+        conditions.push({
+          categories: { some: { slug: { equals: categorySlug } } },
+        })
+      }
+      if (writerId)
+        conditions.push({ writers: { some: { id: { equals: writerId } } } })
+      if (writerName) {
+        conditions.push({
+          writers: {
+            some: { name: { contains: writerName, mode: 'insensitive' } },
+          },
+        })
+      }
+      if (state) conditions.push({ state: { equals: state } })
+      if (style) conditions.push({ style: { equals: style } })
+      if (conditions.length === 0)
+        throw new Error('Provide at least one filter')
+
+      return result(
+        await context.query.Post.findMany({
+          take: getLimit(args.limit),
+          orderBy: { publishTime: 'desc' },
+          where: { AND: conditions },
+          query: POST_SUMMARY_QUERY,
+        })
+      )
+    },
+  },
+]
+
+/**
+ * READr's MCP auth intentionally uses the same Keystone session and role used
+ * by the Admin UI. List-level access is still enforced by context.query.
+ */
+export function isReadrMcpAuthorized(context: ReadrMcpContext) {
+  return Boolean(context.session?.data?.role)
+}

--- a/packages/readr/package.json
+++ b/packages/readr/package.json
@@ -20,7 +20,7 @@
     "@ioredis/commands": "^1.2.0",
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.2.0",
-    "@mirrormedia/lilith-core": "^3.0.1",
+    "@mirrormedia/lilith-core": "3.1.0-beta.1",
     "express": "^4.17.1",
     "http-proxy-middleware": "^2.0.3",
     "http2-proxy": "^5.0.53",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3292,6 +3292,26 @@
     teeny-request "^9.0.0"
     uuid "^8.0.0"
 
+"@google-cloud/storage@^7.19.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/storage/-/storage-7.21.0.tgz#46b89afbdc3014e18b60afdfba5d9212a23e7b58"
+  integrity sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==
+  dependencies:
+    "@google-cloud/paginator" "^5.0.0"
+    "@google-cloud/projectify" "^4.0.0"
+    "@google-cloud/promisify" "<4.1.0"
+    abort-controller "^3.0.0"
+    async-retry "^1.3.3"
+    duplexify "^4.1.3"
+    fast-xml-parser "^5.3.4"
+    gaxios "^6.0.2"
+    google-auth-library "^9.6.3"
+    html-entities "^2.5.2"
+    mime "^3.0.0"
+    p-limit "^3.0.1"
+    retry-request "^7.0.0"
+    teeny-request "^9.0.0"
+
 "@google-cloud/tasks@^6.2.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@google-cloud/tasks/-/tasks-6.2.1.tgz#2d648ab80b753bfc1304e67f0eee39ea3be0cca5"
@@ -4192,6 +4212,28 @@
     styled-components "5.3.5"
     zlib "^1.0.5"
 
+"@mirrormedia/lilith-core@3.0.11-beta.10":
+  version "3.0.11-beta.10"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-core/-/lilith-core-3.0.11-beta.10.tgz#72eb4306edbcc8b5eb4f1caca5d8a26c8a7d5684"
+  integrity sha512-GKe22AZvtTDhm/Ygh1wT+pXbwTy7+BH8zE9pcDXUwk7mINzdoEFZe/BtBhM8vmGvfY5EcBlEZsFChny+aE3M2g==
+  dependencies:
+    "@google-cloud/storage" "^5.18.0"
+    "@keystone-ui/button" "^7.0.2"
+    "@keystone-ui/fields" "^7.2.0"
+    "@keystone-ui/modals" "^6.0.3"
+    "@mirrormedia/lilith-draft-editor" "^3.0.14"
+    "@mirrormedia/subscription-webhooks-share" "^1.1.1"
+    "@twreporter/errors" "^1.1.1"
+    axios "^0.26.0"
+    draft-convert "^2.1.12"
+    draft-js "^0.11.7"
+    htmlparser2 "^7.2.0"
+    immutable "^4.0.0"
+    lodash "^4.17.21"
+    shortid "^2.2.16"
+    styled-components "5.3.5"
+    zlib "^1.0.5"
+
 "@mirrormedia/lilith-core@^3.0.1":
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-core/-/lilith-core-3.0.10.tgz#d9e5360db6c71a4a1cf91f776e68a4bd45e334cd"
@@ -4326,6 +4368,11 @@
   version "2.1.8-no-fsevents.3"
   resolved "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz"
   integrity sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==
+
+"@nodable/entities@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-3.0.0.tgz#694703bc864d30eaed55c2e3def00dbd61493670"
+  integrity sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -5820,6 +5867,11 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+anynum@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/anynum/-/anynum-1.0.1.tgz#2aac00e08dfad3726c1d462e60dbc2f831659a44"
+  integrity sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==
 
 apollo-upload-client@^17.0.0:
   version "17.0.0"
@@ -7901,6 +7953,14 @@ fast-write-atomic@0.2.1:
   resolved "https://registry.npmjs.org/fast-write-atomic/-/fast-write-atomic-0.2.1.tgz"
   integrity sha512-WvJe06IfNYlr+6cO3uQkdKdy3Cb1LlCJSF8zRs2eT8yuhdbSlR9nIt+TgQ92RUxiRrQm+/S7RARnMfCs5iuAjw==
 
+fast-xml-builder@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz#bc849804796fe47bf915022dd939b0fc30ba455d"
+  integrity sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==
+  dependencies:
+    path-expression-matcher "^1.6.2"
+    xml-naming "^0.3.0"
+
 fast-xml-parser@4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz"
@@ -7921,6 +7981,18 @@ fast-xml-parser@^4.4.1:
   integrity sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==
   dependencies:
     strnum "^1.1.1"
+
+fast-xml-parser@^5.3.4:
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz#19313f7c9386c47fa4a1de527547b73ed2cfcede"
+  integrity sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==
+  dependencies:
+    "@nodable/entities" "^3.0.0"
+    fast-xml-builder "^1.2.0"
+    is-unsafe "^2.0.0"
+    path-expression-matcher "^1.6.2"
+    strnum "^2.4.1"
+    xml-naming "^0.3.0"
 
 fastq@^1.6.0:
   version "1.13.0"
@@ -9319,6 +9391,11 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-unsafe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-2.0.0.tgz#c0dce4e06742662dde26360160e414ea487da2e9"
+  integrity sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==
 
 is-weakref@^1.0.2:
   version "1.0.2"
@@ -11260,6 +11337,11 @@ path-exists@^4.0.0:
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+path-expression-matcher@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz#567c73c07197e9dcef24e90edcdc571056599168"
+  integrity sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
@@ -12805,6 +12887,13 @@ strnum@^1.1.1:
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.1.2.tgz#57bca4fbaa6f271081715dbc9ed7cee5493e28e4"
   integrity sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==
 
+strnum@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.4.1.tgz#85417f683113badea0fe7e17227676f889ff7e58"
+  integrity sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==
+  dependencies:
+    anynum "^1.0.1"
+
 strtok3@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz"
@@ -13738,6 +13827,11 @@ xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
+xml-naming@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.3.0.tgz#46c1e18bfe2858479982dd2accf34d16e749eda2"
+  integrity sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==
 
 xmlcreate@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
Restores b9e86a20 (reverted in 344a7054). Transport ships in published lilith-core 3.1.0-beta.1; readr pins the exact version, all other packages keep their existing pins and are unaffected. Verified locally and on readr-cms-dev via ndx-demo.

## Scope
- `packages/core/src/mcp/`: MCP Streamable HTTP transport (stateless JSON-RPC subset: `initialize`, `tools/list`, `tools/call`), published to npm as `3.1.0-beta.1` (dist-tag `next`; `latest`/`beta` untouched)
- `packages/readr`: `POST /mcp` endpoint with 5 read-only Post tools (`list_recent_posts`, `get_post`, `get_posts`, `search_posts`, `filter_posts`); auth reuses the Keystone session cookie, list-level access control enforced via `context.query`
- readr pins core to exact `3.1.0-beta.1`; the `^3.0.1` yarn.lock entry shared with `packages/advertise` is unchanged

## Isolation
- All other packages pin older core versions and do not mount the handler, so they cannot receive or activate this code
- Cloud Build triggers filter on `packages/<pkg>/**`; merging this PR only affects readr deploys, and staging/prod pick it up on the normal promote flow (prod gated by Cloud Build approval)

## Verification
- Local (fresh DB): 12-case curl matrix passed — 401 without session, malformed JSON-RPC (-32600), unknown method (-32601), unknown tool (-32602), handshake, `tools/list`, all 5 tools, generic `isError` on tool failure with no internal error leakage
- Dev (readr-cms-dev, image `ndx-demo_b6397f5`): unauthenticated 401, full handshake, `tools/list`, real-data `tools/call` all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)