### PR TITLE
[REVIEW ONLY - DO NOT MERGE] ndx-demo MCP/OAuth delta vs main

### DIFF
--- a/packages/readr/README.md
+++ b/packages/readr/README.md
@@ -57,11 +57,17 @@ DATABASE_URL=postgres://anotherAccount:anotherPasswd@localhost:5433/anotherDatab
 
 ### MCP endpoint
 
-READr 也在同一個 Keystone/Express process 提供 MCP Streamable HTTP endpoint：`POST /mcp`。
-此 endpoint 預設不啟用：只有在環境變數 `IS_MCP_ENABLED` 設為 `true` 的環境才會掛載，所以把程式碼 promote 到 staging/prod 不會自動開放 MCP。未來其他 package 啟用 MCP 時也沿用相同的 flag 慣例。
-它不使用另一組 API key；每個 MCP request 都會由 Keystone 還原既有的 session，因此權限和 Admin UI 相同，且各 list 的 access control 仍由 `context.query` 強制執行。
+READr 在同一個 Keystone/Express process 提供 OAuth 2.0 Authorization Code with PKCE endpoints：`GET /oauth/authorize`、`POST /oauth/token`，以及 MCP Streamable HTTP endpoint：`POST /mcp`。設定 `OAUTH_ISSUER`（公開 HTTPS base URL）與 `OAUTH_SIGNING_SECRET`（至少 32 字元、由 Secret Manager 注入）後才會啟用。
 
-目前 READr tools 包含 `list_recent_posts`、`get_post`、`get_posts`、`search_posts` 和 `filter_posts`。`filter_posts` 的 category 即 CMS 中的文章 section，可依 category、writer、state、style 組合篩選。要讓其他 package 啟用 MCP，請在它們的 `extendExpressApp` 掛上 `createMcpExpressHandler`，並提供該 package 的 `commonContext`、tools，以及以本身 session 判斷的 `isAuthorized`。
+CMS 管理員在 `OAuthClient` list 註冊 public client，設定唯一的 client ID、精確的 redirect URI 白名單及可請求 scope。使用者先登入 CMS，再透過 `/oauth/authorize` 授權；client 以 authorization code 與 S256 PKCE verifier 向 `/oauth/token` 交換 15 分鐘 access token。MCP 每次驗證 token 的簽章、issuer、expiry、scope，並以 token 內的使用者建立 Keystone session，因此 list-level access control 和追蹤欄位仍由原本 CMS 規則執行。
+
+可設定 scope 為 `readr.posts.read`、`readr.posts.write`、`readr.posts.publish`；每個需要的 scope 都要列入 client 的 `allowedScopes` 與 authorization request 的 `scope`。OAuth metadata 位於 `/.well-known/oauth-authorization-server`。目前只支援 public client，因此禁止 client secret，且強制使用 `code_challenge_method=S256`。
+
+支援 Dynamic Client Registration：`POST /oauth/register`。僅接受 public client（`token_endpoint_auth_method: none`）、`authorization_code`、`code` response type，並要求 `redirect_uris` 為 HTTPS 或 localhost HTTP URI；成功回傳 `client_id`。
+
+MCP 的 protected-resource metadata 位於 `/.well-known/oauth-protected-resource/mcp`。部署時將 `MCP_RESOURCE_URL` 設為外部 MCP endpoint 的完整 canonical URL（例如 `https://readr-cms-dev-4g6paft7cq-de.a.run.app/mcp`）；`OAUTH_ISSUER` 則維持 authorization server 的 canonical URL（例如 `https://cms-dev.readr.tw`）。
+
+`convert_to_draftjs` 可將 Google Docs 匯出或複製的 HTML、Markdown 或純文字轉為 Draft.js Raw Content State；支援基本段落、`h1`–`h6` 標題、粗斜體、連結、`ol`／`ul`、圖片、HTML5 影片與 YouTube iframe。轉換結果可直接放入 `create_post` 或 `update_post` 的 `data.content`、`data.summary`、`data.actionList`、`data.citation`。
 
 ### Start GraphQL API server only
 我們也可以單獨把 lilith-readr 當作 GraphQL API server 使用。

