### PR TITLE
feat(readr): add MCP image uploads

### DIFF
--- a/packages/readr/README.md
+++ b/packages/readr/README.md
@@ -67,7 +67,7 @@ OAuth metadata 位於 `/.well-known/oauth-authorization-server`；MCP 的 protec
 
 Tools 與所需 scope：`list_recent_posts`、`get_post`、`get_posts`、`search_posts`、`filter_posts`、`convert_to_draftjs` 需要 `readr.posts.read`；`upload_image`、`create_post`、`update_post` 需要 `readr.posts.write`；`publish_post` 需要 `readr.posts.publish`。session cookie 登入者不受 scope 限制（scope 用來限縮第三方 OAuth client，不限縮使用者本人）。`convert_to_draftjs` 可將 Google Docs 匯出或複製的 HTML、Markdown 或純文字轉為 Draft.js Raw Content State，轉換結果可放入 `create_post` / `update_post` 的 `data.content`、`data.summary`、`data.actionList`、`data.citation`。
 
-`upload_image` 接受 JPEG、PNG、WebP 或 GIF 的 base64 字串（或 `data:image/...;base64,...` data URL），解碼後最大 10 MiB。它會以目前 OAuth/CMS 使用者身分建立 `Photo`，並把檔案交給 Keystone 的 `imageFile` storage；因此既有的 CMS 權限、GCS Fuse 寫入和後續 resize trigger 都會沿用。Cloud Run 環境必須把 `IMAGES_STORAGE_PATH` 設為 GCS Fuse 的圖片目錄（目前 container mount 為 `/app/gcs`，應設定為 `/app/gcs/images`），否則原檔會被寫入 ephemeral container filesystem。
+`upload_image` 接受 JPEG、PNG、WebP 或 GIF 的 base64 字串（或 `data:image/...;base64,...` data URL），解碼後最大 10 MiB；base64 中常見的換行、空白和省略 padding 皆可接受。它會以目前 OAuth/CMS 使用者身分建立 `Photo`，並把檔案交給 Keystone 的 `imageFile` storage；因此既有的 CMS 權限、GCS Fuse 寫入和後續 resize trigger 都會沿用。原圖在寫入成功後即可使用；`resized`／`resizedWebp` URL 則由非同步 resize pipeline 產生，完成前可能回傳 404。Cloud Run 環境必須把 `IMAGES_STORAGE_PATH` 設為 GCS Fuse 的圖片目錄（目前 container mount 為 `/app/gcs`，應設定為 `/app/gcs/images`），否則原檔會被寫入 ephemeral container filesystem。
 
 要讓其他 package 啟用 MCP，請在它們的 `extendExpressApp` 以自己的 `IS_MCP_ENABLED` flag 包住 `createMcpExpressHandler`，並提供該 package 的 context factory、tools 與 `isAuthorized`；transport 一律使用 `@mirrormedia/lilith-mcp` 的實作（獨立小套件、零依賴，不需要動該 package 的 `lilith-core` 版本）。
 

