### PR TITLE
feat(mirrormedia): require section and category on published/scheduled posts

### DIFF
--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -73,6 +73,58 @@ type Session = {
   }
 }
 
+// published/scheduled 分類確認邏輯
+type RelCountInput =
+  | {
+      set?: { id: unknown }[]
+      connect?: { id: unknown }[]
+      disconnect?: { id: unknown }[]
+    }
+  | undefined
+
+// 關聯欄位存檔後的最終數量:現有值套用 set/connect/disconnect(不含 nested create)
+function finalRelCount(
+  existing: { id: number | string }[],
+  input: RelCountInput
+): number {
+  if (input?.set) return input.set.length
+  const ids = new Set(existing.map((r) => String(r.id)))
+  for (const c of input?.connect ?? []) ids.add(String(c.id))
+  for (const d of input?.disconnect ?? []) ids.delete(String(d.id))
+  return ids.size
+}
+
+// 存檔後是否同時有大分類與小分類(update 需查 DB 現有值)
+async function willHaveSectionAndCategory(
+  operation: string,
+  item: { id?: string | number | unknown } | undefined,
+  resolvedData: Record<string, any>,
+  context: KeystoneContext
+): Promise<boolean> {
+  let existingSections: { id: number | string }[] = []
+  let existingCategories: { id: number | string }[] = []
+  if (operation === 'update' && item?.id != null) {
+    const existing = await context.prisma.Post.findUnique({
+      where: { id: Number(item.id) },
+      select: {
+        sections: { select: { id: true } },
+        categories: { select: { id: true } },
+      },
+    })
+    existingSections = existing?.sections ?? []
+    existingCategories = existing?.categories ?? []
+  }
+  const sectionCount = finalRelCount(
+    existingSections,
+    resolvedData.sections as RelCountInput
+  )
+  const categoryCount = finalRelCount(
+    existingCategories,
+    resolvedData.categories as RelCountInput
+  )
+  return sectionCount > 0 && categoryCount > 0
+}
+
 function filterPosts(roles: string[]) {
   return ({
     session,
@@ -885,63 +937,19 @@ const listConfigurations = list({
         return
       }
 
-      // published/scheduled 的文章必須至少有一個大分類(Section)與一個小分類(Category)。
-      // 涵蓋 create(主頁新建 + Create related Post 抽屜)與 update(編輯既有文章改狀態)。
+      // 明確選 published/scheduled 才強制要分類;「草稿+未來時間」交給 beforeOperation
       if (operation === 'create' || operation === 'update') {
-        let nextState = resolvedData.state ?? item?.state
-        // 對齊 beforeOperation:publishedDate 是未來 → 稍後會被強制轉成 scheduled,
-        // 所以這裡提前視為 scheduled 檢查,避免「草稿 + 未來發布時間」繞過分類檢查。
-        const pubDate = resolvedData.publishedDate
-        if (pubDate && new Date(pubDate).getTime() > Date.now()) {
-          nextState = 'scheduled'
-        }
+        const nextState = resolvedData.state ?? item?.state
         if (nextState === 'published' || nextState === 'scheduled') {
-          type RelInput =
-            | {
-                set?: { id: unknown }[]
-                connect?: { id: unknown }[]
-                disconnect?: { id: unknown }[]
-              }
-            | undefined
-
-          // 算某個關聯欄位「這次存檔後」的最終數量:從資料庫現有的關聯,套用這次的 set / connect / disconnect(select mode 不會送 nested create)。
-          const finalCount = (
-            existing: { id: number | string }[],
-            input: RelInput
-          ): number => {
-            if (input?.set) return input.set.length
-            const ids = new Set(existing.map((r) => String(r.id)))
-            for (const c of input?.connect ?? []) ids.add(String(c.id))
-            for (const d of input?.disconnect ?? []) ids.delete(String(d.id))
-            return ids.size
-          }
-
-          // create 沒有既有關聯;只有 update 才需要查 DB 現有的 sections/categories。
-          let existingSections: { id: number | string }[] = []
-          let existingCategories: { id: number | string }[] = []
-          if (operation === 'update' && item?.id != null) {
-            const existing = await context.prisma.Post.findUnique({
-              where: { id: Number(item.id) },
-              select: {
-                sections: { select: { id: true } },
-                categories: { select: { id: true } },
-              },
-            })
-            existingSections = existing?.sections ?? []
-            existingCategories = existing?.categories ?? []
-          }
-
-          const sectionCount = finalCount(
-            existingSections,
-            resolvedData.sections as RelInput
+          const ok = await willHaveSectionAndCategory(
+            operation,
+            item,
+            resolvedData,
+            context
           )
-          const categoryCount = finalCount(
-            existingCategories,
-            resolvedData.categories as RelInput
-          )
-          if (sectionCount === 0 || categoryCount === 0) {
+          if (!ok) {
             addValidationError(
-              '已發布／預約發布/已設定發布時間的文章必須至少選擇一個大分類（Section）與一個小分類（Category）'
+              '已發布／預約發布的文章必須至少選擇一個大分類（Section）與一個小分類（Category）'
             )
           }
         }
@@ -1023,20 +1031,45 @@ const listConfigurations = list({
           resolvedData.slug = resolvedData.slug.trim()
           resolvedData.slug = resolvedData.slug.replace(' ', '_')
         }
-        if (resolvedData.publishedDate) {
+        // date 沒被改時 fallback 到 DB, 讓「只補分類、沒動時間」也能觸發轉 scheduled
+        const nextPublishedDate =
+          resolvedData.publishedDate ?? item?.publishedDate
+        if (nextPublishedDate) {
           /* check the publishedDate */
-          if (resolvedData.publishedDate > Date.now()) {
-            resolvedData.state = 'scheduled'
+          if (new Date(nextPublishedDate).getTime() > Date.now()) {
+            // 未來時間→預約發布;archived/invisible 不碰;CMS 缺分類則維持原狀態,系統/API 照舊
+            const nextState = resolvedData.state ?? item?.state
+            const schedulable =
+              nextState === 'draft' ||
+              nextState === 'published' ||
+              nextState === 'scheduled'
+            const isCmsFlow =
+              envVar.accessControlStrategy !== 'gql' && !!context.session
+            if (
+              schedulable &&
+              (!isCmsFlow ||
+                (await willHaveSectionAndCategory(
+                  operation,
+                  item,
+                  resolvedData,
+                  context
+                )))
+            ) {
+              resolvedData.state = 'scheduled'
+            }
           }
           /* end publishedDate check */
-          resolvedData.publishedDateString = new Date(
-            resolvedData.publishedDate
-          ).toLocaleDateString('zh-TW', {
-            timeZone: 'Asia/Taipei',
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-          })
+          // publishedDateString 只在此次真的有改 date 時重算
+          if (resolvedData.publishedDate) {
+            resolvedData.publishedDateString = new Date(
+              resolvedData.publishedDate
+            ).toLocaleDateString('zh-TW', {
+              timeZone: 'Asia/Taipei',
+              year: 'numeric',
+              month: '2-digit',
+              day: '2-digit',
+            })
+          }
           return
         }
       }

--- a/packages/mirrormedia/lists/Post.ts
+++ b/packages/mirrormedia/lists/Post.ts
@@ -272,6 +272,9 @@ const listConfigurations = list({
       ],
       defaultValue: 'draft',
       isIndexed: true,
+      ui: {
+        views: './lists/views/post/state/index',
+      },
     }),
     publishedDate: timestamp({
       isIndexed: true,
@@ -867,7 +870,13 @@ const listConfigurations = list({
     },
   },
   hooks: {
-    validateInput: async ({ operation, item, context, addValidationError }) => {
+    validateInput: async ({
+      operation,
+      resolvedData,
+      item,
+      context,
+      addValidationError,
+    }) => {
       if (envVar.accessControlStrategy === 'gql') {
         return
       }
@@ -875,6 +884,69 @@ const listConfigurations = list({
       if (!context.session) {
         return
       }
+
+      // published/scheduled 的文章必須至少有一個大分類(Section)與一個小分類(Category)。
+      // 涵蓋 create(主頁新建 + Create related Post 抽屜)與 update(編輯既有文章改狀態)。
+      if (operation === 'create' || operation === 'update') {
+        let nextState = resolvedData.state ?? item?.state
+        // 對齊 beforeOperation:publishedDate 是未來 → 稍後會被強制轉成 scheduled,
+        // 所以這裡提前視為 scheduled 檢查,避免「草稿 + 未來發布時間」繞過分類檢查。
+        const pubDate = resolvedData.publishedDate
+        if (pubDate && new Date(pubDate).getTime() > Date.now()) {
+          nextState = 'scheduled'
+        }
+        if (nextState === 'published' || nextState === 'scheduled') {
+          type RelInput =
+            | {
+                set?: { id: unknown }[]
+                connect?: { id: unknown }[]
+                disconnect?: { id: unknown }[]
+              }
+            | undefined
+
+          // 算某個關聯欄位「這次存檔後」的最終數量:從資料庫現有的關聯,套用這次的 set / connect / disconnect(select mode 不會送 nested create)。
+          const finalCount = (
+            existing: { id: number | string }[],
+            input: RelInput
+          ): number => {
+            if (input?.set) return input.set.length
+            const ids = new Set(existing.map((r) => String(r.id)))
+            for (const c of input?.connect ?? []) ids.add(String(c.id))
+            for (const d of input?.disconnect ?? []) ids.delete(String(d.id))
+            return ids.size
+          }
+
+          // create 沒有既有關聯;只有 update 才需要查 DB 現有的 sections/categories。
+          let existingSections: { id: number | string }[] = []
+          let existingCategories: { id: number | string }[] = []
+          if (operation === 'update' && item?.id != null) {
+            const existing = await context.prisma.Post.findUnique({
+              where: { id: Number(item.id) },
+              select: {
+                sections: { select: { id: true } },
+                categories: { select: { id: true } },
+              },
+            })
+            existingSections = existing?.sections ?? []
+            existingCategories = existing?.categories ?? []
+          }
+
+          const sectionCount = finalCount(
+            existingSections,
+            resolvedData.sections as RelInput
+          )
+          const categoryCount = finalCount(
+            existingCategories,
+            resolvedData.categories as RelInput
+          )
+          if (sectionCount === 0 || categoryCount === 0) {
+            addValidationError(
+              '已發布／預約發布/已設定發布時間的文章必須至少選擇一個大分類（Section）與一個小分類（Category）'
+            )
+          }
+        }
+      }
+
       if (context.session.data?.role !== UserRole.Admin) {
         if (operation === 'update') {
           const { lockBy } = await context.prisma.Post.findUnique({

--- a/packages/mirrormedia/lists/views/post/categories/RelationshipSelect.tsx
+++ b/packages/mirrormedia/lists/views/post/categories/RelationshipSelect.tsx
@@ -25,7 +25,8 @@ import {
   useApolloClient,
   useQuery,
 } from '@keystone-6/core/admin-ui/apollo'
-import { sectionsManager } from './sectionsContext'
+import { fieldFilterManager } from '../../shared/fieldFilterManager'
+import { useDialogScope } from '../../shared/useDialogScope'
 
 function useIntersectionObserver(
   cb: IntersectionObserverCallback,
@@ -162,6 +163,7 @@ export const RelationshipSelect = ({
   orderBy: Record<string, any>[]
   currentItemId: string | null
 }) => {
+  const { anchorRef, scopedKey } = useDialogScope()
   const [search, setSearch] = useState('')
   const [loadingIndicatorElement, setLoadingIndicatorElement] =
     useState<null | HTMLElement>(null)
@@ -189,20 +191,21 @@ export const RelationshipSelect = ({
     postData?.post?.sections?.map((s: any) => s.id) || []
   )
 
-  // 當從數據庫查詢到 sections 時，更新 state 並通知 manager
   useEffect(() => {
     if (postData?.post?.sections) {
       const sectionIds = postData.post.sections.map((s: any) => s.id)
       setCurrentSections(sectionIds)
-      sectionsManager.updateSections(sectionIds)
     }
   }, [postData?.post?.sections])
 
   // 訂閱 sections 的變化（來自用戶在表單中的選擇）
   useEffect(() => {
-    const unsubscribe = sectionsManager.subscribe((sectionIds) => {
-      setCurrentSections(sectionIds)
-    })
+    const unsubscribe = fieldFilterManager.subscribe(
+      scopedKey('sections'),
+      (sectionIds) => {
+        setCurrentSections(sectionIds)
+      }
+    )
     return unsubscribe
   }, [])
 
@@ -236,7 +239,7 @@ export const RelationshipSelect = ({
   // 建立完整的 where 條件，包括 sections 過濾
   const where = useMemo(() => {
     const conditions: any = {}
-    
+
     // 如果有搜尋條件，加入搜尋過濾
     if (searchFilter.OR && searchFilter.OR.length > 0) {
       Object.assign(conditions, searchFilter)
@@ -378,14 +381,25 @@ export const RelationshipSelect = ({
     { current: loadingIndicatorElement }
   )
 
+  // anchor 必須在每個 return 分支都 render,useDialogScope 才能在掛載時(不論當下
+  // 落在哪個分支)由它的 DOM 位置解析出正確的 dialog 命名空間。只放在空狀態分支的話,
+  // 若掛載時 sections 已有值(例如 Apollo cache 命中),anchor 不存在 → scope 誤判為 'main'。
+  const scopeAnchor = <span ref={anchorRef} hidden />
+
   if (error) {
-    return <span>Error</span>
+    return (
+      <span>
+        {scopeAnchor}
+        Error
+      </span>
+    )
   }
 
   // 如果沒有選中任何 section，顯示提示訊息
   if (selectedSections.length === 0) {
     return (
       <div style={{ padding: '8px', color: '#666', fontStyle: 'italic' }}>
+        {scopeAnchor}
         請先選擇大分類（Sections），才能選擇小分類（Categories）
       </div>
     )
@@ -394,6 +408,7 @@ export const RelationshipSelect = ({
   if (state.kind === 'one') {
     return (
       <LoadingIndicatorContext.Provider value={loadingIndicatorContextVal}>
+        {scopeAnchor}
         <Select
           onInputChange={(val) => setSearch(val)}
           isLoading={loading || isLoading}
@@ -434,6 +449,7 @@ export const RelationshipSelect = ({
 
   return (
     <LoadingIndicatorContext.Provider value={loadingIndicatorContextVal}>
+      {scopeAnchor}
       <MultiSelect
         onInputChange={(val) => setSearch(val)}
         isLoading={loading || isLoading}
@@ -479,4 +495,3 @@ const relationshipSelectComponents: Partial<typeof selectComponents> = {
     )
   },
 }
-

--- a/packages/mirrormedia/lists/views/post/categories/index.tsx
+++ b/packages/mirrormedia/lists/views/post/categories/index.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 
-import { Fragment, useState, useEffect } from 'react'
+import { Fragment, useState, useEffect, useRef } from 'react'
 
 import { Button } from '@keystone-ui/button'
 // eslint-disable-next-line
@@ -23,12 +23,15 @@ import {
 } from '@keystone-6/core/types'
 import { Link } from '@keystone-6/core/admin-ui/router'
 import { useKeystone, useList } from '@keystone-6/core/admin-ui/context'
+import { gql, useApolloClient } from '@keystone-6/core/admin-ui/apollo'
 import {
   CellContainer,
   CreateItemDrawer,
 } from '@keystone-6/core/admin-ui/components'
 
 import { RelationshipSelect } from './RelationshipSelect'
+import { fieldFilterManager } from '../../shared/fieldFilterManager'
+import { useDialogScope } from '../../shared/useDialogScope'
 
 function LinkToRelatedItems({
   itemId,
@@ -89,12 +92,103 @@ export const Field = ({
   autoFocus,
   value,
   onChange,
-  forceValidation,
 }: FieldProps<typeof controller>) => {
   const keystone = useKeystone()
   const foreignList = useList(field.refListKey)
   const localList = useList(field.listKey)
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const { anchorRef, scopedKey } = useDialogScope()
+
+  // 組件卸載時，移除此 scope 的全域狀態（用 clearField 連 key 一起刪，避免累積殘留）
+  useEffect(() => {
+    return () => {
+      fieldFilterManager.clearField(scopedKey('categories'))
+    }
+  }, [])
+
+  // 當 categories 值改變，把目前選取的 category IDs 存進 fieldFilterManager
+  // 讓 state 欄位的 validate 能判斷「已發布/預約發布時 categories 是否有值」
+  useEffect(() => {
+    if (value.kind === 'many' && Array.isArray(value.value)) {
+      const categoryIds = value.value
+        .map((item: any) => item.id)
+        .filter(Boolean)
+      fieldFilterManager.updateField(scopedKey('categories'), categoryIds)
+    }
+  }, [value])
+
+  // ── 大分類(sections)換掉時，自動移除「不再隸屬於目前大分類」的小分類
+  const apolloClient = useApolloClient()
+  const [selectedSections, setSelectedSections] = useState<string[]>([])
+  useEffect(() => {
+    const unsubscribe = fieldFilterManager.subscribe(
+      scopedKey('sections'),
+      (ids) => {
+        setSelectedSections((prevIds) => {
+          const same =
+            prevIds.length === ids.length &&
+            prevIds.every((id) => ids.includes(id))
+          return same ? prevIds : ids
+        })
+      }
+    )
+    return unsubscribe
+  }, [])
+
+  // 記住「上一次的非空大分類組合」,用來偵測是否有大分類被移除
+  const lastSectionsRef = useRef<string[] | null>(null)
+  useEffect(() => {
+    if (value.kind !== 'many') return
+    if (selectedSections.length === 0) return // 清空 → 保留;不更新 last(維持上一組非空)
+
+    const last = lastSectionsRef.current
+    lastSectionsRef.current = selectedSections
+
+    if (last === null) return
+
+    const removedAny = last.some((id) => !selectedSections.includes(id))
+    if (!removedAny) return
+
+    const selectedCategoryIds = value.value.map((c) => c.id).filter(Boolean)
+    if (selectedCategoryIds.length === 0) return
+
+    let cancelled = false
+    apolloClient
+      .query<{ items: { id: string }[] }>({
+        query: gql`
+          query CategoriesUnderSections($where: ${foreignList.gqlNames.whereInputName}!) {
+            items: ${foreignList.gqlNames.listQueryName}(where: $where) {
+              id
+            }
+          }
+        `,
+        variables: {
+          where: {
+            AND: [
+              { id: { in: selectedCategoryIds } },
+              { sections: { some: { id: { in: selectedSections } } } },
+            ],
+          },
+        },
+        fetchPolicy: 'network-only',
+      })
+      .then(({ data }) => {
+        if (cancelled || value.kind !== 'many') return
+        const validIds = new Set((data?.items ?? []).map((i) => i.id))
+        const kept = value.value.filter((c) => validIds.has(c.id))
+        if (kept.length !== value.value.length) {
+          onChange?.({ ...value, value: kept })
+        }
+      })
+      .catch((err) => {
+        // 查詢失敗就不動(fail-safe:不亂清小分類),但留下線索方便日後查問題
+        console.error('[categories] 檢查小分類是否隸屬大分類的查詢失敗:', err)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [selectedSections])
 
   if (value.kind === 'count') {
     return (
@@ -117,6 +211,7 @@ export const Field = ({
 
   return (
     <FieldContainer as="fieldset">
+      <span ref={anchorRef} hidden />
       <FieldLabel as="legend">{field.label}</FieldLabel>
       <FieldDescription id={`${field.path}-description`}>
         {field.description}
@@ -142,6 +237,11 @@ export const Field = ({
                     kind: 'many',
                     value: value.value,
                     onChange(newItems) {
+                      // 同步更新 fieldFilterManager，確保父元件重新 render 時 validate() 能讀到最新值
+                      fieldFilterManager.updateField(
+                        scopedKey('categories'),
+                        newItems.map((item: any) => item.id).filter(Boolean)
+                      )
                       onChange?.({
                         ...value,
                         value: newItems,
@@ -229,9 +329,14 @@ export const Field = ({
               onCreate={(val) => {
                 setIsDrawerOpen(false)
                 if (value.kind === 'many') {
+                  const newValue = [...value.value, val]
+                  fieldFilterManager.updateField(
+                    scopedKey('categories'),
+                    newValue.map((item: any) => item.id).filter(Boolean)
+                  )
                   onChange({
                     ...value,
-                    value: [...value.value, val],
+                    value: newValue,
                   })
                 } else if (value.kind === 'one') {
                   onChange({
@@ -248,7 +353,7 @@ export const Field = ({
   )
 }
 
-// @ts-ignore
+// @ts-ignore keystone relationship view type
 export const Cell: CellComponent<typeof controller> = ({ field, item }) => {
   const list = useList(field.refListKey)
   const { colors } = useTheme()
@@ -282,11 +387,8 @@ export const Cell: CellComponent<typeof controller> = ({ field, item }) => {
       {displayItems.map((item, index) => (
         <Fragment key={item.id}>
           {index ? ', ' : ''}
-          {/* @ts-ignore */}
-          <Link
-            href={`/${list.path}/${item.id}`}
-            css={styles}
-          >
+          {/* @ts-ignore keystone Link type */}
+          <Link href={`/${list.path}/${item.id}`} css={styles}>
             {item.label || item.id}
           </Link>
         </Fragment>
@@ -296,7 +398,7 @@ export const Cell: CellComponent<typeof controller> = ({ field, item }) => {
   )
 }
 
-// @ts-ignore
+// @ts-ignore keystone relationship view type
 export const CardValue: CardValueComponent<typeof controller> = ({
   field,
   item,
@@ -311,7 +413,7 @@ export const CardValue: CardValueComponent<typeof controller> = ({
         .map((item, index) => (
           <Fragment key={item.id}>
             {index ? ', ' : ''}
-            {/* @ts-ignore */}
+            {/* @ts-ignore keystone Link type */}
             <Link href={`/${list.path}/${item.id}`}>
               {item.label || item.id}
             </Link>
@@ -342,9 +444,7 @@ type CountRelationshipValue = {
 }
 
 type RelationshipController = FieldController<
-  | ManyRelationshipValue
-  | SingleRelationshipValue
-  | CountRelationshipValue,
+  ManyRelationshipValue | SingleRelationshipValue | CountRelationshipValue,
   string
 > & {
   display: 'count' | 'select'
@@ -379,11 +479,6 @@ export const controller = (
   const refLabelField = config.fieldMeta.refLabelField
   const refSearchFields = config.fieldMeta.refSearchFields
 
-  // 檢查是否有 manualOrder 支援（通過檢查 listKey 是否為 Post）
-  // 如果有 manualOrder，使用 InInputOrder；否則使用原始欄位
-  const hasManualOrder = config.listKey === 'Post'
-  const fieldPath = hasManualOrder ? `${config.path}InInputOrder` : config.path
-
   return {
     refFieldKey: config.fieldMeta.refFieldKey,
     many: config.fieldMeta.many,
@@ -391,8 +486,7 @@ export const controller = (
     path: config.path,
     label: config.label,
     description: config.description,
-    display:
-      config.fieldMeta.displayMode === 'count' ? 'count' : 'select',
+    display: config.fieldMeta.displayMode === 'count' ? 'count' : 'select',
     refLabelField,
     refSearchFields,
     refListKey: config.fieldMeta.refListKey,
@@ -421,10 +515,12 @@ export const controller = (
         }
       }
       if (config.fieldMeta.many) {
-        const value = (data[`${config.path}InInputOrder`] || []).map((x: any) => ({
-          id: x.id,
-          label: x.label || x.id,
-        }))
+        const value = (data[`${config.path}InInputOrder`] || []).map(
+          (x: any) => ({
+            id: x.id,
+            label: x.label || x.id,
+          })
+        )
         return {
           kind: 'many',
           id: data.id,
@@ -452,7 +548,7 @@ export const controller = (
       Label: () => '',
       types: {},
     },
-    validate(value) {
+    validate() {
       return true
     },
     serialize: (state) => {
@@ -497,4 +593,3 @@ export const controller = (
     },
   }
 }
-

--- a/packages/mirrormedia/lists/views/post/sections/index.tsx
+++ b/packages/mirrormedia/lists/views/post/sections/index.tsx
@@ -31,7 +31,8 @@ import {
 
 import { Cards } from './cards'
 import { RelationshipSelect } from './RelationshipSelect'
-import { sectionsManager } from '../categories/sectionsContext'
+import { fieldFilterManager } from '../../shared/fieldFilterManager'
+import { useDialogScope } from '../../shared/useDialogScope'
 
 function LinkToRelatedItems({
   itemId,
@@ -98,12 +99,20 @@ export const Field = ({
   const foreignList = useList(field.refListKey)
   const localList = useList(field.listKey)
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const { anchorRef, scopedKey } = useDialogScope()
+
+  // 組件卸載時，移除此 scope 的全域狀態（用 clearField 連 key 一起刪，避免累積殘留）
+  useEffect(() => {
+    return () => {
+      fieldFilterManager.clearField(scopedKey('sections'))
+    }
+  }, [])
 
   // 當 sections 的值變化時，通知 categories
   useEffect(() => {
     if (value.kind === 'many' && Array.isArray(value.value)) {
       const sectionIds = value.value.map((item: any) => item.id).filter(Boolean)
-      sectionsManager.updateSections(sectionIds)
+      fieldFilterManager.updateField(scopedKey('sections'), sectionIds)
     }
   }, [value])
 
@@ -222,6 +231,7 @@ export const Field = ({
 
   return (
     <FieldContainer as="fieldset">
+      <span ref={anchorRef} hidden />
       <FieldLabel as="legend">{field.label}</FieldLabel>
       <FieldDescription id={`${field.path}-description`}>
         {field.description}
@@ -247,6 +257,11 @@ export const Field = ({
                     kind: 'many',
                     value: value.value,
                     onChange(newItems) {
+                      // 同步更新全域狀態，確保 Keystone 的 validate 函式能立刻讀到最新值
+                      fieldFilterManager.updateField(
+                        scopedKey('sections'),
+                        newItems.map((item: any) => item.id).filter(Boolean)
+                      )
                       onChange?.({
                         ...value,
                         value: newItems,
@@ -333,9 +348,15 @@ export const Field = ({
               onCreate={(val) => {
                 setIsDrawerOpen(false)
                 if (value.kind === 'many') {
+                  const newValue = [...value.value, val]
+                  // 同步更新全域狀態，確保新建完 Section 關閉抽屜後，驗證能立刻讀到最新值
+                  fieldFilterManager.updateField(
+                    scopedKey('sections'),
+                    newValue.map((item: any) => item.id).filter(Boolean)
+                  )
                   onChange({
                     ...value,
-                    value: [...value.value, val],
+                    value: newValue,
                   })
                 } else if (value.kind === 'one') {
                   onChange({
@@ -352,7 +373,7 @@ export const Field = ({
   )
 }
 
-// @ts-ignore
+// @ts-ignore keystone relationship view type
 export const Cell: CellComponent<typeof controller> = ({ field, item }) => {
   const list = useList(field.refListKey)
   const { colors } = useTheme()
@@ -386,11 +407,8 @@ export const Cell: CellComponent<typeof controller> = ({ field, item }) => {
       {displayItems.map((item, index) => (
         <Fragment key={item.id}>
           {index ? ', ' : ''}
-          {/* @ts-ignore */}
-          <Link
-            href={`/${list.path}/${item.id}`}
-            css={styles}
-          >
+          {/* @ts-ignore keystone Link type */}
+          <Link href={`/${list.path}/${item.id}`} css={styles}>
             {item.label || item.id}
           </Link>
         </Fragment>
@@ -400,7 +418,7 @@ export const Cell: CellComponent<typeof controller> = ({ field, item }) => {
   )
 }
 
-// @ts-ignore
+// @ts-ignore keystone relationship view type
 export const CardValue: CardValueComponent<typeof controller> = ({
   field,
   item,
@@ -415,7 +433,7 @@ export const CardValue: CardValueComponent<typeof controller> = ({
         .map((item, index) => (
           <Fragment key={item.id}>
             {index ? ', ' : ''}
-            {/* @ts-ignore */}
+            {/* @ts-ignore keystone Link type */}
             <Link href={`/${list.path}/${item.id}`}>
               {item.label || item.id}
             </Link>
@@ -522,11 +540,6 @@ export const controller = (
   const refLabelField = config.fieldMeta.refLabelField
   const refSearchFields = config.fieldMeta.refSearchFields
 
-  // 檢查是否有 manualOrder 支援（通過檢查 listKey 是否為 Post）
-  // 如果有 manualOrder，使用 InInputOrder；否則使用原始欄位
-  const hasManualOrder = config.listKey === 'Post'
-  const fieldPath = hasManualOrder ? `${config.path}InInputOrder` : config.path
-
   return {
     refFieldKey: config.fieldMeta.refFieldKey,
     many: config.fieldMeta.many,
@@ -598,10 +611,12 @@ export const controller = (
         }
       }
       if (config.fieldMeta.many) {
-        const value = (data[`${config.path}InInputOrder`] || []).map((x: any) => ({
-          id: x.id,
-          label: x.label || x.id,
-        }))
+        const value = (data[`${config.path}InInputOrder`] || []).map(
+          (x: any) => ({
+            id: x.id,
+            label: x.label || x.id,
+          })
+        )
         return {
           kind: 'many',
           id: data.id,
@@ -624,8 +639,14 @@ export const controller = (
       }
     },
     filter: {
-      // @ts-ignore
-      Filter: ({ onChange, value }) => {
+      // @ts-ignore keystone filter prop type
+      Filter: ({
+        onChange,
+        value,
+      }: {
+        onChange: (value: string) => void
+        value: string
+      }) => {
         const foreignList = useList(config.fieldMeta.refListKey)
         const { filterValues, loading } = useRelationshipFilterValues({
           value,
@@ -655,7 +676,7 @@ export const controller = (
           />
         )
       },
-      graphql: ({ value }) => {
+      graphql: ({ value }: { value: string }) => {
         const foreignIds = getForeignIds(value)
         if (config.fieldMeta.many) {
           return {
@@ -676,7 +697,7 @@ export const controller = (
           },
         }
       },
-      Label({ value }) {
+      Label({ value }: { value: string }) {
         const foreignList = useList(config.fieldMeta.refListKey)
         const { filterValues } = useRelationshipFilterValues({
           value,

--- a/packages/mirrormedia/lists/views/post/state/index.tsx
+++ b/packages/mirrormedia/lists/views/post/state/index.tsx
@@ -1,0 +1,284 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { useState, useEffect, useRef } from 'react'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { jsx } from '@keystone-ui/core'
+import {
+  FieldContainer,
+  FieldDescription,
+  FieldLabel,
+  Select,
+} from '@keystone-ui/fields'
+import {
+  CardValueComponent,
+  CellComponent,
+  FieldController,
+  FieldControllerConfig,
+  FieldProps,
+} from '@keystone-6/core/types'
+import { CellContainer } from '@keystone-6/core/admin-ui/components'
+import { useList } from '@keystone-6/core/admin-ui/context'
+
+import { fieldFilterManager } from '../../shared/fieldFilterManager'
+import { useDialogScope } from '../../shared/useDialogScope'
+
+type Option = { label: string; value: string }
+type SelectValue = string | null
+
+type SelectController = FieldController<SelectValue, string> & {
+  options: Option[]
+  listKey: string
+}
+
+/**
+ * 核心驗證邏輯 (SSOT)
+ * 判斷是否應該阻擋儲存：state 為已發布/預約發布，且 sections 或 categories 其中一個沒有值
+ */
+function checkBlocked(
+  stateValue: SelectValue,
+  sLen: number,
+  cLen: number
+): boolean {
+  if (stateValue !== 'published' && stateValue !== 'scheduled') return false
+  return sLen === 0 || cLen === 0
+}
+
+export const Field = ({
+  field,
+  value,
+  onChange,
+  forceValidation,
+}: FieldProps<typeof controller>) => {
+  const [showModal, setShowModal] = useState(false)
+  const { anchorRef, scopedKey } = useDialogScope()
+
+  // 頁面底部 toolbar 主按鈕的文字：編輯頁為「Save changes」，新建頁為「Create <單數名>」(例如 Create Post)
+  // 用精準比對，才不會誤攔 cards 欄位的內嵌建立鈕(例如 heroImage 的「Create Photo」)
+  const localList = useList((field as SelectController).listKey)
+  const primaryActionLabelsRef = useRef<string[]>([])
+  primaryActionLabelsRef.current = [
+    'Save changes',
+    `Create ${localList.singular}`,
+  ]
+
+  const [sectionsLen, setSectionsLen] = useState(0)
+  const [categoriesLen, setCategoriesLen] = useState(0)
+
+  useEffect(() => {
+    const unsub1 = fieldFilterManager.subscribe(scopedKey('sections'), (vals) =>
+      setSectionsLen(vals.length)
+    )
+    const unsub2 = fieldFilterManager.subscribe(
+      scopedKey('categories'),
+      (vals) => setCategoriesLen(vals.length)
+    )
+    return () => {
+      unsub1()
+      unsub2()
+    }
+  }, [])
+
+  const isBlocked = checkBlocked(value, sectionsLen, categoriesLen)
+
+  const isBlockedRef = useRef(isBlocked)
+  useEffect(() => {
+    isBlockedRef.current = isBlocked
+  }, [isBlocked])
+
+  useEffect(() => {
+    const handleGlobalClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      const button = target.closest('button')
+
+      if (!button || !isBlockedRef.current) return
+
+      // 避免 deadlock：抽屜 (Drawer/Dialog) 內的建立鈕直接放行，避免擋到「新建關聯項目」
+      if (button.closest('[role="dialog"]')) return
+
+      // 只攔截頁面底部 toolbar 的「儲存/建立」主按鈕
+      const text = button.textContent?.trim() ?? ''
+      if (!primaryActionLabelsRef.current.includes(text)) return
+
+      e.preventDefault()
+      e.stopPropagation()
+      setShowModal(true)
+    }
+
+    document.addEventListener('click', handleGlobalClick, true)
+    return () => document.removeEventListener('click', handleGlobalClick, true)
+  }, [])
+
+  useEffect(() => {
+    if (forceValidation && isBlocked) {
+      setShowModal(true)
+    }
+  }, [forceValidation, isBlocked])
+
+  const options = (field as SelectController).options
+  const selectedOption = options.find((opt) => opt.value === value) ?? null
+
+  return (
+    <FieldContainer>
+      <span ref={anchorRef} hidden />
+      <FieldLabel>{field.label}</FieldLabel>
+      {field.description && (
+        <FieldDescription id={`${field.path}-description`}>
+          {field.description}
+        </FieldDescription>
+      )}
+
+      <Select
+        value={selectedOption}
+        options={options}
+        onChange={(option: Option | null) => onChange?.(option?.value ?? null)}
+        isDisabled={onChange === undefined}
+      />
+
+      {showModal && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 9999,
+          }}
+          onClick={() => setShowModal(false)}
+        >
+          <div
+            style={{
+              background: '#fff',
+              borderRadius: '8px',
+              padding: '36px 40px',
+              maxWidth: '400px',
+              width: '90%',
+              textAlign: 'center',
+              boxShadow: '0 10px 40px rgba(0, 0, 0, 0.2)',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3
+              style={{
+                margin: 0,
+                marginBottom: '16px',
+                color: '#e53e3e',
+                fontSize: '20px',
+                fontWeight: 600,
+              }}
+            >
+              貼心小提醒！
+            </h3>
+            <p
+              style={{
+                fontSize: '16px',
+                color: '#4a5568',
+                marginBottom: '32px',
+                lineHeight: 1.6,
+                marginTop: 0,
+              }}
+            >
+              要記得選大分類和小分類才能送出喔~
+            </p>
+            <button
+              type="button"
+              onClick={() => setShowModal(false)}
+              style={{
+                padding: '10px 32px',
+                backgroundColor: '#3182ce',
+                color: '#fff',
+                border: 'none',
+                borderRadius: '6px',
+                fontSize: '16px',
+                cursor: 'pointer',
+                fontWeight: 600,
+              }}
+            >
+              確認
+            </button>
+          </div>
+        </div>
+      )}
+    </FieldContainer>
+  )
+}
+
+export const Cell: CellComponent<typeof controller> = ({ item, field }) => {
+  const f = field as SelectController
+  const options = f.options
+  const value = item[f.path]
+  const option = options.find((o) => o.value === value)
+  return <CellContainer>{option?.label ?? value ?? ''}</CellContainer>
+}
+
+export const CardValue: CardValueComponent<typeof controller> = ({
+  item,
+  field,
+}) => {
+  const f = field as SelectController
+  const options = f.options
+  const value = item[f.path]
+  const option = options.find((o) => o.value === value)
+  return (
+    <FieldContainer>
+      <FieldLabel>{f.label}</FieldLabel>
+      <div>{option?.label ?? value ?? ''}</div>
+    </FieldContainer>
+  )
+}
+
+export const controller = (
+  config: FieldControllerConfig<{
+    options: Option[]
+    defaultValue: string | null
+  }>
+): SelectController => {
+  return {
+    path: config.path,
+    listKey: config.listKey,
+    label: config.label,
+    description: config.description,
+    graphqlSelection: config.path,
+    options: config.fieldMeta.options,
+    defaultValue: config.fieldMeta.defaultValue ?? null,
+    deserialize: (data) => data[config.path] ?? null,
+    serialize: (value) => ({ [config.path]: value }),
+    // 正確性改由後端 hooks.validateInput 把關(涵蓋主頁 + 抽屜 + API)。
+    // 前端不再用 validate 擋存檔,避免讀全域單例導致抽屜被無聲擋下。
+    validate: () => true,
+    filter: {
+      Filter: ({
+        onChange,
+        value,
+      }: {
+        onChange: (value: string) => void
+        value: string
+      }) => {
+        const options = config.fieldMeta.options
+        const selected = options.find((o) => o.value === value) ?? null
+        return (
+          <Select
+            value={selected}
+            options={options}
+            onChange={(opt: Option | null) => onChange(opt?.value ?? '')}
+          />
+        )
+      },
+      graphql: ({ value }: { value: string }) => ({
+        [config.path]: { equals: value },
+      }),
+      Label: ({ value }: { value: string }) => {
+        const option = config.fieldMeta.options.find((o) => o.value === value)
+        return option?.label ?? value
+      },
+      types: {
+        matches: {
+          label: 'is',
+          initialValue: '',
+        },
+      },
+    },
+  }
+}

--- a/packages/mirrormedia/lists/views/post/state/index.tsx
+++ b/packages/mirrormedia/lists/views/post/state/index.tsx
@@ -135,6 +135,12 @@ export const Field = ({
         isDisabled={onChange === undefined}
       />
 
+      <FieldDescription id={`${field.path}-hint`}>
+        <span style={{ color: '#000' }}>
+          未選擇大分類與小分類的文章將維持草稿，不會依發佈時間自動發佈。
+        </span>
+      </FieldDescription>
+
       {showModal && (
         <div
           style={{

--- a/packages/mirrormedia/lists/views/shared/useDialogScope.ts
+++ b/packages/mirrormedia/lists/views/shared/useDialogScope.ts
@@ -1,0 +1,50 @@
+import { useLayoutEffect, useRef } from 'react'
+
+// 全域遞增計數器,用來給每個「抽屜(Drawer/Dialog)」發一個唯一 id。
+let scopeCounter = 0
+
+/**
+ * 依「欄位最近的那個 [role="dialog"] 元素」決定命名空間。
+ *
+ * 為什麼用「元素身分」而不是「數 dialog 層數」:
+ * Keystone 的抽屜是用 portal 丟到 <body> 底下當兄弟節點,不是一層包一層。
+ * 所以「數層數」會讓兩個(甚至巢狀開啟的)抽屜都算成同一層而互相污染。
+ * 改成「每個 dialog 元素給一個唯一 id」,同一個抽屜裡的欄位會拿到同一個 id、
+ * 不同抽屜(兄弟或巢狀)則各自不同 → 完全隔離。
+ *
+ * 主頁面(沒有 dialog)固定用 'main'。
+ */
+function resolveScope(el: HTMLElement | null): string {
+  const dialog = el?.closest('[role="dialog"]') as HTMLElement | null
+  if (!dialog) return 'main'
+  if (!dialog.dataset.ffScope) {
+    scopeCounter += 1
+    dialog.dataset.ffScope = `dlg${scopeCounter}`
+  }
+  return dialog.dataset.ffScope
+}
+
+/**
+ * 給同一個表單裡的欄位共用的「命名空間」。
+ *
+ * 用法:
+ *   const { anchorRef, scopedKey } = useDialogScope()
+ *   ...把 <span ref={anchorRef} hidden /> 放進欄位的 render 裡...
+ *   fieldFilterManager.updateField(scopedKey('sections'), ids)
+ *
+ * 同一個表單(同一個 dialog 元素,或同為主頁面)的欄位會算出相同 namespace → 彼此看得到;
+ * 不同表單(主頁 vs 抽屜、抽屜 vs 巢狀抽屜)則隔離,不互相污染。
+ */
+export function useDialogScope<T extends HTMLElement = HTMLSpanElement>() {
+  const anchorRef = useRef<T>(null)
+  // 預設 'main';掛載後由 layout effect 依實際 DOM 位置更新。
+  const scopeRef = useRef('main')
+
+  useLayoutEffect(() => {
+    scopeRef.current = resolveScope(anchorRef.current)
+  }, [])
+
+  const scopedKey = (field: string) => `${scopeRef.current}:${field}`
+
+  return { anchorRef, scopedKey }
+}


### PR DESCRIPTION
#### Issues

- 已發布 / 預約發布的文章，必須至少有一個大分類（Section）＋一個小分類（Category）
- 設了「未來發布時間」的文章，只有在有分類時才自動轉為預約發布
- Task: [[後端] CMS 防呆機制](https://app.asana.com/1/614399484723017/project/1217056824510799/task/1216500789448598?focus=true) 

#### Changes

1. 檢查分類
- 後端 Post.ts validateInput
  - create/update 時且狀態為 published/scheduled：檢查存檔是否同時有 section 與 category
  - 用 finalRelCount 依 set/connect/disconnect 計算數量；update 會查 DB 值
- 前端 views/post/state/index.tsx
  - state 自訂 view，訂閱目前 section/category 數量
  - 缺分類但狀態 published/scheduled 會跳出提醒 modal
- 新增 views/shared/useDialogScope.ts
  - 依「最近的 [role="dialog"] 元素」給每個表單命名空間
  - Create Post / Create releated Post中建立的文章欄位狀態互不污染
- views/post/sections、views/post/categories
  - 選取 IDs publish 到 scoped key、unmount 時清除
  - categories：大分類移除時自動清掉不再隸屬的小分類（查詢失敗 fail-safe）

2. 未來時間只在有分類時自動排程
  - 發布時間為未來：CMS 流程只有在有 section+category 時才轉 scheduled；缺分類則維持草稿、不自動發布
  - 系統／API（gql）流程照舊；archived / invisible 不受影響

#### Testing
- 已發布/預約發布 + 缺大小分類 → 主頁跳提醒、後端阻擋
- 補齊 section+category → 可存為 published/scheduled
- 草稿 + 未來時間 + 無分類 → 維持草稿；補上分類 → 轉 scheduled
- 「Create related」抽屜內新建 section/category → 不被主頁存檔邏輯誤擋
- 編輯已發布文章移除分類 → 阻擋

