### PR TITLE
feat(readr): gate MCP endpoint behind IS_MCP_ENABLED flag

### DIFF
--- a/packages/readr/README.md
+++ b/packages/readr/README.md
@@ -58,6 +58,7 @@ DATABASE_URL=postgres://anotherAccount:anotherPasswd@localhost:5433/anotherDatab
 ### MCP endpoint
 
 READr 也在同一個 Keystone/Express process 提供 MCP Streamable HTTP endpoint：`POST /mcp`。
+此 endpoint 預設不啟用：只有在環境變數 `IS_MCP_ENABLED` 設為 `true` 的環境才會掛載，所以把程式碼 promote 到 staging/prod 不會自動開放 MCP。未來其他 package 啟用 MCP 時也沿用相同的 flag 慣例。
 它不使用另一組 API key；每個 MCP request 都會由 Keystone 還原既有的 session，因此權限和 Admin UI 相同，且各 list 的 access control 仍由 `context.query` 強制執行。
 
 目前 READr tools 包含 `list_recent_posts`、`get_post`、`get_posts`、`search_posts` 和 `filter_posts`。`filter_posts` 的 category 即 CMS 中的文章 section，可依 category、writer、state、style 組合篩選。要讓其他 package 啟用 MCP，請在它們的 `extendExpressApp` 掛上 `createMcpExpressHandler`，並提供該 package 的 `commonContext`、tools，以及以本身 session 判斷的 `isAuthorized`。

--- a/packages/readr/environment-variables.ts
+++ b/packages/readr/environment-variables.ts
@@ -1,5 +1,6 @@
 const {
   IS_UI_DISABLED,
+  IS_MCP_ENABLED,
   ACCESS_CONTROL_STRATEGY,
   PREVIEW_SERVER_ORIGIN,
   DATABASE_PROVIDER,
@@ -24,6 +25,9 @@ enum DatabaseProvider {
 
 export default {
   isUIDisabled: IS_UI_DISABLED === 'true',
+  // MCP endpoint is opt-in per environment: unset or any value other than
+  // 'true' keeps the /mcp route unmounted.
+  isMcpEnabled: IS_MCP_ENABLED === 'true',
   memoryCacheTtl: Number.isNaN(Number(MEMORY_CACHE_TTL))
     ? 300_000
     : Number(MEMORY_CACHE_TTL),

--- a/packages/readr/keystone.ts
+++ b/packages/readr/keystone.ts
@@ -73,16 +73,20 @@ export default withAuth(
 
         // MCP shares this Express process and restores the package's existing
         // Keystone session for every request; no separate credentials exist.
-        app.post(
-          '/mcp',
-          createMcpExpressHandler({
-            name: 'lilith-readr',
-            version: '0.1.0',
-            context: commonContext,
-            tools: readrMcpTools,
-            isAuthorized: isReadrMcpAuthorized,
-          })
-        )
+        // Mounted only when IS_MCP_ENABLED=true on the target environment, so
+        // promoting this code to staging/prod does not expose the endpoint.
+        if (envVar.isMcpEnabled) {
+          app.post(
+            '/mcp',
+            createMcpExpressHandler({
+              name: 'lilith-readr',
+              version: '0.1.0',
+              context: commonContext,
+              tools: readrMcpTools,
+              isAuthorized: isReadrMcpAuthorized,
+            })
+          )
+        }
 
         // Check if the request is sent by an authenticated user
         const authenticationMw = async (


### PR DESCRIPTION
Follow-up to #1306. Mounts `POST /mcp` only when the environment sets `IS_MCP_ENABLED=true` (default: off), so the next main→staging→prod promote ships inert code and no environment exposes MCP until its Cloud Run service opts in. Future packages adopting MCP reuse the same flag convention.

Verified locally: flag unset → `POST /mcp` is not mounted (Keystone default 302); flag on → mounted and auth-gated (401 `-32001` without session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)