--- a/packages/readr/README.md
+++ b/packages/readr/README.md
@@ -65,7 +65,9 @@ READr 同時提供 OAuth 2.0 Authorization Code with PKCE endpoints：`GET /oaut
 
 OAuth metadata 位於 `/.well-known/oauth-authorization-server`；MCP 的 protected-resource metadata 位於 `/.well-known/oauth-protected-resource/mcp`。部署時將 `MCP_RESOURCE_URL` 設為外部 MCP endpoint 的完整 canonical URL，`OAUTH_ISSUER` 維持 authorization server 的 canonical URL。
 
-Tools 與所需 scope：`list_recent_posts`、`get_post`、`get_posts`、`search_posts`、`filter_posts`、`convert_to_draftjs` 需要 `readr.posts.read`；`create_post`、`update_post` 需要 `readr.posts.write`；`publish_post` 需要 `readr.posts.publish`。session cookie 登入者不受 scope 限制（scope 用來限縮第三方 OAuth client，不限縮使用者本人）。`convert_to_draftjs` 可將 Google Docs 匯出或複製的 HTML、Markdown 或純文字轉為 Draft.js Raw Content State，轉換結果可放入 `create_post` / `update_post` 的 `data.content`、`data.summary`、`data.actionList`、`data.citation`。
+Tools 與所需 scope：`list_recent_posts`、`get_post`、`get_posts`、`search_posts`、`filter_posts`、`convert_to_draftjs` 需要 `readr.posts.read`；`upload_image`、`create_post`、`update_post` 需要 `readr.posts.write`；`publish_post` 需要 `readr.posts.publish`。session cookie 登入者不受 scope 限制（scope 用來限縮第三方 OAuth client，不限縮使用者本人）。`convert_to_draftjs` 可將 Google Docs 匯出或複製的 HTML、Markdown 或純文字轉為 Draft.js Raw Content State，轉換結果可放入 `create_post` / `update_post` 的 `data.content`、`data.summary`、`data.actionList`、`data.citation`。
+
+`upload_image` 接受 JPEG、PNG、WebP 或 GIF 的 base64 字串（或 `data:image/...;base64,...` data URL），解碼後最大 10 MiB。它會以目前 OAuth/CMS 使用者身分建立 `Photo`，並把檔案交給 Keystone 的 `imageFile` storage；因此既有的 CMS 權限、GCS Fuse 寫入和後續 resize trigger 都會沿用。Cloud Run 環境必須把 `IMAGES_STORAGE_PATH` 設為 GCS Fuse 的圖片目錄（目前 container mount 為 `/app/gcs`，應設定為 `/app/gcs/images`），否則原檔會被寫入 ephemeral container filesystem。
 
 要讓其他 package 啟用 MCP，請在它們的 `extendExpressApp` 以自己的 `IS_MCP_ENABLED` flag 包住 `createMcpExpressHandler`，並提供該 package 的 context factory、tools 與 `isAuthorized`；transport 一律使用 `@mirrormedia/lilith-mcp` 的實作（獨立小套件、零依賴，不需要動該 package 的 `lilith-core` 版本）。
 

--- a/packages/readr/mcp.ts
+++ b/packages/readr/mcp.ts
@@ -4,6 +4,7 @@ import {
   RequestContextFactory,
   textContent,
 } from '@mirrormedia/lilith-mcp'
+import { Readable } from 'stream'
 import envVar from './environment-variables'
 import { convertToDraftJs } from './draftjs'
 import { AccessTokenClaims, CommonContext, verifyAccessToken } from './oauth'
@@ -15,6 +16,9 @@ type ReadrMcpContext = {
       findMany: (args: Record<string, unknown>) => Promise<unknown>
       createOne: (args: Record<string, unknown>) => Promise<unknown>
       updateOne: (args: Record<string, unknown>) => Promise<unknown>
+    }
+    Photo: {
+      createOne: (args: Record<string, unknown>) => Promise<unknown>
     }
     User: {
       findOne: (args: Record<string, unknown>) => Promise<unknown>
@@ -48,6 +52,18 @@ const POST_DETAIL_QUERY = `
   citationApiData
   createdAt updatedAt
 `
+const PHOTO_DETAIL_QUERY = `
+  id name
+  imageFile { id url filesize width height extension }
+  resized { original w480 w800 w1200 w1600 w2400 }
+  resizedWebp { original w480 w800 w1200 w1600 w2400 }
+`
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+type SupportedImage = {
+  mimeType: 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif'
+  extension: 'jpg' | 'png' | 'webp' | 'gif'
+}
 
 // Scopes granted by the OAuth token that produced a context. Cookie-session
 // (Admin UI) callers have no entry here: they keep their full CMS permissions,
@@ -149,6 +165,67 @@ function getPostData(value: unknown, operation: 'create' | 'update') {
 
 function getPostId(value: unknown) {
   return getString(value, 'id', true)
+}
+
+function imageType(bytes: Buffer): SupportedImage | undefined {
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return { mimeType: 'image/jpeg', extension: 'jpg' }
+  }
+  if (
+    bytes.length >= 8 &&
+    bytes.subarray(0, 8).equals(Buffer.from('\x89PNG\r\n\x1a\n'))
+  ) {
+    return { mimeType: 'image/png', extension: 'png' }
+  }
+  if (bytes.length >= 6 && /^GIF8[79]a$/.test(bytes.subarray(0, 6).toString())) {
+    return { mimeType: 'image/gif', extension: 'gif' }
+  }
+  if (
+    bytes.length >= 12 &&
+    bytes.subarray(0, 4).equals(Buffer.from('RIFF')) &&
+    bytes.subarray(8, 12).equals(Buffer.from('WEBP'))
+  ) {
+    return { mimeType: 'image/webp', extension: 'webp' }
+  }
+}
+
+function imageUpload(value: unknown, mimeType: unknown) {
+  const valueString = getString(value, 'image', true)
+  const dataUrl = /^data:([^;,]+);base64,([a-z0-9+/=]+)$/i.exec(valueString)
+  const encoded = dataUrl ? dataUrl[2] : valueString
+  if (!dataUrl && !/^[a-z0-9+/=]+$/i.test(encoded)) {
+    throw new McpToolError('image must be a base64 string or image data URL.')
+  }
+
+  const bytes = Buffer.from(encoded, 'base64')
+  if (bytes.length === 0 || bytes.toString('base64') !== encoded) {
+    throw new McpToolError('image must contain valid base64-encoded image data.')
+  }
+  if (bytes.length > MAX_IMAGE_BYTES) {
+    throw new McpToolError('image must not exceed 10 MiB.')
+  }
+
+  const detected = imageType(bytes)
+  if (!detected) {
+    throw new McpToolError('Only JPEG, PNG, WebP, and GIF images are supported.')
+  }
+  const suppliedMimeType = dataUrl?.[1] || getString(mimeType, 'mimeType')
+  if (suppliedMimeType && suppliedMimeType.toLowerCase() !== detected.mimeType) {
+    throw new McpToolError('mimeType does not match the uploaded image.')
+  }
+  return { bytes, ...detected }
+}
+
+function imageFilename(value: unknown, extension: SupportedImage['extension']) {
+  const supplied = getString(value, 'filename')
+  const safe = supplied?.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 180)
+  const stem = (safe || 'image').replace(/\.[^.]+$/, '') || 'image'
+  return `${stem}.${extension}`
 }
 
 export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
@@ -363,6 +440,61 @@ export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
       return result(
         convertToDraftJs(source, format as 'html' | 'markdown' | 'plain_text')
       )
+    },
+  },
+  {
+    name: 'upload_image',
+    description:
+      'Upload a JPEG, PNG, WebP, or GIF to the READr CMS photo library. Supply base64 image data (or a data URL), then use the returned image URLs or photo ID in an article. The CMS storage backend writes the original file and triggers its normal resize pipeline.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        image: {
+          type: 'string',
+          description:
+            'Base64-encoded image data, optionally as a data URL. Maximum decoded size: 10 MiB.',
+        },
+        filename: {
+          type: 'string',
+          description: 'Optional source filename. Its extension is replaced with the detected image type.',
+        },
+        mimeType: {
+          type: 'string',
+          enum: ['image/jpeg', 'image/png', 'image/webp', 'image/gif'],
+          description:
+            'Required when image is raw base64; omit when image is a data URL.',
+        },
+        name: {
+          type: 'string',
+          description: 'Optional CMS photo title. Defaults to the filename.',
+        },
+      },
+      required: ['image'],
+      additionalProperties: false,
+    },
+    async execute(args, context) {
+      requireScope(context, 'readr.posts.write')
+      const upload = imageUpload(args.image, args.mimeType)
+      const filename = imageFilename(args.filename, upload.extension)
+      const name = getString(args.name, 'name') || filename
+      const photo = await context.query.Photo.createOne({
+        data: {
+          name,
+          imageFile: {
+            // Keystone's Upload scalar consumes this same stream-shaped value
+            // used by GraphQL multipart uploads, so its configured `images`
+            // storage remains the one and only write path.
+            upload: Promise.resolve({
+              createReadStream: () => Readable.from(upload.bytes),
+              filename,
+              mimetype: upload.mimeType,
+              encoding: '7bit',
+            }),
+          },
+        },
+        query: PHOTO_DETAIL_QUERY,
+      })
+      return result(photo)
     },
   },
   {

--- a/packages/readr/mcp.ts
+++ b/packages/readr/mcp.ts
@@ -5,6 +5,8 @@ import {
   textContent,
 } from '@mirrormedia/lilith-mcp'
 import { Readable } from 'stream'
+// @ts-ignore graphql-upload does not publish TypeScript declarations for this internal export.
+import Upload from 'graphql-upload/Upload.js'
 import envVar from './environment-variables'
 import { convertToDraftJs } from './draftjs'
 import { AccessTokenClaims, CommonContext, verifyAccessToken } from './oauth'
@@ -59,6 +61,9 @@ const PHOTO_DETAIL_QUERY = `
   resizedWebp { original w480 w800 w1200 w1600 w2400 }
 `
 const MAX_IMAGE_BYTES = 10 * 1024 * 1024
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+])
 
 type SupportedImage = {
   mimeType: 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif'
@@ -176,13 +181,13 @@ function imageType(bytes: Buffer): SupportedImage | undefined {
   ) {
     return { mimeType: 'image/jpeg', extension: 'jpg' }
   }
-  if (
-    bytes.length >= 8 &&
-    bytes.subarray(0, 8).equals(Buffer.from('\x89PNG\r\n\x1a\n'))
-  ) {
+  if (bytes.length >= 8 && bytes.subarray(0, 8).equals(PNG_SIGNATURE)) {
     return { mimeType: 'image/png', extension: 'png' }
   }
-  if (bytes.length >= 6 && /^GIF8[79]a$/.test(bytes.subarray(0, 6).toString())) {
+  if (
+    bytes.length >= 6 &&
+    /^GIF8[79]a$/.test(bytes.subarray(0, 6).toString())
+  ) {
     return { mimeType: 'image/gif', extension: 'gif' }
   }
   if (
@@ -196,15 +201,27 @@ function imageType(bytes: Buffer): SupportedImage | undefined {
 
 function imageUpload(value: unknown, mimeType: unknown) {
   const valueString = getString(value, 'image', true)
-  const dataUrl = /^data:([^;,]+);base64,([a-z0-9+/=]+)$/i.exec(valueString)
-  const encoded = dataUrl ? dataUrl[2] : valueString
-  if (!dataUrl && !/^[a-z0-9+/=]+$/i.test(encoded)) {
+  const dataUrl = /^data:([^;,]+);base64,([\s\S]+)$/i.exec(valueString)
+  const encoded = (dataUrl ? dataUrl[2] : valueString).replace(/\s+/g, '')
+  if (!/^[a-z0-9+/]*={0,2}$/i.test(encoded)) {
     throw new McpToolError('image must be a base64 string or image data URL.')
   }
 
-  const bytes = Buffer.from(encoded, 'base64')
-  if (bytes.length === 0 || bytes.toString('base64') !== encoded) {
-    throw new McpToolError('image must contain valid base64-encoded image data.')
+  const unpadded = encoded.replace(/=+$/, '')
+  if (!unpadded || unpadded.length % 4 === 1) {
+    throw new McpToolError(
+      'image must contain valid base64-encoded image data.'
+    )
+  }
+  const normalized = unpadded.padEnd(Math.ceil(unpadded.length / 4) * 4, '=')
+  const bytes = Buffer.from(normalized, 'base64')
+  if (
+    bytes.length === 0 ||
+    bytes.toString('base64').replace(/=+$/, '') !== unpadded
+  ) {
+    throw new McpToolError(
+      'image must contain valid base64-encoded image data.'
+    )
   }
   if (bytes.length > MAX_IMAGE_BYTES) {
     throw new McpToolError('image must not exceed 10 MiB.')
@@ -212,10 +229,15 @@ function imageUpload(value: unknown, mimeType: unknown) {
 
   const detected = imageType(bytes)
   if (!detected) {
-    throw new McpToolError('Only JPEG, PNG, WebP, and GIF images are supported.')
+    throw new McpToolError(
+      'Only JPEG, PNG, WebP, and GIF images are supported.'
+    )
   }
   const suppliedMimeType = dataUrl?.[1] || getString(mimeType, 'mimeType')
-  if (suppliedMimeType && suppliedMimeType.toLowerCase() !== detected.mimeType) {
+  if (
+    suppliedMimeType &&
+    suppliedMimeType.toLowerCase() !== detected.mimeType
+  ) {
     throw new McpToolError('mimeType does not match the uploaded image.')
   }
   return { bytes, ...detected }
@@ -226,6 +248,24 @@ function imageFilename(value: unknown, extension: SupportedImage['extension']) {
   const safe = supplied?.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 180)
   const stem = (safe || 'image').replace(/\.[^.]+$/, '') || 'image'
   return `${stem}.${extension}`
+}
+
+function imageUploadValue(
+  bytes: Buffer,
+  filename: string,
+  mimeType: SupportedImage['mimeType']
+) {
+  // context.query reaches GraphQL's Upload scalar through `variableValues`.
+  // Its parseValue accepts only a graphql-upload Upload instance, not the
+  // Promise/FileUpload shape that field resolvers receive after parsing.
+  const upload = new Upload()
+  upload.resolve({
+    createReadStream: () => Readable.from(bytes),
+    filename,
+    mimetype: mimeType,
+    encoding: '7bit',
+  })
+  return upload
 }
 
 export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
@@ -445,7 +485,7 @@ export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
   {
     name: 'upload_image',
     description:
-      'Upload a JPEG, PNG, WebP, or GIF to the READr CMS photo library. Supply base64 image data (or a data URL), then use the returned image URLs or photo ID in an article. The CMS storage backend writes the original file and triggers its normal resize pipeline.',
+      'Upload a JPEG, PNG, WebP, or GIF to the READr CMS photo library. Supply base64 image data (or a data URL), then use the returned photo ID or original image URL in an article. Resize URLs are generated asynchronously and can return 404 until the CMS resize pipeline completes.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -456,7 +496,8 @@ export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
         },
         filename: {
           type: 'string',
-          description: 'Optional source filename. Its extension is replaced with the detected image type.',
+          description:
+            'Optional source filename. Its extension is replaced with the detected image type.',
         },
         mimeType: {
           type: 'string',
@@ -481,15 +522,9 @@ export const readrMcpTools: McpTool<ReadrMcpContext>[] = [
         data: {
           name,
           imageFile: {
-            // Keystone's Upload scalar consumes this same stream-shaped value
-            // used by GraphQL multipart uploads, so its configured `images`
-            // storage remains the one and only write path.
-            upload: Promise.resolve({
-              createReadStream: () => Readable.from(upload.bytes),
-              filename,
-              mimetype: upload.mimeType,
-              encoding: '7bit',
-            }),
+            // Use the same Upload scalar path as GraphQL multipart uploads,
+            // so Keystone's configured `images` storage is the only writer.
+            upload: imageUploadValue(upload.bytes, filename, upload.mimeType),
           },
         },
         query: PHOTO_DETAIL_QUERY,

--- a/packages/readr/package.json
+++ b/packages/readr/package.json
@@ -23,6 +23,7 @@
     "@mirrormedia/lilith-core": "^3.0.1",
     "@mirrormedia/lilith-mcp": "0.1.0",
     "express": "^4.17.1",
+    "graphql-upload": "^15.0.2",
     "http-proxy-middleware": "^2.0.3",
     "http2-proxy": "^5.0.53",
     "patch-package": "^6.4.7"


### PR DESCRIPTION
## What changed

Adds the `upload_image` MCP tool for READr CMS. It accepts validated base64 or data-URL images and creates a real `Photo.imageFile` through Keystone storage.

## Why

Creating a Photo record alone does not upload image bytes, so GCS and its resize trigger never run. This tool uses the existing Keystone storage path and preserves CMS role access control.

## Notes

The Cloud Run service must set `IMAGES_STORAGE_PATH=/app/gcs/images` so original images are written through the existing GCS Fuse mount.

## Validation

- `git diff --check`