--- a/packages/readr/draftjs.ts
+++ b/packages/readr/draftjs.ts
@@ -1,0 +1,209 @@
+import { createHash } from 'crypto'
+
+type InlineStyleRange = { offset: number; length: number; style: string }
+type EntityRange = { offset: number; length: number; key: number }
+type RawBlock = {
+  key: string
+  text: string
+  type: string
+  depth: number
+  inlineStyleRanges: InlineStyleRange[]
+  entityRanges: EntityRange[]
+  data: Record<string, never>
+}
+
+type RawEntity = {
+  type: string
+  mutability: 'MUTABLE' | 'IMMUTABLE'
+  data: Record<string, unknown>
+}
+
+export type RawDraftContentState = {
+  blocks: RawBlock[]
+  entityMap: Record<string, RawEntity>
+}
+
+type BlockInput = { text: string; type?: string; entity?: RawEntity }
+
+function decodeHtml(value: string) {
+  return value
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([\da-f]+);/gi, (_, code) => String.fromCodePoint(parseInt(code, 16)))
+}
+
+function keyFor(index: number, text: string) {
+  return createHash('sha1').update(`${index}:${text}`).digest('hex').slice(0, 8)
+}
+
+function htmlInline(value: string, entityMap: Record<string, RawEntity>) {
+  const textParts: string[] = []
+  const styles = new Map<string, number>()
+  const links: Array<{ offset: number; href: string }> = []
+  const inlineStyleRanges: InlineStyleRange[] = []
+  const entityRanges: EntityRange[] = []
+  const offset = () => textParts.join('').length
+
+  for (const token of value.replace(/<br\s*\/?>/gi, '\n').split(/(<[^>]+>)/g)) {
+    if (!token) continue
+    if (!token.startsWith('<')) {
+      textParts.push(decodeHtml(token.replace(/\s+/g, ' ')))
+      continue
+    }
+    const closing = /^<\//.test(token)
+    const name = token.replace(/^<\/?\s*([^\s/>]+).*$/, '$1').toLowerCase()
+    const style = name === 'strong' || name === 'b' ? 'BOLD' : name === 'em' || name === 'i' ? 'ITALIC' : undefined
+    if (style) {
+      if (closing) {
+        const start = styles.get(style)
+        if (start !== undefined && offset() > start) inlineStyleRanges.push({ offset: start, length: offset() - start, style })
+        styles.delete(style)
+      } else styles.set(style, offset())
+    }
+    if (name === 'a') {
+      if (closing) {
+        const link = links.pop()
+        if (link && offset() > link.offset) {
+          const key = Object.keys(entityMap).length
+          entityMap[String(key)] = { type: 'LINK', mutability: 'MUTABLE', data: { url: link.href } }
+          entityRanges.push({ offset: link.offset, length: offset() - link.offset, key })
+        }
+      } else {
+        const href = /href\s*=\s*["']([^"']+)["']/i.exec(token)?.[1]
+        if (href) links.push({ offset: offset(), href: decodeHtml(href) })
+      }
+    }
+  }
+  return { text: textParts.join('').trim(), inlineStyleRanges, entityRanges }
+}
+
+function markdownBlocks(source: string): BlockInput[] {
+  const blocks: BlockInput[] = []
+  let paragraph: string[] = []
+  const flush = () => {
+    if (paragraph.length) blocks.push({ text: paragraph.join(' ') })
+    paragraph = []
+  }
+  for (const line of source.replace(/\r\n?/g, '\n').split('\n')) {
+    const heading = /^(#{1,6})\s+(.+)$/.exec(line)
+    const unordered = /^[-*+]\s+(.+)$/.exec(line)
+    const ordered = /^\d+[.)]\s+(.+)$/.exec(line)
+    const image = /^!\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)$/.exec(line.trim())
+    if (heading) {
+      flush()
+      blocks.push({ text: heading[2], type: `header-${['one', 'two', 'three', 'four', 'five', 'six'][heading[1].length - 1]}` })
+    }
+    else if (unordered) { flush(); blocks.push({ text: unordered[1], type: 'unordered-list-item' }) }
+    else if (ordered) { flush(); blocks.push({ text: ordered[1], type: 'ordered-list-item' }) }
+    else if (image) {
+      flush()
+      blocks.push({
+        text: ' ',
+        type: 'atomic',
+        entity: { type: 'imageLink', mutability: 'IMMUTABLE', data: { src: image[2], alt: image[1] } },
+      })
+    }
+    else if (!line.trim()) flush()
+    else paragraph.push(line.trim())
+  }
+  flush()
+  return blocks
+}
+
+function htmlBlocks(source: string): BlockInput[] {
+  const blocks: BlockInput[] = []
+  const pattern = /<(h[1-6]|p|div|li|blockquote|img|video|iframe)(\s[^>]*)?(?:>([\s\S]*?)<\/\1>|\s*\/?>)/gi
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(source))) {
+    const tag = match[1].toLowerCase()
+    const attrs = match[2] || ''
+    const body = match[3] || ''
+    const attribute = (name: string) => new RegExp(`${name}\\s*=\\s*["']([^"']+)["']`, 'i').exec(attrs)?.[1]
+    if (tag === 'img') {
+      const src = attribute('src')
+      if (src) blocks.push({ text: ' ', type: 'atomic', entity: { type: 'imageLink', mutability: 'IMMUTABLE', data: { src, alt: attribute('alt') || '' } } })
+      continue
+    }
+    if (tag === 'video') {
+      const src = attribute('src')
+      if (src) blocks.push({ text: ' ', type: 'atomic', entity: { type: 'videoLink', mutability: 'IMMUTABLE', data: { src } } })
+      continue
+    }
+    if (tag === 'iframe') {
+      const src = attribute('src') || ''
+      const youtubeId = /(?:youtube\.com\/embed\/|youtu\.be\/)([\w-]{11})/.exec(src)?.[1]
+      if (youtubeId) blocks.push({ text: ' ', type: 'atomic', entity: { type: 'YOUTUBE', mutability: 'IMMUTABLE', data: { id: youtubeId, description: attribute('title') || '' } } })
+      continue
+    }
+    let type = /^h[1-6]$/.test(tag)
+      ? `header-${['one', 'two', 'three', 'four', 'five', 'six'][Number(tag[1]) - 1]}`
+      : tag === 'blockquote'
+        ? 'blockquote'
+        : 'unstyled'
+    if (tag === 'li') {
+      const before = source.slice(0, match.index)
+      const lastOl = Math.max(before.lastIndexOf('<ol'), before.lastIndexOf('<OL'))
+      const lastUl = Math.max(before.lastIndexOf('<ul'), before.lastIndexOf('<UL'))
+      const lastCloseOl = Math.max(before.lastIndexOf('</ol'), before.lastIndexOf('</OL'))
+      const lastCloseUl = Math.max(before.lastIndexOf('</ul'), before.lastIndexOf('</UL'))
+      type = lastOl > lastCloseOl && lastOl > lastUl && lastOl > lastCloseUl
+        ? 'ordered-list-item'
+        : 'unordered-list-item'
+    }
+    blocks.push({ text: body, type })
+  }
+  return blocks.length ? blocks : [{ text: source.replace(/<[^>]*>/g, ' ') }]
+}
+
+function markdownInline(value: string) {
+  return value
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2">$1</a>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/__([^_]+)__/g, '<strong>$1</strong>')
+    .replace(/\*([^*]+)\*/g, '<em>$1</em>')
+    .replace(/_([^_]+)_/g, '<em>$1</em>')
+}
+
+/** Converts basic HTML (including Google Docs export) or Markdown to Draft.js raw content. */
+export function convertToDraftJs(source: string, format: 'html' | 'markdown' | 'plain_text' = 'html'): RawDraftContentState {
+  const entityMap: Record<string, RawEntity> = {}
+  const inputs = format === 'markdown'
+    ? markdownBlocks(source)
+    : format === 'plain_text'
+      ? source.split(/\n\s*\n/).map((text) => ({ text }))
+      : htmlBlocks(source)
+  const blocks = inputs.map((input, index) => {
+    if (input.entity) {
+      const entityKey = Object.keys(entityMap).length
+      entityMap[String(entityKey)] = input.entity
+      return {
+        key: keyFor(index, input.text),
+        text: ' ',
+        type: 'atomic',
+        depth: 0,
+        inlineStyleRanges: [],
+        entityRanges: [{ offset: 0, length: 1, key: entityKey }],
+        data: {},
+      }
+    }
+    const inline = htmlInline(
+      format === 'markdown' ? markdownInline(input.text) : input.text,
+      entityMap
+    )
+    return {
+      key: keyFor(index, inline.text),
+      text: inline.text,
+      type: input.type || 'unstyled',
+      depth: 0,
+      inlineStyleRanges: inline.inlineStyleRanges,
+      entityRanges: inline.entityRanges,
+      data: {},
+    }
+  }).filter((block) => block.text || block.type !== 'unstyled')
+  return { blocks: blocks.length ? blocks : [{ key: keyFor(0, ''), text: '', type: 'unstyled', depth: 0, inlineStyleRanges: [], entityRanges: [], data: {} }], entityMap }
+}

