### PR TITLE
feat(mcp): surface Keystone validation and access errors to MCP clients

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirrormedia/lilith-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Reusable MCP (Model Context Protocol) Streamable HTTP transport, OAuth 2.1 endpoints, and bearer-auth wiring for Lilith Keystone CMS packages",
   "main": "lib/index.js",
   "types": "@types/index.d.ts",

--- a/packages/mcp/src/express.ts
+++ b/packages/mcp/src/express.ts
@@ -17,6 +17,30 @@ const MCP_PROTOCOL_VERSION = '2025-03-26'
  */
 export class McpToolError extends Error {}
 
+/**
+ * Decides what an MCP client may see when a tool throws. Keystone validation
+ * and access-denied errors carry editor-facing messages (the Admin UI shows
+ * them verbatim to the same users), so they are surfaced for every tool in
+ * every package — an agent can only self-correct when it sees the reason.
+ * Everything else stays behind a generic message.
+ */
+function toolErrorText(error: unknown): string {
+  if (error instanceof McpToolError) return error.message
+  const code = (error as { extensions?: { code?: string } } | null)?.extensions
+    ?.code
+  const message = (error as { message?: string } | null)?.message
+  if (
+    typeof message === 'string' &&
+    (code === 'KS_VALIDATION_FAILURE' ||
+      code === 'KS_ACCESS_DENIED' ||
+      message.startsWith('You provided invalid data for this operation') ||
+      message.startsWith('Access denied:'))
+  ) {
+    return message
+  }
+  return 'The tool could not complete the request.'
+}
+
 function sendResult(
   response: Parameters<ExpressHandler>[1],
   id: JsonRpcRequest['id'],
@@ -139,14 +163,9 @@ export function createMcpExpressHandler<Context>(
           return sendResult(response, rpcRequest.id, { content })
         } catch (error) {
           // Tool failures are a successful MCP protocol response. This keeps
-          // the transport usable while avoiding accidental disclosure of an
-          // application/database error to the client.
+          // the transport usable; toolErrorText decides what is safe to show.
           return sendResult(response, rpcRequest.id, {
-            content: textContent(
-              error instanceof McpToolError
-                ? error.message
-                : 'The tool could not complete the request.'
-            ),
+            content: textContent(toolErrorText(error)),
             isError: true,
           })
         }

--- a/packages/mirrormedia/mcp.ts
+++ b/packages/mirrormedia/mcp.ts
@@ -98,6 +98,15 @@ function singleResult(posts: unknown) {
   return result(Array.isArray(posts) ? posts[0] || null : posts)
 }
 
+function getIdArray(value: unknown, name: string) {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value) || !value.every((id) => typeof id === 'string')) {
+    throw new McpToolError(`${name} must be an array of ID strings.`)
+  }
+  const ids = value.map((id) => id.trim()).filter(Boolean)
+  return ids.length ? ids : undefined
+}
+
 type RawDraftBlock = {
   key: string
   text: string
@@ -977,7 +986,7 @@ export const mirrormediaMcpTools: McpTool<MirrormediaMcpContext>[] = [
   {
     name: 'publish_post',
     description:
-      'Publish an existing Mirror Media article now, or schedule it by providing publishedDate as an RFC 3339 timestamp.',
+      'Publish an existing Mirror Media article now, or schedule it by providing publishedDate as an RFC 3339 timestamp. Publishing requires the post to end up with at least one section (大分類) and one category (小分類); pass sectionIds/categoryIds to attach them in the same call, or set them beforehand with update_post. Use filter_posts or the CMS to find the IDs.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -986,6 +995,18 @@ export const mirrormediaMcpTools: McpTool<MirrormediaMcpContext>[] = [
           type: 'string',
           format: 'date-time',
           description: 'Optional RFC 3339 publication time; defaults to now.',
+        },
+        sectionIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Optional Section (大分類) IDs to attach before publishing. Added to any sections the post already has.',
+        },
+        categoryIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Optional Category (小分類) IDs to attach before publishing. Added to any categories the post already has.',
         },
       },
       required: ['id'],
