### PR TITLE
feat(mirrormedia): add categories field to custom post creation page

### DIFF
--- a/packages/mirrormedia/admin/pages/custom-post-creation/index.tsx
+++ b/packages/mirrormedia/admin/pages/custom-post-creation/index.tsx
@@ -29,6 +29,7 @@ const PICKED_FIELDS = [
   'slug',
   'title',
   'sections',
+  'categories',
   'writers',
   'content',
   'heroImage',


### PR DESCRIPTION
#### Issue
- 自訂建立文章頁（custom-post-creation）目前只有大分類、缺小分類，要仿照一般 Post 一樣可選小分類，以符合現行防呆機制
- Task: [Create Post + 新增Category 跟防呆機制](https://app.asana.com/1/614399484723017/inbox/1211621121118901/item/1217401536552822/story/1217412996686128?focus=true)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217401536552822