--- a/packages/readr/environment-variables.ts
+++ b/packages/readr/environment-variables.ts
@@ -1,6 +1,5 @@
 const {
   IS_UI_DISABLED,
-  IS_MCP_ENABLED,
   ACCESS_CONTROL_STRATEGY,
   PREVIEW_SERVER_ORIGIN,
   DATABASE_PROVIDER,
@@ -16,6 +15,10 @@ const {
   MEMORY_CACHE_SIZE,
   GCS_BASE_URL,
   INVALID_CDN_CACHE_SERVER_URL,
+  OAUTH_ISSUER,
+  OAUTH_SIGNING_SECRET,
+  OAUTH_ACCESS_TOKEN_TTL_SECONDS,
+  MCP_RESOURCE_URL,
 } = process.env
 
 enum DatabaseProvider {
@@ -25,9 +28,6 @@ enum DatabaseProvider {
 
 export default {
   isUIDisabled: IS_UI_DISABLED === 'true',
-  // MCP endpoint is opt-in per environment: unset or any value other than
-  // 'true' keeps the /mcp route unmounted.
-  isMcpEnabled: IS_MCP_ENABLED === 'true',
   memoryCacheTtl: Number.isNaN(Number(MEMORY_CACHE_TTL))
     ? 300_000
     : Number(MEMORY_CACHE_TTL),
@@ -64,4 +64,12 @@ export default {
     storagePath: IMAGES_STORAGE_PATH || 'public/images',
   },
   invalidateCDNCacheServerURL: INVALID_CDN_CACHE_SERVER_URL,
+  oauth: {
+    issuer: OAUTH_ISSUER,
+    signingSecret: OAUTH_SIGNING_SECRET,
+    accessTokenTtlSeconds: Number.isNaN(Number(OAUTH_ACCESS_TOKEN_TTL_SECONDS))
+      ? 900
+      : Math.max(60, Number(OAUTH_ACCESS_TOKEN_TTL_SECONDS)),
+    resourceUrl: MCP_RESOURCE_URL,
+  },
 }

--- a/packages/readr/keystone.ts
+++ b/packages/readr/keystone.ts
@@ -6,8 +6,8 @@ import envVar from './environment-variables'
 import express, { Request, Response, NextFunction } from 'express'
 import { createAuth } from '@keystone-6/auth'
 import { statelessSessions } from '@keystone-6/core/session'
-import { createMcpExpressHandler } from '@mirrormedia/lilith-core'
-import { isReadrMcpAuthorized, readrMcpTools } from './mcp'
+import { createReadrMcpHandler } from './mcp'
+import { createOAuthHandlers } from './oauth'
 
 const { withAuth } = createAuth({
   listKey: 'User',
@@ -61,32 +61,29 @@ export default withAuth(
       },
     },
     server: {
-      healthCheck: {
-        path: '/health_check',
-        data: { status: 'healthy' },
-      },
+	  healthCheck: {
+	    path: '/health_check',
+	    data: { status: 'healthy' },
+	  },
       extendExpressApp: (app, commonContext) => {
         // This middleware is available in Express v4.16.0 onwards
         // Set to 50mb because DraftJS Editor playload could be really large
         const jsonBodyParser = express.json({ limit: '50mb' })
         app.use(jsonBodyParser)
+        app.use(express.urlencoded({ extended: false }))
 
-        // MCP shares this Express process and restores the package's existing
-        // Keystone session for every request; no separate credentials exist.
-        // Mounted only when IS_MCP_ENABLED=true on the target environment, so
-        // promoting this code to staging/prod does not expose the endpoint.
-        if (envVar.isMcpEnabled) {
-          app.post(
-            '/mcp',
-            createMcpExpressHandler({
-              name: 'lilith-readr',
-              version: '0.1.0',
-              context: commonContext,
-              tools: readrMcpTools,
-              isAuthorized: isReadrMcpAuthorized,
-            })
-          )
-        }
+        // Keystone's generated context is structurally compatible with the
+        // narrow package-local OAuth/MCP context interfaces.
+        const oauth = createOAuthHandlers(commonContext as any)
+        app.get('/.well-known/oauth-authorization-server', oauth.metadata)
+        app.get(
+          '/.well-known/oauth-protected-resource/mcp',
+          oauth.protectedResourceMetadata
+        )
+        app.post('/oauth/register', oauth.register)
+        app.get('/oauth/authorize', oauth.authorize)
+        app.post('/oauth/token', oauth.token)
+        app.post('/mcp', createReadrMcpHandler(commonContext as any))
 
         // Check if the request is sent by an authenticated user
         const authenticationMw = async (

--- a/packages/readr/lists/OAuthAuthorizationCode.ts
+++ b/packages/readr/lists/OAuthAuthorizationCode.ts
@@ -1,0 +1,29 @@
+// @ts-ignore: no definition
+import { utils } from '@mirrormedia/lilith-core'
+import { list } from '@keystone-6/core'
+import { relationship, text, timestamp } from '@keystone-6/core/fields'
+
+const { allowRoles, admin } = utils.accessControl
+
+/** Internal, short-lived and single-use records for OAuth authorization codes. */
+export default list({
+  fields: {
+    codeHash: text({ validation: { isRequired: true }, isIndexed: 'unique' }),
+    client: relationship({ ref: 'OAuthClient', validation: { isRequired: true } }),
+    user: relationship({ ref: 'User', validation: { isRequired: true } }),
+    redirectUri: text({ validation: { isRequired: true } }),
+    codeChallenge: text({ validation: { isRequired: true } }),
+    scope: text({ validation: { isRequired: true } }),
+    expiresAt: timestamp({ validation: { isRequired: true }, isIndexed: true }),
+    usedAt: timestamp(),
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin),
+      create: allowRoles(admin),
+      update: allowRoles(admin),
+      delete: allowRoles(admin),
+    },
+  },
+  ui: { isHidden: true },
+})

--- a/packages/readr/lists/OAuthClient.ts
+++ b/packages/readr/lists/OAuthClient.ts
@@ -1,0 +1,37 @@
+// @ts-ignore: no definition
+import { utils } from '@mirrormedia/lilith-core'
+import { list } from '@keystone-6/core'
+import { checkbox, json, text } from '@keystone-6/core/fields'
+
+const { allowRoles, admin } = utils.accessControl
+
+/** Public OAuth clients. Redirect URIs are exact-match allowlisted. */
+export default list({
+  fields: {
+    name: text({ validation: { isRequired: true }, label: 'Client name' }),
+    clientId: text({
+      validation: { isRequired: true },
+      isIndexed: 'unique',
+      label: 'OAuth client ID',
+    }),
+    redirectUris: json({
+      validation: { isRequired: true },
+      label: 'Allowed redirect URIs',
+      ui: { description: 'JSON array; each URI must match exactly.' },
+    }),
+    allowedScopes: json({
+      validation: { isRequired: true },
+      defaultValue: ['readr.posts.read'],
+      label: 'Allowed scopes',
+    }),
+    isActive: checkbox({ defaultValue: true, label: 'Active' }),
+  },
+  access: {
+    operation: {
+      query: allowRoles(admin),
+      create: allowRoles(admin),
+      update: allowRoles(admin),
+      delete: allowRoles(admin),
+    },
+  },
+})

--- a/packages/readr/lists/index.ts
+++ b/packages/readr/lists/index.ts
@@ -18,6 +18,8 @@ import ProjectNote from './ProjectNote'
 import NoteCategory from './NoteCategory'
 import Award from './Award'
 import PageVariable from './PageVariable'
+import OAuthClient from './OAuthClient'
+import OAuthAuthorizationCode from './OAuthAuthorizationCode'
 
 export const listDefinition = {
   EditorChoice,
@@ -40,4 +42,6 @@ export const listDefinition = {
   ProjectNote,
   NoteCategory,
   Quote,
+  OAuthClient,
+  OAuthAuthorizationCode,
 }

--- a/packages/readr/mcp.ts
+++ b/packages/readr/mcp.ts
@@ -1,15 +1,55 @@
-import { McpTool, textContent } from '@mirrormedia/lilith-core'
+import type { NextFunction, Request, Response } from 'express'
+import envVar from './environment-variables'
+import { convertToDraftJs } from './draftjs'
+import { CommonContext, verifyAccessToken } from './oauth'
+
+type McpTextContent = { type: 'text'; text: string }
+
+type McpTool<Context> = {
+  name: string
+  description: string
+  inputSchema?: Record<string, unknown>
+  execute: (
+    args: Record<string, unknown>,
+    context: Context
+  ) => Promise<McpTextContent[]> | McpTextContent[]
+}
 
 type ReadrMcpContext = {
   session?: { data?: { role?: string } }
   query: {
     Post: {
       findMany: (args: Record<string, unknown>) => Promise<unknown>
+      createOne: (args: Record<string, unknown>) => Promise<unknown>
+      updateOne: (args: Record<string, unknown>) => Promise<unknown>
+    }
+    User: {
+      findOne: (args: Record<string, unknown>) => Promise<unknown>
+    }
+    OAuthClient: {
+      findOne: (args: Record<string, unknown>) => Promise<unknown>
     }
   }
+  sudo: () => ReadrMcpContext
+  withSession: (session: {
+    itemId: string
+    listKey: 'User'
+    data: { id: string; name: string; role: string }
+  }) => ReadrMcpContext
 }
 
-const POST_SUMMARY_QUERY = `id name slug state publishTime subtitle
+type JsonRpcRequest = {
+  jsonrpc?: unknown
+  id?: string | number | null
+  method?: unknown
+  params?: unknown
+}
+
+const JSON_RPC_VERSION = '2.0'
+const MCP_PROTOCOL_VERSION = '2025-03-26'
+
+const POST_SUMMARY_QUERY =
+  `id name slug state publishTime subtitle
    categories { id slug title } writers { id name }`
 const POST_DETAIL_QUERY = `
   id slug sortOrder name subtitle state publishTime
@@ -34,12 +74,49 @@ function getString(value: unknown, name: string, required = false) {
   return undefined
 }
 
+function textContent(text: string): McpTextContent[] {
+  return [{ type: 'text', text }]
+}
+
 function result(posts: unknown) {
   return textContent(JSON.stringify(posts, null, 2))
 }
 
 function singleResult(posts: unknown) {
   return result(Array.isArray(posts) ? posts[0] || null : posts)
+}
+
+const WRITABLE_POST_FIELDS = new Set([
+  'slug', 'sortOrder', 'name', 'subtitle', 'publishTime', 'categories',
+  'writers', 'photographers', 'cameraOperators', 'designers', 'engineers',
+  'dataAnalysts', 'otherByline', 'leadingEmbeddedCode', 'heroVideo',
+  'heroImage', 'heroCaption', 'heroImageSize', 'style', 'summary', 'content',
+  'actionList', 'citation', 'readringTime', 'projects', 'tags', 'wordCount',
+  'readingTime', 'collabration', 'relatedPosts', 'data', 'ogTitle',
+  'ogDescription', 'ogImage', 'isFeatured', 'note', 'project', 'css',
+])
+
+function getPostData(value: unknown, operation: 'create' | 'update') {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('data must be an object')
+  }
+
+  const data: Record<string, unknown> = {}
+  for (const [key, fieldValue] of Object.entries(value)) {
+    if (!WRITABLE_POST_FIELDS.has(key)) {
+      throw new Error(`${key} cannot be set through MCP`)
+    }
+    data[key] = fieldValue
+  }
+  if (operation === 'create' && !getString(data.name, 'data.name')) {
+    throw new Error('data.name is required')
+  }
+  if (Object.keys(data).length === 0) throw new Error('data must not be empty')
+  return data
+}
+
+function getPostId(value: unknown) {
+  return getString(value, 'id', true)
 }
 
 export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
@@ -65,8 +142,7 @@ export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
   },
   {
     name: 'get_post',
-    description:
-      'Get the complete READr article by its Keystone post ID or slug.',
+    description: 'Get the complete READr article by its Keystone post ID or slug.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -110,10 +186,7 @@ export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
       additionalProperties: false,
     },
     async execute(args, context) {
-      if (
-        !Array.isArray(args.ids) ||
-        !args.ids.every((id) => typeof id === 'string')
-      ) {
+      if (!Array.isArray(args.ids) || !args.ids.every((id) => typeof id === 'string')) {
         throw new Error('ids must be an array of post IDs')
       }
       const ids = args.ids.slice(0, 100)
@@ -160,8 +233,7 @@ export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
   },
   {
     name: 'filter_posts',
-    description:
-      'Filter READr posts by category (section), writer, state, or style.',
+    description: 'Filter READr posts by category (section), writer, state, or style.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -185,28 +257,20 @@ export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
       const style = getString(args.style, 'style')
 
       if (categoryId) {
-        conditions.push({
-          categories: { some: { id: { equals: categoryId } } },
-        })
+        conditions.push({ categories: { some: { id: { equals: categoryId } } } })
       }
       if (categorySlug) {
-        conditions.push({
-          categories: { some: { slug: { equals: categorySlug } } },
-        })
+        conditions.push({ categories: { some: { slug: { equals: categorySlug } } } })
       }
-      if (writerId)
-        conditions.push({ writers: { some: { id: { equals: writerId } } } })
+      if (writerId) conditions.push({ writers: { some: { id: { equals: writerId } } } })
       if (writerName) {
         conditions.push({
-          writers: {
-            some: { name: { contains: writerName, mode: 'insensitive' } },
-          },
+          writers: { some: { name: { contains: writerName, mode: 'insensitive' } } },
         })
       }
       if (state) conditions.push({ state: { equals: state } })
       if (style) conditions.push({ style: { equals: style } })
-      if (conditions.length === 0)
-        throw new Error('Provide at least one filter')
+      if (conditions.length === 0) throw new Error('Provide at least one filter')
 
       return result(
         await context.query.Post.findMany({
@@ -218,12 +282,285 @@ export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
       )
     },
   },
+  {
+    name: 'convert_to_draftjs',
+    description:
+      'Convert Google Docs HTML, Markdown, or plain text into Draft.js Raw Content State for Post content fields. Review the returned JSON, then pass it as data.content, data.summary, data.actionList, or data.citation to create_post or update_post.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source: { type: 'string', description: 'HTML exported or copied from Google Docs, Markdown, or plain text.' },
+        format: {
+          type: 'string',
+          enum: ['html', 'markdown', 'plain_text'],
+          default: 'html',
+        },
+      },
+      required: ['source'],
+      additionalProperties: false,
+    },
+    async execute(args) {
+      const source = getString(args.source, 'source', true)
+      const format = args.format === undefined ? 'html' : args.format
+      if (!['html', 'markdown', 'plain_text'].includes(format as string)) {
+        throw new Error('format must be html, markdown, or plain_text')
+      }
+      return result(convertToDraftJs(source, format as 'html' | 'markdown' | 'plain_text'))
+    },
+  },
+  {
+    name: 'create_post',
+    description:
+      'Create a new READr article as a draft. Use publish_post to publish it after review.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'object',
+          description:
+            'Post fields accepted by the CMS. name is required; relationship fields use Keystone connect syntax.',
+        },
+      },
+      required: ['data'],
+      additionalProperties: false,
+    },
+    async execute(args, context) {
+      const data = getPostData(args.data, 'create')
+      const post = await context.query.Post.createOne({
+        data: { ...data, state: 'draft' },
+        query: POST_DETAIL_QUERY,
+      })
+      return result(post)
+    },
+  },
+  {
+    name: 'update_post',
+    description:
+      'Update editable fields on an existing READr article. This tool cannot change publication state; use publish_post.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Keystone Post ID' },
+        data: {
+          type: 'object',
+          description:
+            'Post fields accepted by the CMS. Relationship fields use Keystone update syntax.',
+        },
+      },
+      required: ['id', 'data'],
+      additionalProperties: false,
+    },
+    async execute(args, context) {
+      const post = await context.query.Post.updateOne({
+        where: { id: getPostId(args.id) },
+        data: getPostData(args.data, 'update'),
+        query: POST_DETAIL_QUERY,
+      })
+      return result(post)
+    },
+  },
+  {
+    name: 'publish_post',
+    description:
+      'Publish an existing READr article now, or schedule it by providing publishTime as an RFC 3339 timestamp.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Keystone Post ID' },
+        publishTime: {
+          type: 'string',
+          format: 'date-time',
+          description: 'Optional RFC 3339 publication time; defaults to now.',
+        },
+      },
+      required: ['id'],
+      additionalProperties: false,
+    },
+    async execute(args, context) {
+      const publishTime = getString(args.publishTime, 'publishTime')
+      if (publishTime && Number.isNaN(Date.parse(publishTime))) {
+        throw new Error('publishTime must be an RFC 3339 timestamp')
+      }
+      const effectivePublishTime = publishTime || new Date().toISOString()
+      const post = await context.query.Post.updateOne({
+        where: { id: getPostId(args.id) },
+        data: {
+          state:
+            new Date(effectivePublishTime).getTime() > Date.now()
+              ? 'scheduled'
+              : 'published',
+          publishTime: effectivePublishTime,
+        },
+        query: POST_DETAIL_QUERY,
+      })
+      return result(post)
+    },
+  },
 ]
 