@@ -998,15 +1019,24 @@ export const mirrormediaMcpTools: McpTool<MirrormediaMcpContext>[] = [
         throw new Error('publishedDate must be an RFC 3339 timestamp')
       }
       const effectivePublishTime = publishTime || new Date().toISOString()
+      const sectionIds = getIdArray(args.sectionIds, 'sectionIds')
+      const categoryIds = getIdArray(args.categoryIds, 'categoryIds')
+      const data: Record<string, unknown> = {
+        state:
+          new Date(effectivePublishTime).getTime() > Date.now()
+            ? 'scheduled'
+            : 'published',
+        publishedDate: effectivePublishTime,
+      }
+      if (sectionIds) {
+        data.sections = { connect: sectionIds.map((id) => ({ id })) }
+      }
+      if (categoryIds) {
+        data.categories = { connect: categoryIds.map((id) => ({ id })) }
+      }
       const post = await context.query.Post.updateOne({
         where: { id: getPostId(args.id) },
-        data: {
-          state:
-            new Date(effectivePublishTime).getTime() > Date.now()
-              ? 'scheduled'
-              : 'published',
-          publishedDate: effectivePublishTime,
-        },
+        data,
         query: POST_DETAIL_QUERY,
       })
       return result(post)

--- a/packages/mirrormedia/package.json
+++ b/packages/mirrormedia/package.json
@@ -27,7 +27,7 @@
     "@keystone-6/core": "5.2.0",
     "@keyv/redis": "^2.7.0",
     "@mirrormedia/lilith-core": "3.0.11-beta.10",
-    "@mirrormedia/lilith-mcp": "0.2.0",
+    "@mirrormedia/lilith-mcp": "0.3.0",
     "@reduxjs/toolkit": "^2.2.7",
     "@twreporter/errors": "^1.1.2",
     "express": "^4.17.1",

--- a/packages/readr/package.json
+++ b/packages/readr/package.json
@@ -21,7 +21,7 @@
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.2.0",
     "@mirrormedia/lilith-core": "^3.0.1",
-    "@mirrormedia/lilith-mcp": "0.2.0",
+    "@mirrormedia/lilith-mcp": "0.3.0",
     "express": "^4.17.1",
     "graphql-upload": "^15.0.2",
     "http-proxy-middleware": "^2.0.3",


### PR DESCRIPTION
Follow-up to #1329, reworked per review discussion: the error surfacing now lives in the shared transport so **every tool in every package** gets it, instead of a per-call-site wrapper in mirrormedia.

## Problem
The transport masked every tool failure behind `The tool could not complete the request.` — safe, but an agent hitting Mirror Media's publish rule (published posts need at least one section 大分類 and one category 小分類) or a permission denial saw the same message as a genuine breakage and could not self-correct.

## Change
- **lilith-mcp 0.3.0** (needs npm publish before merge): the tools/call error path now surfaces `KS_VALIDATION_FAILURE` and `KS_ACCESS_DENIED` messages. These are editor-facing strings the Admin UI already shows verbatim to the same users, so no new information is exposed. Everything else stays behind the generic mask.
- **mirrormedia**: `publish_post` accepts optional `sectionIds` / `categoryIds` (connect syntax, additive) so an uncategorised draft can be published in one call; categories can equally be set beforehand with `update_post`. The interim package-local error wrapper was removed — the transport covers it.
- Both packages pin `lilith-mcp@0.3.0` (readr gains the surfacing with no code change).

## Verified locally against the Mirror Media DB
- Publishing an uncategorised draft returns the real message via the shared transport: `已發布／預約發布的文章必須至少選擇一個大分類（Section）與一個小分類（Category）`
- `publish_post` with `sectionIds`/`categoryIds` publishes successfully
- Updating a nonexistent post surfaces `Access denied: You cannot update that Post - it may not exist`
- Plain internal errors remain masked

## Merge order
1. `npm publish` `@mirrormedia/lilith-mcp@0.3.0` (owner)
2. Merge