-/**
- * READr's MCP auth intentionally uses the same Keystone session and role used
- * by the Admin UI. List-level access is still enforced by context.query.
- */
-export function isReadrMcpAuthorized(context: ReadrMcpContext) {
-  return Boolean(context.session?.data?.role)
+function isJsonRpcRequest(value: unknown): value is JsonRpcRequest {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function sendResult(response: Response, id: JsonRpcRequest['id'], result: unknown) {
+  return response.json({ jsonrpc: JSON_RPC_VERSION, id: id ?? null, result })
+}
+
+function sendError(
+  response: Response,
+  id: JsonRpcRequest['id'],
+  code: number,
+  message: string
+) {
+  return response.status(code === -32601 ? 404 : 400).json({
+    jsonrpc: JSON_RPC_VERSION,
+    id: id ?? null,
+    error: { code, message },
+  })
+}
+
+function accessToken(request: Request) {
+  const authorization = request.header('authorization')
+  if (!authorization?.startsWith('Bearer ')) return undefined
+  return authorization.slice('Bearer '.length)
+}
+
+function protectedResourceMetadataUrl(request: Request) {
+  const resourceUrl =
+    envVar.oauth.resourceUrl || `${request.protocol}://${request.get('host')}/mcp`
+  return new URL('/.well-known/oauth-protected-resource/mcp', resourceUrl).toString()
+}
+
+async function getAuthorizedContext(
+  commonContext: CommonContext,
+  request: Request,
+  response: Response
+) {
+  const claims = verifyAccessToken(accessToken(request) || '')
+  if (!claims) return null
+  const context = (await commonContext.withRequest(request, response)) as ReadrMcpContext
+  const client = (await context.sudo().query.OAuthClient.findOne({
+    where: { clientId: claims.aud },
+    query: 'id isActive',
+  })) as { isActive?: boolean } | null
+  if (!client?.isActive) return null
+  const user = (await context.sudo().query.User.findOne({
+    where: { id: claims.sub },
+    query: 'id name role',
+  })) as { id?: string; name?: string; role?: string } | null
+  if (
+    !user?.id ||
+    !user.name ||
+    !['admin', 'moderator', 'editor', 'contributor'].includes(user.role || '')
+  ) return null
+  return context.withSession({
+    itemId: user.id,
+    listKey: 'User',
+    data: {
+      id: user.id,
+      name: user.name,
+      role: user.role!,
+    },
+  })
+}
+
+/** A package-local MCP adapter so lilith-core remains unchanged. */
+export function createReadrMcpHandler(commonContext: CommonContext) {
+  const tools = new Map(readrMcpTools.map((tool) => [tool.name, tool]))
+  const requiredScope: Record<string, string> = {
+    list_recent_posts: 'readr.posts.read',
+    get_post: 'readr.posts.read',
+    get_posts: 'readr.posts.read',
+    search_posts: 'readr.posts.read',
+    filter_posts: 'readr.posts.read',
+    convert_to_draftjs: 'readr.posts.read',
+    create_post: 'readr.posts.write',
+    update_post: 'readr.posts.write',
+    publish_post: 'readr.posts.publish',
+  }
+
+  return async (request: Request, response: Response, next: NextFunction) => {
+    try {
+      if (!isJsonRpcRequest(request.body) || request.body.jsonrpc !== JSON_RPC_VERSION) {
+        return sendError(response, null, -32600, 'Invalid JSON-RPC request')
+      }
+
+      const rpcRequest = request.body
+      const context = await getAuthorizedContext(commonContext, request, response)
+      if (!context) {
+        response.set(
+          'WWW-Authenticate',
+          `Bearer resource_metadata="${protectedResourceMetadataUrl(request)}"`
+        )
+        return response.status(401).json({
+          jsonrpc: JSON_RPC_VERSION,
+          id: rpcRequest.id ?? null,
+          error: { code: -32001, message: 'Authentication required' },
+        })
+      }
+
+      if (rpcRequest.method === 'initialize') {
+        return sendResult(response, rpcRequest.id, {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: { name: 'lilith-readr', version: '0.1.0' },
+        })
+      }
+      if (rpcRequest.method === 'notifications/initialized') {
+        return response.status(202).end()
+      }
+      if (rpcRequest.method === 'tools/list') {
+        return sendResult(response, rpcRequest.id, {
+          tools: readrMcpTools.map(({ name, description, inputSchema }) => ({
+            name,
+            description,
+            inputSchema: inputSchema || { type: 'object', properties: {} },
+          })),
+        })
+      }
+      if (rpcRequest.method !== 'tools/call') {
+        return sendError(
+          response,
+          rpcRequest.id,
+          -32601,
+          `Unsupported method: ${String(rpcRequest.method)}`
+        )
+      }
+
+      const params = rpcRequest.params
+      if (typeof params !== 'object' || params === null || Array.isArray(params)) {
+        return sendError(response, rpcRequest.id, -32602, 'tools/call requires an object params value')
+      }
+      const { name, arguments: args = {} } = params as {
+        name?: unknown
+        arguments?: unknown
+      }
+      if (typeof name !== 'string' || !tools.has(name)) {
+        return sendError(response, rpcRequest.id, -32602, 'Unknown tool')
+      }
+      if (typeof args !== 'object' || args === null || Array.isArray(args)) {
+        return sendError(response, rpcRequest.id, -32602, 'Tool arguments must be an object')
+      }
+
+      const claims = verifyAccessToken(accessToken(request) || '')
+      if (!claims || (requiredScope[name] && !claims.scope.includes(requiredScope[name]))) {
+        return sendResult(response, rpcRequest.id, {
+          content: textContent('The OAuth token does not include the required scope.'),
+          isError: true,
+        })
+      }
+
+      try {
+        const content = await tools.get(name)!.execute(args as Record<string, unknown>, context)
+        return sendResult(response, rpcRequest.id, { content })
+      } catch {
+        return sendResult(response, rpcRequest.id, {
+          content: textContent('The tool could not complete the request.'),
+          isError: true,
+        })
+      }
+    } catch (error) {
+      next(error)
+    }
+  }
 }

--- a/packages/readr/migrations/20260810090000_add_oauth_authorization_server/migration.sql
+++ b/packages/readr/migrations/20260810090000_add_oauth_authorization_server/migration.sql
@@ -1,0 +1,33 @@
+CREATE TABLE "OAuthClient" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL DEFAULT '',
+    "clientId" TEXT NOT NULL DEFAULT '',
+    "redirectUris" JSONB NOT NULL,
+    "allowedScopes" JSONB NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    CONSTRAINT "OAuthClient_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "OAuthAuthorizationCode" (
+    "id" SERIAL NOT NULL,
+    "codeHash" TEXT NOT NULL DEFAULT '',
+    "client" INTEGER NOT NULL,
+    "user" INTEGER NOT NULL,
+    "redirectUri" TEXT NOT NULL DEFAULT '',
+    "codeChallenge" TEXT NOT NULL DEFAULT '',
+    "scope" TEXT NOT NULL DEFAULT '',
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    CONSTRAINT "OAuthAuthorizationCode_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "OAuthClient_clientId_key" ON "OAuthClient"("clientId");
+CREATE UNIQUE INDEX "OAuthAuthorizationCode_codeHash_key" ON "OAuthAuthorizationCode"("codeHash");
+CREATE INDEX "OAuthAuthorizationCode_client_idx" ON "OAuthAuthorizationCode"("client");
+CREATE INDEX "OAuthAuthorizationCode_user_idx" ON "OAuthAuthorizationCode"("user");
+CREATE INDEX "OAuthAuthorizationCode_expiresAt_idx" ON "OAuthAuthorizationCode"("expiresAt");
+
+ALTER TABLE "OAuthAuthorizationCode" ADD CONSTRAINT "OAuthAuthorizationCode_client_fkey"
+  FOREIGN KEY ("client") REFERENCES "OAuthClient"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "OAuthAuthorizationCode" ADD CONSTRAINT "OAuthAuthorizationCode_user_fkey"
+  FOREIGN KEY ("user") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/readr/oauth.ts
+++ b/packages/readr/oauth.ts
@@ -1,0 +1,343 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'crypto'
+import type { NextFunction, Request, Response } from 'express'
+import envVar from './environment-variables'
+
+const CODE_TTL_MS = 5 * 60 * 1000
+const SUPPORTED_SCOPES = new Set([
+  'readr.posts.read',
+  'readr.posts.write',
+  'readr.posts.publish',
+])
+
+type OAuthUser = { id: string; name: string; role: string }
+type OAuthClient = {
+  id: string
+  clientId: string
+  redirectUris: unknown
+  allowedScopes: unknown
+  isActive: boolean
+}
+type OAuthCode = {
+  id: string
+  redirectUri: string
+  codeChallenge: string
+  scope: string
+  expiresAt: string
+  usedAt?: string | null
+  client: OAuthClient
+  user: OAuthUser
+}
+
+type Context = {
+  session?: { itemId?: string; data?: { name?: string; role?: string } }
+  query: Record<string, {
+    findOne?: (args: Record<string, unknown>) => Promise<unknown>
+    createOne?: (args: Record<string, unknown>) => Promise<unknown>
+    updateOne?: (args: Record<string, unknown>) => Promise<unknown>
+  }>
+  sudo: () => Context
+}
+
+export type CommonContext = {
+  withRequest: (request: Request, response: Response) => Promise<Context>
+}
+
+export type AccessTokenClaims = {
+  sub: string
+  name: string
+  role: string
+  scope: string[]
+  aud: string
+  iss: string
+  exp: number
+}
+
+function getSingle(value: unknown) {
+  return typeof value === 'string' && value ? value : undefined
+}
+
+function base64url(value: string | Buffer) {
+  return Buffer.from(value).toString('base64url')
+}
+
+function sha256(value: string) {
+  return createHash('sha256').update(value).digest('base64url')
+}
+
+function hashCode(code: string) {
+  return createHash('sha256').update(code).digest('hex')
+}
+
+function configured() {
+  return Boolean(envVar.oauth.issuer && envVar.oauth.signingSecret)
+}
+
+function oauthError(
+  response: Response,
+  error: string,
+  description: string,
+  status = 400
+) {
+  return response.status(status).json({ error, error_description: description })
+}
+
+function redirectError(redirectUri: string, error: string, state?: string) {
+  const destination = new URL(redirectUri)
+  destination.searchParams.set('error', error)
+  if (state) destination.searchParams.set('state', state)
+  return destination.toString()
+}
+
+function scopes(value: unknown) {
+  if (!Array.isArray(value) || !value.every((scope) => typeof scope === 'string')) return []
+  return value.filter((scope) => SUPPORTED_SCOPES.has(scope))
+}
+
+function stringArray(value: unknown) {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+    ? value
+    : []
+}
+
+function isValidRedirectUri(value: string) {
+  try {
+    const url = new URL(value)
+    if (url.hash) return false
+    // Native OAuth clients commonly use a claimed custom scheme (for example,
+    // `com.example.app:/oauth/callback`) instead of an HTTPS callback.
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      return !['data:', 'file:', 'javascript:'].includes(url.protocol)
+    }
+    return (
+      url.protocol === 'https:' ||
+      (url.protocol === 'http:' &&
+        (url.hostname === 'localhost' || url.hostname === '127.0.0.1'))
+    )
+  } catch {
+    return false
+  }
+}
+
+function signAccessToken(claims: Omit<AccessTokenClaims, 'iss' | 'exp'>) {
+  const now = Math.floor(Date.now() / 1000)
+  const payload: AccessTokenClaims = {
+    ...claims,
+    iss: envVar.oauth.issuer!,
+    exp: now + envVar.oauth.accessTokenTtlSeconds,
+  }
+  const encodedHeader = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const encodedPayload = base64url(JSON.stringify(payload))
+  const signingInput = `${encodedHeader}.${encodedPayload}`
+  const signature = createHmac('sha256', envVar.oauth.signingSecret!)
+    .update(signingInput)
+    .digest('base64url')
+  return `${signingInput}.${signature}`
+}
+
+export function verifyAccessToken(token: string): AccessTokenClaims | null {
+  if (!configured()) return null
+  const parts = token.split('.')
+  if (parts.length !== 3) return null
+  const [encodedHeader, encodedPayload, signature] = parts
+  const expected = createHmac('sha256', envVar.oauth.signingSecret!)
+    .update(`${encodedHeader}.${encodedPayload}`)
+    .digest('base64url')
+  const actualBytes = Buffer.from(signature)
+  const expectedBytes = Buffer.from(expected)
+  if (actualBytes.length !== expectedBytes.length || !timingSafeEqual(actualBytes, expectedBytes)) return null
+
+  try {
+    const header = JSON.parse(Buffer.from(encodedHeader, 'base64url').toString())
+    const claims = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString()) as AccessTokenClaims
+    if (
+      header.alg !== 'HS256' ||
+      header.typ !== 'JWT' ||
+      claims.iss !== envVar.oauth.issuer ||
+      !claims.sub ||
+      !claims.name ||
+      !['admin', 'moderator', 'editor', 'contributor'].includes(claims.role) ||
+      !Array.isArray(claims.scope) ||
+      claims.scope.some((scope) => !SUPPORTED_SCOPES.has(scope)) ||
+      !Number.isInteger(claims.exp) ||
+      claims.exp <= Math.floor(Date.now() / 1000)
+    ) return null
+    return claims
+  } catch {
+    return null
+  }
+}
+
+async function findClient(context: Context, clientId: string) {
+  return (await context.sudo().query.OAuthClient.findOne?.({
+    where: { clientId },
+    query: 'id clientId redirectUris allowedScopes isActive',
+  })) as OAuthClient | null
+}
+
+export function createOAuthHandlers(commonContext: CommonContext) {
+  const metadata = (_request: Request, response: Response) => {
+    if (!configured()) return oauthError(response, 'server_error', 'OAuth is not configured', 503)
+    const issuer = envVar.oauth.issuer!.replace(/\/$/, '')
+    return response.json({
+      issuer,
+      authorization_endpoint: `${issuer}/oauth/authorize`,
+      token_endpoint: `${issuer}/oauth/token`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code'],
+      registration_endpoint: `${issuer}/oauth/register`,
+      code_challenge_methods_supported: ['S256'],
+      token_endpoint_auth_methods_supported: ['none'],
+      scopes_supported: [...SUPPORTED_SCOPES],
+    })
+  }
+  const register = async (request: Request, response: Response, next: NextFunction) => {
+    try {
+      if (!configured()) return oauthError(response, 'server_error', 'OAuth is not configured', 503)
+      const redirectUris = stringArray(request.body?.redirect_uris)
+      const clientName = getSingle(request.body?.client_name) || 'Dynamic OAuth client'
+      const scopeValue = getSingle(request.body?.scope)
+      const requestedScopes = scopeValue
+        ? scopeValue.split(' ').filter(Boolean)
+        : [...SUPPORTED_SCOPES]
+      const tokenEndpointAuthMethod =
+        getSingle(request.body?.token_endpoint_auth_method) || 'none'
+      const grantTypes = stringArray(request.body?.grant_types)
+      const responseTypes = stringArray(request.body?.response_types)
+      if (
+        redirectUris.length === 0 ||
+        redirectUris.some((uri) => !isValidRedirectUri(uri)) ||
+        requestedScopes.length === 0 ||
+        requestedScopes.some((scope) => !SUPPORTED_SCOPES.has(scope)) ||
+        tokenEndpointAuthMethod !== 'none' ||
+        (grantTypes.length > 0 && !grantTypes.includes('authorization_code')) ||
+        (responseTypes.length > 0 && !responseTypes.includes('code'))
+      ) {
+        return oauthError(
+          response,
+          'invalid_client_metadata',
+          'A public client needs valid redirect_uris, supported scopes, authorization_code, and token_endpoint_auth_method=none'
+        )
+      }
+      const clientId = `readr_${randomBytes(24).toString('base64url')}`
+      const context = await commonContext.withRequest(request, response)
+      await context.sudo().query.OAuthClient.createOne?.({
+        data: {
+          name: clientName,
+          clientId,
+          redirectUris,
+          allowedScopes: requestedScopes,
+          isActive: true,
+        },
+      })
+      return response.status(201).json({
+        client_id: clientId,
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        client_name: clientName,
+        redirect_uris: redirectUris,
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+        scope: requestedScopes.join(' '),
+      })
+    } catch (error) { next(error) }
+  }
+  const protectedResourceMetadata = (request: Request, response: Response) => {
+    if (!configured()) return oauthError(response, 'server_error', 'OAuth is not configured', 503)
+    const requestOrigin = `${request.protocol}://${request.get('host')}`
+    const resource = envVar.oauth.resourceUrl || `${requestOrigin}/mcp`
+    return response.json({
+      resource,
+      authorization_servers: [envVar.oauth.issuer!.replace(/\/$/, '')],
+      scopes_supported: [...SUPPORTED_SCOPES],
+      bearer_methods_supported: ['header'],
+      resource_name: 'READr CMS MCP',
+    })
+  }
+  const authorize = async (request: Request, response: Response, next: NextFunction) => {
+    try {
+      if (!configured()) return oauthError(response, 'server_error', 'OAuth is not configured', 503)
+      const clientId = getSingle(request.query.client_id)
+      const redirectUri = getSingle(request.query.redirect_uri)
+      const responseType = getSingle(request.query.response_type)
+      const challenge = getSingle(request.query.code_challenge)
+      const method = getSingle(request.query.code_challenge_method)
+      const state = getSingle(request.query.state)
+      const requestedScopes = (getSingle(request.query.scope) || 'readr.posts.read').split(' ')
+      if (!clientId || !redirectUri || responseType !== 'code' || !challenge || method !== 'S256') {
+        return oauthError(response, 'invalid_request', 'client_id, redirect_uri, response_type=code, and S256 PKCE are required')
+      }
+      const context = await commonContext.withRequest(request, response)
+      const client = await findClient(context, clientId)
+      if (!client?.isActive || !stringArray(client.redirectUris).includes(redirectUri)) {
+        return oauthError(response, 'invalid_request', 'Unknown client or redirect URI')
+      }
+      const allowedScopes = scopes(client.allowedScopes)
+      if (!requestedScopes.length || requestedScopes.some((scope) => !allowedScopes.includes(scope))) {
+        return response.redirect(redirectError(redirectUri, 'invalid_scope', state))
+      }
+      const userId = context.session?.itemId
+      if (!userId || !context.session?.data?.role || !context.session.data.name) {
+        return oauthError(response, 'login_required', 'Sign in to READr CMS, then retry the authorization request', 401)
+      }
+      const user = (await context.sudo().query.User.findOne?.({
+        where: { id: userId },
+        query: 'id name role',
+      })) as OAuthUser | null
+      if (!user || !['admin', 'moderator', 'editor'].includes(user.role)) {
+        return response.redirect(redirectError(redirectUri, 'access_denied', state))
+      }
+      const code = randomBytes(32).toString('base64url')
+      await context.sudo().query.OAuthAuthorizationCode.createOne?.({
+        data: {
+          codeHash: hashCode(code),
+          client: { connect: { id: client.id } },
+          user: { connect: { id: user.id } },
+          redirectUri,
+          codeChallenge: challenge,
+          scope: requestedScopes.join(' '),
+          expiresAt: new Date(Date.now() + CODE_TTL_MS).toISOString(),
+        },
+      })
+      const destination = new URL(redirectUri)
+      destination.searchParams.set('code', code)
+      if (state) destination.searchParams.set('state', state)
+      return response.redirect(destination.toString())
+    } catch (error) { next(error) }
+  }
+
+  const token = async (request: Request, response: Response, next: NextFunction) => {
+    try {
+      if (!configured()) return oauthError(response, 'server_error', 'OAuth is not configured', 503)
+      const grantType = getSingle(request.body?.grant_type)
+      const code = getSingle(request.body?.code)
+      const verifier = getSingle(request.body?.code_verifier)
+      const clientId = getSingle(request.body?.client_id)
+      const redirectUri = getSingle(request.body?.redirect_uri)
+      if (grantType !== 'authorization_code' || !code || !verifier || !clientId || !redirectUri) {
+        return oauthError(response, 'invalid_request', 'authorization_code grant with code, verifier, client_id and redirect_uri is required')
+      }
+      const context = await commonContext.withRequest(request, response)
+      const record = (await context.sudo().query.OAuthAuthorizationCode.findOne?.({
+        where: { codeHash: hashCode(code) },
+        query: 'id redirectUri codeChallenge scope expiresAt usedAt client { id clientId redirectUris allowedScopes isActive } user { id name role }',
+      })) as OAuthCode | null
+      if (!record || record.usedAt || !record.client.isActive || record.client.clientId !== clientId || record.redirectUri !== redirectUri || new Date(record.expiresAt).getTime() <= Date.now() || sha256(verifier) !== record.codeChallenge) {
+        return oauthError(response, 'invalid_grant', 'Authorization code is invalid, expired, or already used')
+      }
+      await context.sudo().query.OAuthAuthorizationCode.updateOne?.({
+        where: { id: record.id },
+        data: { usedAt: new Date().toISOString() },
+      })
+      const scope = record.scope.split(' ').filter((value) => SUPPORTED_SCOPES.has(value))
+      const accessToken = signAccessToken({
+        sub: record.user.id,
+        name: record.user.name,
+        role: record.user.role,
+        scope,
+        aud: record.client.clientId,
+      })
+      return response.json({ access_token: accessToken, token_type: 'Bearer', expires_in: envVar.oauth.accessTokenTtlSeconds, scope: scope.join(' ') })
+    } catch (error) { next(error) }
+  }
+  return { metadata, protectedResourceMetadata, register, authorize, token }
+}

--- a/packages/readr/schema.prisma
+++ b/packages/readr/schema.prisma
@@ -317,6 +317,35 @@ model User {
   from_NoteCategory_updatedBy     NoteCategory[]     @relation("NoteCategory_updatedBy")
   from_Quote_createdBy            Quote[]            @relation("Quote_createdBy")
   from_Quote_updatedBy            Quote[]            @relation("Quote_updatedBy")
+  from_OAuthAuthorizationCode_user OAuthAuthorizationCode[] @relation("OAuthAuthorizationCode_user")
+}
+
+model OAuthClient {
+  id            Int                      @id @default(autoincrement())
+  name          String                   @default("")
+  clientId      String                   @unique @default("")
+  redirectUris  Json
+  allowedScopes Json
+  isActive      Boolean                  @default(true)
+  authorizationCodes OAuthAuthorizationCode[] @relation("OAuthAuthorizationCode_client")
+}
+
+model OAuthAuthorizationCode {
+  id            Int         @id @default(autoincrement())
+  codeHash      String      @unique @default("")
+  client        OAuthClient @relation("OAuthAuthorizationCode_client", fields: [clientId], references: [id])
+  clientId      Int         @map("client")
+  user          User        @relation("OAuthAuthorizationCode_user", fields: [userId], references: [id])
+  userId        Int         @map("user")
+  redirectUri   String      @default("")
+  codeChallenge String      @default("")
+  scope         String      @default("")
+  expiresAt     DateTime
+  usedAt        DateTime?
+
+  @@index([clientId])
+  @@index([userId])
+  @@index([expiresAt])
 }
 
 model Post {


### PR DESCRIPTION
Read-only visualization of what hcchien's MCP work on `ndx-demo` adds/changes relative to current main (post #1306 + #1308). Opened as a draft purely so the delta can be reviewed file-by-file; **do not merge** — integration should re-target the core transport and keep the IS_MCP_ENABLED flag (both are removed in this snapshot because ndx-demo predates them).

## Included (hcchien's work, byte-faithful from ndx-demo tip 0a3ed8f6)
- `oauth.ts` (343 lines): OAuth 2.0 Authorization Code + PKCE (S256 enforced), public clients only, 15-min signed access tokens, scopes `readr.posts.read|write|publish`, RFC 8414 AS metadata, RFC 9728 protected-resource metadata, RFC 7591 dynamic client registration
- `lists/OAuthClient.ts`, `lists/OAuthAuthorizationCode.ts` + `lists/index.ts` registration + `schema.prisma` models + migration
- `mcp.ts`: self-contained MCP handler (replaces the core-transport mount) with read + write tools; per-request token verification builds a Keystone session for the token's user, so list-level access control still applies
- `draftjs.ts` + `convert_to_draftjs` tool: HTML/Markdown/plain text → Draft.js Raw Content State for `create_post`/`update_post`
- `environment-variables.ts`: `OAUTH_ISSUER`, `OAUTH_SIGNING_SECRET`, `OAUTH_ACCESS_TOKEN_TTL_SECONDS`, `MCP_RESOURCE_URL` (OAuth only activates when issuer+secret are set)
- `keystone.ts`, `README.md`: his versions (note: they drop the `IS_MCP_ENABLED` gate and core-transport mount from main — visible as deletions in this diff)

## Excluded (demo-only, dies with ndx-demo)
- `lists/Post.ts` recommendedTitle/recommendedPoll fields, their two migrations, and `schema.graphql` (generated)

## Integration decisions to align with HC (not resolved by this PR)
1. Transport: port his OAuth verification + tools onto `createMcpExpressHandler` (core) instead of the self-contained handler
2. Keep the `IS_MCP_ENABLED` flag alongside his OAUTH_* activation gates
3. Write/publish tools reach prod via a separately reviewed PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)